### PR TITLE
Enhancement #257 - Using PostGIS R-Tree (SQLite) for faster queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+local-testing.db
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install: pip install -r requirements.txt
 # command to prepare for tests
 before_script:
   - export DATABASE_URL='sqlite:///local.db'
+  - export BUILD_MARKER_INDEX_SQL_FILE='./static/data/sql/postgresql-buildrtreeindex.sql'
   - python models.py
 # command to run tests
 script: python -m unittest discover tests

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Contributing
 3. `mkvirtualenv anyway`
 4. `cd anyway`
 5. `pip install -r requirements.txt`
+	* In case you're getting an error as 'Command "python setup.py egg_info" failed with error code 1 in', try to run `sudo apt-get install libpq-dev python-dev`
+6. `workon anyway` (each time you start working)
 
 * Each time you start working: `workon anyway`
 

--- a/config.py
+++ b/config.py
@@ -13,5 +13,11 @@ SENDGRID_USERNAME = os.environ.get('SENDGRID_USERNAME')
 SENDGRID_PASSWORD = os.environ.get('SENDGRID_PASSWORD')
 SQLALCHEMY_POOL_RECYCLE = 60
 
+# The default path is SQLite file as it's the development environment DB
+_build_marker_file_path = os.environ.get('BUILD_MARKER_INDEX_SQL_FILE') or './static/data/sql/sqlite-buildrtreeindex.sql'
+BUILD_MARKER_INDEX_SQL_FILE = os.path.join(_build_marker_file_path)
+MARKER_INDEX_PROVIDER_TYPE = os.environ.get('DATABASE_TYPE') or 'SQLite' #TODO: extract the database type from DATABASE_URL address
+
 
 SECRET_KEY = 'aiosdjsaodjoidjioewnioewfnoeijfoisdjf'
+

--- a/database.py
+++ b/database.py
@@ -1,9 +1,12 @@
 import os
+import logging
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy.engine import reflection
+from sqlalchemy.schema import Table
 import config
-
 
 engine = create_engine(config.SQLALCHEMY_DATABASE_URI, convert_unicode=True, echo=False)
 db_session = scoped_session(sessionmaker(autocommit=False, autoflush=True, bind=engine))
@@ -11,3 +14,39 @@ Base = declarative_base()
 Base.query = db_session.query_property()
 
 
+def get_table(table_name, meta):
+	insp = reflection.Inspector.from_engine(engine)
+
+	if table_name in insp.get_table_names():
+		table = Table(table_name, meta, autoload=True, autoload_with=engine)
+		return table
+	else:	
+		logging.warning("Could not find table: {0}".format(table_name))
+		return None
+
+
+def insert_table(table_name, values):
+	if not isinstance(values, list) and not isinstance(values, dict):
+		logging.error("Trying to insert non dictionary object(s) to the table. \nUse single or list of dictionary object(s) with keys and values to insert the table. Values type: {0}".format(type(values)))
+		return False
+
+	table = get_table(table_name, Base.metadata)
+	if table is not None:
+		# catch unexpected values
+		try:
+			engine.execute(table.insert(), values)
+			return True
+		except Exception, e:
+			logging.error("Could not execute Insert to table: {0}. Error: {2}".format(table_name, e.message))
+			return False
+	else:
+		return False
+
+
+def delete_table(table_name):
+	table = get_table(table_name, Base.metadata)
+	if table is not None:
+		engine.execute(table.delete())
+		return True
+	logging.error("Error deleting table, Could not find table: {0}".format(table_name))
+	return False

--- a/main.py
+++ b/main.py
@@ -135,6 +135,7 @@ def marker(marker_id):
     involved = db_session.query(Involved).filter(Involved.accident_id == marker_id)
     vehicles = db_session.query(Vehicle).filter(Vehicle.accident_id == marker_id)
     list_to_return = list()
+    list_to_return.append("Involved: ")
     for inv in involved:
         obj = inv.serialize()
         if (92,obj["age_group"]) in lmsDictionary:
@@ -152,6 +153,8 @@ def marker(marker_id):
         if (81,obj["home_residence_type"]) in lmsDictionary:
             obj["home_residence_type"] = lmsDictionary[81,obj["home_residence_type"]]
         list_to_return.append(obj)
+    list_to_return.append("]")
+    list_to_return.append("Vehicles: ")
     for veh in vehicles:
         obj = veh.serialize()
         if (111,obj["engine_volume"]) in lmsDictionary:

