### PR TITLE
Fix #349 - Change copy buttons label to mark text

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -102,12 +102,12 @@
                 <div class="embed-code">
                     <label for="map_link">קישור לתצוגה הנוכחית</label>
                     <input id="map_link" type="text" class="form-control form-control-wide" value="" placeholder="">
-                    <button class="btn btn-default js-btn-copytoclipboard" data-copy="map_link" style="float: left;" type="button">העתק</button>
+                    <button class="btn btn-default js-btn-copytoclipboard" data-copy="map_link" style="float: left;" type="button">סמן טקסט</button>
                 </div>
                 <div class="embed-code">
                     <label for="iframe_link">קוד לשילוב המפה בדפי אינטרנט</label>
                     <textarea id="iframe_link" class="form-control form-control-wide"></textarea>
-                    <button class="btn btn-default js-btn-copytoclipboard" data-copy="iframe_link" style="float: left;" type="button">העתק</button>
+                    <button class="btn btn-default js-btn-copytoclipboard" data-copy="iframe_link" style="float: left;" type="button">סמן טקסט</button>
                 </div>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
Fix #349 - Copying to clipboard is not good practice, buttons labels were changed to their actual functionality.