### PR TITLE
Fixed sidebar accident title mismatch

### DIFF
--- a/static/js/sidebar.js
+++ b/static/js/sidebar.js
@@ -97,7 +97,7 @@ var SidebarView = Backbone.View.extend({
 
                 var entryHtml = this.sidebarItemTemplate({
                     created: moment(markerModel.get("created")).format("LLLL"),
-                    type: SUBTYPE_STRING[markerModel.get("subtype")],
+                    type: localization.SUG_TEUNA[markerModel.get("subtype")],
                     icon: markerView.getIcon()
                 });
 


### PR DESCRIPTION
Fixed #300 - `SUBTYPE_STRING` is an array with no logic keys. 
I changed it to pull string from `localization`