### PR TITLE
Suggested fix for issue #113: 'Multiple Markers' icons by severity.

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -367,10 +367,16 @@ $(function() {
                 _.each(markers, function(marker){
                     marker.icon = marker.view.getIcon();
                     marker.title = marker.view.getTitle();
+                    marker.view.model.set("currentlySpiderfied",true);
                 });
                 this.clickedMarker = true;
             }.bind(this));
             this.oms.addListener("unspiderfy", this.setMultipleMarkersIcon.bind(this));
+            this.oms.addListener("unspiderfy", function(markers){
+                _.each(markers, function(marker){
+                    marker.view.model.unset("currentlySpiderfied");
+                });
+            }.bind(this));
             console.log('Loaded OverlappingMarkerSpiderfier');
 
             var mcOptions = {maxZoom: MINIMAL_ZOOM - 1, minimumClusterSize: 1};

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -275,9 +275,33 @@ $(function() {
             return params;
         },
         setMultipleMarkersIcon: function() {
+            var groupID = 1;
+            var groupsSeverities = this.groupsSeverities = [];
+
             _.each(this.oms.markersNearAnyOtherMarker(), function(marker) {
-                marker.icon = getIcon("multiple", SEVERITY_VARIOUS);
+                marker.view.model.unset("groupID");
+            });
+
+            _.each(this.oms.markersNearAnyOtherMarker(), function(marker) {
                 marker.title = 'מספר תאונות בנקודה זו';
+                var groupHead = marker.view.model;
+                if(!groupHead.get("groupID")){
+                    var groupHeadSeverity = groupHead.get('severity');
+                    groupHead.set("groupID",groupID);
+                    groupsSeverities.push(groupHeadSeverity);
+                    _.each(this.oms.markersNearMarker(marker), function(markerNear){
+                        var markerNearModel = markerNear.view.model;
+                        markerNearModel.set("groupID",groupID);
+                        if ((groupHeadSeverity != markerNearModel.get('severity'))){
+                            groupsSeverities[groupsSeverities.length -1] = SEVERITY_VARIOUS;
+                        }
+                    });
+                    groupID++;
+                }
+            },this);
+
+            _.each(this.oms.markersNearAnyOtherMarker(), function(marker){
+                marker.icon = MULTIPLE_ICONS[groupsSeverities[marker.view.model.get("groupID") -1]];
             });
         },
         downloadCsv: function() {

--- a/static/js/marker.js
+++ b/static/js/marker.js
@@ -128,7 +128,8 @@ var MarkerView = Backbone.View.extend({
     },
     unhighlight : function() {
     	if (app.oms.markersNearMarker(this.marker, true)[0]){
-    		this.marker.setIcon(this.getIcon("multiple", SEVERITY_VARIOUS));
+    		var group = this.marker.view.model.get("groupID") -1;
+    		this.marker.setIcon(MULTIPLE_ICONS[app.groupsSeverities[group]]);
     	}
         this.marker.setAnimation(null);
 

--- a/static/js/marker.js
+++ b/static/js/marker.js
@@ -105,7 +105,7 @@ var MarkerView = Backbone.View.extend({
         });
     },
     highlight : function() {
-    	if (app.oms.markersNearMarker(this.marker, true)[0]){
+    	if (app.oms.markersNearMarker(this.marker, true)[0]  && !this.model.get("currentlySpiderfied")){
     		this.marker.setIcon(this.getIcon());
     	}
         this.marker.setAnimation(google.maps.Animation.BOUNCE);
@@ -127,9 +127,9 @@ var MarkerView = Backbone.View.extend({
 
     },
     unhighlight : function() {
-    	if (app.oms.markersNearMarker(this.marker, true)[0]){
-    		var group = this.marker.view.model.get("groupID") -1;
-    		this.marker.setIcon(MULTIPLE_ICONS[app.groupsSeverities[group]]);
+    	if (app.oms.markersNearMarker(this.marker, true)[0] && !this.model.get("currentlySpiderfied")){
+            var group = this.model.get("groupID") -1;
+            this.marker.setIcon(MULTIPLE_ICONS[app.groupsSeverities[group]]);
     	}
         this.marker.setAnimation(null);
 


### PR DESCRIPTION
In case all markers in a spider are of the same severity, an appropriate icon will be shown with the matched color.