### PR TITLE
Removed a residual of a white block from the sidebar

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -373,7 +373,7 @@
                     <div class="sidebar-title current-view-count" style="display: table-cell"></div>
                 </div>
             </div>
-            <div style="overflow-y: scroll; position: absolute; top: 340px; bottom: 30px; width: 100%" id="step6tour">
+            <div style="overflow-y: scroll; position: absolute; top: 340px; bottom: 0px; width: 100%" id="step6tour">
                 <ul class="current-view"></ul>
             </div>
         </div>


### PR DESCRIPTION
Fix for issue #347.
Removed a white block which the "Download csv file" used to be placed in.