### PR TITLE
Fix #294 - wrong non-urban accidents marking

### DIFF
--- a/process.py
+++ b/process.py
@@ -96,17 +96,26 @@ def get_junction(accident, roads):
     :return: returns the junction or None if it wasn't found
     """
     if accident["KM"] is not None:
-        dist = 10
+        min_dist = 100000
         key = (), ()
+        junc_km = 0
         for option in roads:
             if accident[field_names.road1] == option[0] and accident[field_names.road2] == option[1] and \
-               abs(accident["KM"]-option[2]) < dist:
+               abs(accident["KM"]-option[2]) < min_dist:
+                min_dist = abs(accident["KM"]-option[2])
                 key = accident[field_names.road1], accident[field_names.road2], option[2]
-                dist = abs(accident["KM"]-option[2])
+                junc_km = option[2]
+        junction = roads.get(key, None)
+        if accident["KM"] - junc_km > 0:
+            direction = u"מזרח" if accident[field_names.road1] % 2 == 0 else u"צפון"
+        else:
+            direction = u"מערב" if accident[field_names.road1] % 2 == 0 else u"דרום"
+
+        return (accident["km"]/10) + " " + direction + u" ל:" + junction.decode(content_encoding) if junction else u""
     else:
         key = accident[field_names.road1], accident[field_names.road2]
-    junction = roads.get(key, None)
-    return junction.decode(content_encoding) if junction else u""
+        junction = roads.get(key, None)
+        return junction.decode(content_encoding) if junction else u""
 
 
 def parse_date(accident):

--- a/process.py
+++ b/process.py
@@ -91,9 +91,20 @@ def get_streets(accident, streets):
 def get_junction(accident, roads):
     """
     extracts the junction from an accident
+    omerxx: added "km" parameter to the calculation to only show the right junction,
+    and *only* if the accident is under 10 km's away from the designated junction.
     :return: returns the junction or None if it wasn't found
     """
-    key = accident[field_names.road1], accident[field_names.road2]
+    if accident["KM"] is not None:
+        dist = 10
+        key = (), ()
+        for option in roads:
+            if accident[field_names.road1] == option[0] and accident[field_names.road2] == option[1] and \
+               abs(accident["KM"]-option[2]) < dist:
+                key = accident[field_names.road1], accident[field_names.road2], option[2]
+                dist = abs(accident["KM"]-option[2])
+    else:
+        key = accident[field_names.road1], accident[field_names.road2]
     junction = roads.get(key, None)
     return junction.decode(content_encoding) if junction else u""
 
@@ -229,7 +240,7 @@ def get_files(directory):
             csv.close()
             yield name, streets_map
         elif name == NON_URBAN_INTERSECTION:
-            roads = {(x[field_names.road1], x[field_names.road2]): x[field_names.junction_name] for x in csv if
+            roads = {(x[field_names.road1], x[field_names.road2], x["KM"]): x[field_names.junction_name] for x in csv if
                      field_names.road1 in x and field_names.road2 in x}
             csv.close()
             yield ROADS, roads


### PR DESCRIPTION
#294 : Added km parameter to `get_files` under **non-urban-intersection**.
Then had `get_junction` retrieve the right junction based on distance (by KM) from the options available.

**Note 1**: The junction retrieved is the nearest junction **available** i.e has a value in junctions csv.