### PR TITLE
Fix #448 - all years filter causing invalid date errors

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -856,19 +856,14 @@ $(function () {
             this.updateFilterString();
         },
         changeDate: function() {
-            var start_date, end_date, all_years = false;
+            var start_date, end_date;
             if ($("#checkbox-2014").is(":checked")) { start_date = "2014"; end_date = "2015" }
             else if ($("#checkbox-2013").is(":checked")) { start_date = "2013"; end_date = "2014" }
             else if ($("#checkbox-2012").is(":checked")) { start_date = "2012"; end_date = "2013" }
             else if ($("#checkbox-2011").is(":checked")) { start_date = "2011"; end_date = "2012" }
-            else if ($("#checkbox-all-years").is(":checked")) { start_date = "2005"; end_date = "2025"; all_years = true }
-            if (!all_years) {
-                $("#sdate").val(start_date + '-01-01');
-                $("#edate").val(end_date + '-01-01');
-            } else {
-                $("#sdate").val('');
-                $("#edate").val('');
-            }
+            else if ($("#checkbox-all-years").is(":checked")) { start_date = "2005"; end_date = "2025" }
+            $("#sdate").val(start_date + '-01-01');
+            $("#edate").val(end_date + '-01-01');
 
             this.show_day = $("input[type='radio'][name='day']:checked").val()
             this.show_holiday = $("input[type='radio'][name='holiday']:checked").val()


### PR DESCRIPTION
Fixed #448: all years filter to present the date span, preventing invalid date error with further filtering