### PR TITLE
Fix #394 - Bad scrolling behavior (related to tour.js)

### DIFF
--- a/static/js/tour.js
+++ b/static/js/tour.js
@@ -80,13 +80,14 @@ var tour1 = new Tour({
         },
     ]});
 // Initialize the tour
-tour1.init();
-resetTour();// Start the tour
-tour.addStep(tour1.getStep(0));
-tour.addStep(tour1.getStep(1));
-tour.init();
-tour.start();
+
 function tourClick(){
+    tour1.init();
+    resetTour();// Start the tour
+    tour.addStep(tour1.getStep(0));
+    tour.addStep(tour1.getStep(1));
+    tour.init();
+    tour.start();
     if (!tour.ended()) {
         tour.end();
         if (infowindow) {


### PR DESCRIPTION
I think this should be merged to `dev` and `master` and #372 should be reopened.
Moved the initialization of the tour inside it's button click so it would stop messing up index.html scrolling behavior.
This fix rolls back the previous behavior to the tour blinking, but prevent a much worse issue of index.html.
* Fix for #394 (bad scrolling behavior)

* Related to #372 (issue) and #392 (pull request) for fixing the two tour appearances.