### PR TITLE
Forcing the scrollbar to stay visible in the Info-window(hides itself by default)

### DIFF
--- a/static/css/accordion.css
+++ b/static/css/accordion.css
@@ -1,6 +1,6 @@
 .accordion-container{
 	width: 300px;
-	margin: 30px 2px 30px 0px;
+	margin: 30px 2px 0px 0px;
 }
 
 .accordion-container label{

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -288,3 +288,14 @@ textarea.form-control-wide {
 .sb-button{
     min-height: initial !important;
 }
+
+.marker-info-window::-webkit-scrollbar{
+    -webkit-appearance: none;
+    width: 7px;
+}
+
+.marker-info-window::-webkit-scrollbar-thumb{
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, .5);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -254,7 +254,7 @@
 
 
         <div id="marker-content-template" style="display: none">
-            <div class="marker-info-window" style="overflow-y: auto; height: 360px;">
+            <div class="marker-info-window" style="overflow-y: auto; overflow-x: hidden; height: 370px;">
                 <img class="profile-image" style="float: left" />
                 <h4 class="title"></h4>
                 <p class="added-by"></p>


### PR DESCRIPTION
This will be more UXic, to make sure even the small percentage of users that won't notice the expansion of the content downwards in the info-window, will have a scrollbar to point-out the scrolling ability.
It will only be shown once there's extra content to scroll to.