### PR TITLE
Added a calculated duration(function) instead of the 1300 ms fixed one for the autoScroll mechanism

### DIFF
--- a/static/js/marker.js
+++ b/static/js/marker.js
@@ -286,7 +286,8 @@ var MarkerView = Backbone.View.extend({
 
                 setTimeout(function(){
                     var sectionHeightScroll = $(input).siblings(".accordion-roller").height() + curIwScroll;
-                    var bestScrollTo = sectionHeightScroll < labelPos ? sectionHeightScroll : labelPos;
+                    var bestScrollTo = Math.min(sectionHeightScroll, labelPos);
+                    var scrollAnimationDuration = Math.min((bestScrollTo - curIwScroll) * 9, 1300);
 
                     $(infoWindow).on("mousewheel keyup mousedown DOMMouseScroll wheel touchmove", function(){
                         $(infoWindow).stop();
@@ -294,7 +295,7 @@ var MarkerView = Backbone.View.extend({
 
                     $(infoWindow).animate({
                         scrollTop: bestScrollTo
-                    }, 1300, function(){
+                    }, scrollAnimationDuration, function(){
                         $(infoWindow).off("mousewheel keyup mousedown DOMMouseScroll wheel touchmove");
                     });
                 }.bind(this),550);


### PR DESCRIPTION
The situation previous to this update is a bit unintuitive.
The duration of the autoScroll animation is 1300 ms, but the height of the animated div can vary. This means a div with height 600px will be scrolled much-much faster than a div with 85px height.