### PR TITLE
Fix for issue #321: Fixed problem of images not showing in the sidebar list on retina displays

### DIFF
--- a/static/js/sidebar.js
+++ b/static/js/sidebar.js
@@ -95,10 +95,15 @@ var SidebarView = Backbone.View.extend({
                     continue;
                 }
 
+                var iconUrl = markerView.getIcon();
+                if (isRetina){
+                    iconUrl = iconUrl.url;
+                }
+
                 var entryHtml = this.sidebarItemTemplate({
                     created: moment(markerModel.get("created")).format("LLLL"),
                     type: localization.SUG_TEUNA[markerModel.get("subtype")],
-                    icon: markerView.getIcon()
+                    icon: iconUrl
                 });
 
                 var $entry = $(entryHtml);


### PR DESCRIPTION
Fix for issue #321: Fixed problem of images not showing in the sidebar list on retina displays.
The src icon received an object instead of a url.