### PR TITLE
Fix for issue #180: Adding support for retina displays.

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -704,7 +704,11 @@ $(function () {
               map: this.map,
               icon: USER_LOCATION_ICON
             });
-             //agam add- tour find location for step 2
+            if (isRetina){
+                
+                this.locationMarker.setIcon({url: USER_LOCATION_ICON, scaledSize: new google.maps.Size(30, 50)});
+            }
+             // agam add- tour find location for step 2
             if (tourLocation == 2)
             {
                 tourLocation = 3;

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -97,6 +97,14 @@ function getIcon(accidentType, severity) {
     } catch (err) {
         // stick to default icon
     }
+    if (isRetina){
+        var googleIcon = {
+            url: icon,
+            scaledSize: new google.maps.Size(30, 50)
+        };
+        icon = googleIcon;
+    }
+
     return icon;
 }
 

--- a/static/js/marker.js
+++ b/static/js/marker.js
@@ -26,7 +26,11 @@ var MarkerView = Backbone.View.extend({
         });
 
         if (this.model.get("type") == MARKER_TYPE_DISCUSSION) {
-            this.marker.setIcon(DISCUSSION_ICON);
+            if (isRetina){
+                this.marker.setIcon({url: DISCUSSION_ICON, scaledSize: new google.maps.Size(30, 50)});
+            } else {
+                this.marker.setIcon(DISCUSSION_ICON);
+            }
             this.marker.setTitle("דיון"); //this.model.get("title"));
             this.marker.setMap(this.map);
             this.marker.view = this;
@@ -183,7 +187,11 @@ var MarkerView = Backbone.View.extend({
     },
     opacitySeverityForGroup : function() {
         var group = this.model.get("groupID") -1;
-        this.marker.icon = MULTIPLE_ICONS[app.groupsData[group].severity];
+        if (isRetina){
+            this.marker.icon = { url: MULTIPLE_ICONS[app.groupsData[group].severity], scaledSize: new google.maps.Size(30, 50) };
+        } else {
+            this.marker.icon = MULTIPLE_ICONS[app.groupsData[group].severity];
+        }
         if (app.groupsData[group].opacity != 'opaque'){
             this.marker.opacity = INACCURATE_MARKER_OPACITY / app.groupsData[group].opacity;
         }

--- a/static/js/retina.js
+++ b/static/js/retina.js
@@ -1,0 +1,21 @@
+var isRetina = (
+    window.devicePixelRatio > 1 ||
+    (window.matchMedia && window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5),(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)").matches)
+);
+
+if(isRetina){
+    function addRetinaSuffix(url){
+        return url.replace(/(^.*)(\.png)$/gi,function switchFunction(x,y1,y2){return y1+"@2x"+y2;});
+    }
+
+    for (var icon in ICONS){
+        for (var i in ICONS[icon]){            
+            ICONS[icon][i] = addRetinaSuffix(ICONS[icon][i]);
+        }
+    }
+    for (var icon in MULTIPLE_ICONS){
+        MULTIPLE_ICONS[icon] = addRetinaSuffix(MULTIPLE_ICONS[icon]);
+    }
+    USER_LOCATION_ICON = addRetinaSuffix(USER_LOCATION_ICON);
+    DISCUSSION_ICON = addRetinaSuffix(DISCUSSION_ICON);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -382,7 +382,8 @@
             "js/libs/bootstrap-tour.min.js",
             "js/app.js",
             "js/localization.js",
-            "js/years.js" %}
+            "js/years.js",
+            "js/retina.js" %}
             <script type="text/javascript" src="{{ ASSET_URL }}"></script>
         {% endassets %}
 


### PR DESCRIPTION
After this commit, when a retina display is being the detected, it will be served a different set of icons, higher quality ones, which are more adequate to its prominence.