--- a/markerindex_provider.py
+++ b/markerindex_provider.py
@@ -1,0 +1,136 @@
+from database import engine
+
+from utilities import File
+import config
+from database import Base, insert_table, delete_table
+from sqlalchemy.schema import Table
+
+from sqlalchemy import Column, Integer
+from geoalchemy2 import types
+from database import db_session
+from sqlalchemy.orm import load_only
+
+# Different names required because when declaring MarkerIndex(Base) class
+# Engine cause override the table reflection when using SQLite
+SQLITE_MARKER_INDEX_TABLE_NAME = 'marker_index'
+POSTGRESQL_MARKER_INDEX_TABLE_NAME = 'marker_index_gis'
+
+
+# Extract marker index data from a marker, as Marker object or a dictionary
+def _get_id_lat_lng(marker):
+    import collections
+    from models import Marker
+
+    try:
+        if type(marker) is dict:
+            id = marker["id"]
+            lat = marker["latitude"]
+            lng = marker["longitude"]
+        elif type(marker) is Marker:
+            id = marker.id
+            lat = marker.latitude
+            lng = marker.longitude
+        else:
+            raise AttributeError("Bad marker type: {0}, for marker: {1}.".format(type(marker), str(marker)))
+    except:
+        raise AttributeError("Getting marker data faild for marker: {0}".format(str(marker)))
+
+    if id is None:
+        raise AttributeError("Could not get id for marker: {0}".format(str(marker)))
+
+    result = collections.namedtuple('SimpleMarker', ['id', 'lat', 'lng'])
+    return result(id, lat, lng)
+
+
+class MarkerIndexProvider(object):
+
+    @staticmethod
+    def factory(type):
+        class SQLiteMarkerIndexProvider(MarkerIndexProvider):
+            def create_table(self):
+                sql = File.read(config.BUILD_MARKER_INDEX_SQL_FILE)
+                engine.execute(sql)
+
+            def delete_table(self):
+                delete_table(self.get_table_name())
+
+            def insert_indexes(self, indexes):
+                insert_table(self.get_table_name(), indexes)
+
+            def create_index(self, marker):
+                simple_marker = _get_id_lat_lng(marker)
+
+                # getting the marker data as: marker.id or marker["id"],
+                # for Marker object and raw object respectively
+                return {
+                    "id": simple_marker.id,
+                    "minLng": simple_marker.lng,
+                    "maxLng": simple_marker.lng,
+                    "minLat": simple_marker.lat,
+                    "maxLat": simple_marker.lat
+                }
+
+            def get_bounding_indexes(self, ne_lat, ne_lng, sw_lat, sw_lng):
+                # Get the ids of the bounding markers from the R*Tree index first
+                indexes_table = Table(self.get_table_name(), Base.metadata, autoload=True, autoload_with=engine)
+
+                result = db_session.query(indexes_table).with_entities(indexes_table.c.id) \
+                    .filter(indexes_table.c.minLng <= ne_lng) \
+                    .filter(indexes_table.c.maxLng >= sw_lng) \
+                    .filter(indexes_table.c.minLat <= ne_lat) \
+                    .filter(indexes_table.c.maxLat >= sw_lat)
+                return result
+
+            def get_table_name(self):
+                return SQLITE_MARKER_INDEX_TABLE_NAME
+
+        class PostgreMarkerIndexProvider(MarkerIndexProvider):
+            def _is_iterable(self, obj):
+                return hasattr(obj, '__iter__')
+
+            def create_table(self):
+                # Creates the table only if not exists
+                MarkerIndex.__table__.create(engine, checkfirst=True)
+
+            def delete_table(self):
+                db_session.query(MarkerIndex).delete()
+
+            def drop_table(self):
+                MarkerIndex.__table__.drop(engine)
+
+            def insert_indexes(self, indexes):
+                if self._is_iterable(indexes):
+                    db_session.add_all(indexes)
+                else:
+                    db_session.add(indexes)
+
+                db_session.commit()
+
+            def create_index(self, marker):
+                simple_marker = _get_id_lat_lng(marker)
+                return MarkerIndex(id=simple_marker.id,
+                                   geom='SRID=4326; POINT({0} {1})'.format(simple_marker.lat, simple_marker.lng))
+
+            def get_bounding_indexes(self, ne_lat, ne_lng, sw_lat, sw_lng):
+                result = db_session.query(MarkerIndex).filter(
+                    MarkerIndex.geom.intersects('POLYGON(({0} {1}, {2} {3}, {4} {5}, {6} {7}, {8} {9}))'
+                        .format(ne_lat, ne_lng, ne_lat, sw_lng, sw_lat, sw_lng, sw_lat, ne_lng, ne_lat, ne_lng))) \
+                .options(load_only("id"))
+                return result
+
+            def get_table_name(self):
+                return POSTGRESQL_MARKER_INDEX_TABLE_NAME
+
+        if type == "SQLite": return SQLiteMarkerIndexProvider()
+        if type == "PostgreSQL":
+            class MarkerIndex(Base):
+                __tablename__ = POSTGRESQL_MARKER_INDEX_TABLE_NAME
+                __table_args__ = {'extend_existing': True}
+                id = Column(Integer, primary_key=True)
+                geom = Column(types.Geometry(geometry_type='POINT', srid=4326))
+            return PostgreMarkerIndexProvider()
+        raise TypeError('Bad MarkerIndexProvider creation: ' + type)
+
+
+def create_provider(override_config_type=None):
+    return MarkerIndexProvider.factory(override_config_type or config.MARKER_INDEX_PROVIDER_TYPE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==0.10.1
 Flask-Assets==0.10
-Flask-SQLAlchemy==1.0
+Flask-SQLAlchemy==2.0
 Jinja2==2.7.1
 MarkupSafe==0.18
 SQLAlchemy==0.9
@@ -18,3 +18,4 @@ Flask-Admin==1.1.0
 Flask-Login==0.2.11
 WTForms==2.0.2
 sendgrid==1.4.0
+GeoAlchemy2==0.2.5

--- a/static/data/sql/postgresql-buildrtreeindex.sql
+++ b/static/data/sql/postgresql-buildrtreeindex.sql
@@ -1,0 +1,1 @@
+CREATE INDEX marker_index ON markers IF NOT EXISTS USING rtree(id, minLng, maxLng, minLat, maxLat);

--- a/static/data/sql/sqlite-buildrtreeindex.sql
+++ b/static/data/sql/sqlite-buildrtreeindex.sql
@@ -1,0 +1,1 @@
+CREATE VIRTUAL TABLE IF NOT EXISTS marker_index USING rtree(id, minLng, maxLng, minLat, maxLat);

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,71 @@
+import config
+
+# This is hack, no need to change the config file.
+# Make this change before importing 'database' and initializing the engine with the real DATABASE_URI
+db_name = "local-testing.db"
+config.SQLALCHEMY_DATABASE_URI  = "sqlite:///" + db_name
+
+import unittest
+import os
+
+from sqlalchemy import Column, Integer, MetaData
+from sqlalchemy.schema import Table
+
+from database import Base, insert_table, engine
+from models import Marker
+
+
+table_name = 'test'
+
+class Test(Base):
+    __tablename__ = table_name
+    id = Column('id', Integer, primary_key = True)
+    number = Column('number', Integer)
+
+class TeseDBInsert(unittest.TestCase):
+
+    def setUp(self):
+        Base.metadata.create_all(engine)
+
+    def tearDown(self):
+        Base.metadata.drop_all(engine)
+        # option to delete the db testing file
+        # if os.path.isfile(db_name):
+        #     os.remove(os.path.join(db_name))
+
+    good_data = {
+        "number": 100
+    }
+
+    bad_data = {
+        "number": "hello world"
+    }
+
+    def test_bad_table_name(self):
+        self.assertEqual(insert_table("bad table name", self.good_data), False)
+
+    def test_null_insertion(self):
+        self.assertEqual(insert_table(table_name, None), False)
+
+    def test_bad_obj_insertion(self):
+        self.assertEqual(insert_table(table_name, 123), False)     
+
+    # This isn't the way to insert a model to the table (only dict will pass).
+    def test_bad_model_object_insertion(self):
+        self.assertEqual(insert_table(table_name, Test(number=300)), False)
+
+    # Yes, SQLAlchemy allow to insert wrong types, so insert 'hello world' string to Integer column will return True
+    def test_worng_type_insert(self):
+        self.assertEqual(insert_table(table_name, self.bad_data), True)   
+
+    def test_good_single_raw_object_insertion(self):
+        self.assertEqual(insert_table(table_name, self.good_data), True)
+
+    def test_good_raw_array_insertion(self):
+        arr = []
+        for x in xrange(1,10):
+            arr.append(self.good_data)
+        self.assertEqual(insert_table(table_name, arr), True)
+
+if __name__ == '__main__':
+     unittest.main()

--- a/tests/test_markerindex_provider.py
+++ b/tests/test_markerindex_provider.py
@@ -1,0 +1,258 @@
+import config
+
+# This is hack, no need to change the config file.
+# Make this change before importing 'database' and initializing
+# the engine with the real DATABASE_URI
+db_name = "local-testing.db"
+config.SQLALCHEMY_DATABASE_URI = "sqlite:///" + db_name
+
+import unittest
+
+from markerindex_provider import create_provider
+
+from sqlalchemy.schema import Table
+import database
+from sqlalchemy.engine.reflection import Inspector
+
+
+class TestFactory(unittest.TestCase):
+    def test_create_provider_bad_type(self):
+        with self.assertRaises(TypeError):
+            create_provider("BadTypeSQL")
+
+    def test_create_two_diffrent_providers(self):
+        import markerindex_provider
+        sql_provider = create_provider("SQLite")
+        postgres_provider = create_provider("PostgreSQL")
+        self.assertEqual(sql_provider.get_table_name(), markerindex_provider.SQLITE_MARKER_INDEX_TABLE_NAME)
+        self.assertEqual(postgres_provider.get_table_name(), markerindex_provider.POSTGRESQL_MARKER_INDEX_TABLE_NAME)
+
+
+class TestSQLiteProvider(unittest.TestCase):
+    provider = Base = db_session = engine = ""
+
+    def _create_default_dict_marker(self, id=1):
+        marker = {
+            "id": id,
+            "latitude": 2.0,
+            "longitude": 3.0
+        }
+        return marker
+
+    def _count_all_indexes(self):
+        table = Table(self.provider.get_table_name(), self.Base.metadata,
+                      autoload=True, autoload_with=self.engine)
+        result = self.db_session.query(table.c.id).count()
+        return result
+
+    @classmethod
+    def setUpClass(cls):
+        db_name = "local-testing.db"
+        config.SQLALCHEMY_DATABASE_URI = "sqlite:///" + db_name
+        import imp
+        imp.reload(database)
+        import markerindex_provider
+        imp.reload(markerindex_provider)
+        from database import engine, db_session, Base
+        cls.engine = engine
+        cls.db_session = db_session
+        cls.Base = Base
+
+    def setUp(self):
+        self.provider = create_provider("SQLite")
+
+    def tearDown(self):
+        self.Base.metadata.drop_all(self.engine)
+        # option to delete the db testing file
+        # if os.path.isfile(db_name):
+        #     os.remove(os.path.join(db_name))
+
+    def test_table_creation(self):
+        self.provider.create_table()
+        inspector = Inspector.from_engine(self.engine)
+        self.assertTrue(
+            self.provider.get_table_name() in inspector.get_table_names())
+
+    def test_table_creation_empty_table(self):
+        self.provider.create_table()
+        rows = self._count_all_indexes()
+        self.assertEqual(rows, 0)
+
+    def test_create_index(self):
+        marker = self._create_default_dict_marker()
+        result = self.provider.create_index(marker)
+        self.assertEqual(result["id"], 1)
+        self.assertEqual(result["minLat"], 2.0)
+        self.assertEqual(result["maxLat"], 2.0)
+        self.assertEqual(result["minLng"], 3.0)
+        self.assertEqual(result["maxLng"], 3.0)
+
+    def test_create_bad_index(self):
+        no_id_marker = {
+            "latitude": 2.0,
+            "longitude": 3.0
+        }
+        with self.assertRaises(AttributeError):
+            self.provider.create_index(no_id_marker)
+
+    def test_create_none_index(self):
+        with self.assertRaises(AttributeError):
+            self.provider.create_index(None)
+
+    def test_create_table_when_exists(self):
+        self.provider.create_table()
+        self.provider.create_table()
+        inspector = Inspector.from_engine(self.engine)
+        self.assertTrue(
+            self.provider.get_table_name() in inspector.get_table_names())
+
+    def test_insert_single_index(self):
+        self.provider.create_table()
+        marker = self._create_default_dict_marker()
+        index = self.provider.create_index(marker)
+        self.provider.insert_indexes(index)
+        rows = self._count_all_indexes()
+        self.assertEqual(rows, 1)
+
+    def test_insert_indexes(self):
+        self.provider.create_table()
+        markers = [
+            self._create_default_dict_marker(1),
+            self._create_default_dict_marker(2),
+            self._create_default_dict_marker(3)
+        ]
+
+        indexes = []
+        for marker in markers:
+            indexes.append(self.provider.create_index(marker))
+
+        self.provider.insert_indexes(indexes)
+        rows = self._count_all_indexes()
+        self.assertEqual(rows, 3)
+
+    def test_create_table_when_exists_not_overwriting_data(self):
+        self.test_insert_indexes()
+        self.provider.create_table()
+        rows = self._count_all_indexes()
+        self.assertEqual(rows, 3)
+
+
+class TestPostgreSQLProvider(unittest.TestCase):
+    provider = Base = db_session = engine = ""
+
+    def _create_default_dict_marker(self, id=1):
+        marker = {
+            "id": id,
+            "latitude": 2.0,
+            "longitude": 3.0
+        }
+        return marker
+
+    def _count_all_indexes(self):
+        table = Table(self.provider.get_table_name(), self.Base.metadata,
+                      autoload=True, autoload_with=self.engine)
+        result = self.db_session.query(table.c.id).count()
+        # Close session to unblock DROP command (tearDown)
+        self.db_session.close()
+        return result
+
+    @classmethod
+    def setUpClass(cls):
+        config.SQLALCHEMY_DATABASE_URI = "postgresql://postgres:postgres@localhost/test_db"
+        import imp
+        imp.reload(database)
+        import markerindex_provider
+        imp.reload(markerindex_provider)
+        from database import engine, db_session, Base
+        cls.engine = engine
+        cls.db_session = db_session
+        cls.Base = Base
+
+    def setUp(self):
+        self.provider = create_provider("PostgreSQL")
+
+    def tearDown(self):
+        self.Base.metadata.drop_all(self.engine)
+
+    def test_table_creation(self):
+        self.provider.create_table()
+        inspector = Inspector.from_engine(self.engine)
+        self.assertTrue(
+            self.provider.get_table_name() in inspector.get_table_names())
+
+    def test_table_creation_empty_table(self):
+        self.provider.create_table()
+        rows = self._count_all_indexes()
+        self.assertEqual(rows, 0)
+
+    def test_create_index_from_dictionary(self):
+        marker = self._create_default_dict_marker()
+        result = self.provider.create_index(marker)
+        self.assertEqual(result.id, 1)
+        self.assertEqual(result.geom, 'SRID=4326; POINT(2.0 3.0)')
+
+    def test_create_index_from_marker_class(self):
+        from models import Marker
+        data = {
+            "title": None,
+            "description": None,
+            "latitude": 2.0,
+            "longitude": 3.0
+        }
+        marker = Marker.parse(data)
+        marker.id = 1
+
+        result = self.provider.create_index(marker)
+        self.assertEqual(result.id, 1)
+        self.assertEqual(result.geom, 'SRID=4326; POINT(2.0 3.0)')
+
+    def test_create_bad_index(self):
+        no_id_marker = self._create_default_dict_marker()
+        del no_id_marker["id"]
+        with self.assertRaises(AttributeError):
+            self.provider.create_index(no_id_marker)
+
+    def test_create_none_index(self):
+        with self.assertRaises(AttributeError):
+            self.provider.create_index(None)
+
+    def test_create_table_when_exists(self):
+        self.provider.create_table()
+        self.provider.create_table()
+        inspector = Inspector.from_engine(self.engine)
+        self.assertTrue(
+            self.provider.get_table_name() in inspector.get_table_names())
+
+    def test_insert_single_index(self):
+        self.provider.create_table()
+        marker = self._create_default_dict_marker()
+        index = self.provider.create_index(marker)
+        self.provider.insert_indexes(index)
+        rows = self._count_all_indexes()
+        self.assertEqual(rows, 1)
+
+    def test_insert_indexes(self):
+        self.provider.create_table()
+        markers = [
+            self._create_default_dict_marker(1),
+            self._create_default_dict_marker(2),
+            self._create_default_dict_marker(3)
+        ]
+
+        indexes = []
+        for marker in markers:
+            indexes.append(self.provider.create_index(marker))
+
+        self.provider.insert_indexes(indexes)
+        rows = self._count_all_indexes()
+        self.assertEqual(rows, 3)
+
+    def test_create_table_when_exists_not_overwriting_data(self):
+        self.test_insert_indexes()
+        self.provider.create_table()
+        rows = self._count_all_indexes()
+        self.assertEqual(rows, 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utilities.py
+++ b/utilities.py
@@ -96,3 +96,11 @@ class ItmToWGS84(object):
         """
         longitude, latitude = pyproj.transform(self.itm, self.wgs84, x, y)
         return longitude, latitude
+		
+		
+class File(object):
+    @staticmethod
+    def read(filename):
+        with open(filename) as file:
+            data = file.read()
+            return data


### PR DESCRIPTION
Enhancement #257 - Using PostGIS for faster queries and R-Tree Module for SQLite . Marker index (PostGIS/R-Tree) provider will be load by configuration, the provider will manage the work with the respective database. Marker Indexes are generated after accidents import (at the end of proccess). There is a simple static MarkerIndex class at models to warp the provider. Tests included (except of boundingbox). Note: To use PostGIS on a PostgreSQL server, need to add postgis extension with command: CREATE EXTENSION postgis. To run tests, add a test_db database and postgis extension.

<!---
@huboard:{"order":338.0,"milestone_order":340,"custom_state":""}
-->
