### PR TITLE
fix bounding box tests (#437)

### DIFF
--- a/tests/test_bounding_box_query.py
+++ b/tests/test_bounding_box_query.py
@@ -17,33 +17,59 @@ class TestQueryFilters(unittest.TestCase):
     """
 
     def setUp(self):
-        kwargs = {'approx': True, 'show_day': 7, 'show_discussions': True, 'accurate': True, 'surface': 0, 'weather': 0,
-                  'district': 0, 'show_markers': True, 'show_fatal': True, 'show_time': 24, 'show_intersection': 3,
-                  'show_light': True, 'sw_lat': 32.06711066128336, 'controlmeasure': 0, 'ne_lng': 34.799307929669226,
-                  'show_severe': True, 'start_time': 25, 'acctype': 0, 'separation': 0, 'show_urban': 3, 'show_lane': 3,
-                  'sw_lng': 34.78879367033085, 'zoom': 17, 'show_holiday': 0, 'end_time': 25, 'road': 0,
-                  'ne_lat': 32.07254745790576, 'start_date': "01/01/2014", 'end_date': "01/01/2015"}
+        kwargs = {'approx': True, 'show_day': 7, 'show_discussions': True, 'accurate': True, 'surface': 0, 
+                  'weather': 0, 'district': 0, 'show_markers': True, 'show_fatal': True, 'show_time': 24, 
+                  'show_intersection': 3, 'show_light': True, 'sw_lat': 32.067363446951944, 'controlmeasure': 0, 
+                  'start_date': datetime.date(2014, 1, 1), 'ne_lng': 34.79928962966915, 'show_severe': True, 
+                  'end_date': datetime.date(2016, 1, 1), 'start_time': 25, 'acctype': 0, 'separation': 0, 
+                  'show_urban': 3, 'show_lane': 3, 'sw_lng': 34.78877537033077, 'zoom': 17, 'show_holiday': 0, 
+                  'end_time': 25, 'road': 0, 'ne_lat': 32.072427482938345}
 
+        self.query_args = kwargs
         self.query = Marker.bounding_box_query(yield_per=50, **kwargs)
-        print self.query
 
     def tearDown(self):
         self.query = None
 
     def test_location_filters(self):
         for marker in self.query:
-            self.assertTrue(self.query['sw_lat'] <= marker.latitude <= self.query['ne_lat'])
-            self.assertTrue(self.query['sw_lng'] <= marker.longitude <= self.query['ne_lng'])
+            self.assertTrue(self.query_args['sw_lat'] <= marker.latitude  <= self.query_args['ne_lat'])
+            self.assertTrue(self.query_args['sw_lng'] <= marker.longitude <= self.query_args['ne_lng'])
 
-    def test_accuracy_filter(self):
-        for marker in self.query:
-            self.assertTrue(marker['approx'])
+    def test_accurate_filter(self):
+        kwargs = self.query_args.copy()
+        kwargs['approx'] = False
+        markers = Marker.bounding_box_query(yield_per=50, **kwargs)
+        for marker in markers:
+            self.assertTrue(marker.locationAccuracy == 1)
 
-    def test_severity_filters(self):
-        for marker in self.query:
-            self.assertFalse(marker['fatal'])
-            self.assertTrue(marker['severe'])
-            self.assertTrue(marker['light'])
+    def test_approx_filter(self):
+        kwargs = self.query_args.copy()
+        kwargs['accurate'] = False
+        markers = Marker.bounding_box_query(yield_per=50, **kwargs)
+        for marker in markers:
+            self.assertTrue(marker.locationAccuracy != 1)
+
+    def test_fatal_severity_filter(self):
+        kwargs = self.query_args.copy()
+        kwargs['show_fatal'] = False
+        markers = Marker.bounding_box_query(yield_per=50, **kwargs)
+        for marker in markers:
+            self.assertTrue(marker.severity != 1)
+    
+    def test_severe_severity_filter(self):
+        kwargs = self.query_args.copy()
+        kwargs['show_severe'] = False
+        markers = Marker.bounding_box_query(yield_per=50, **kwargs)
+        for marker in markers:
+            self.assertTrue(marker.severity != 2)
+
+    def test_light_severity_filter(self):
+        kwargs = self.query_args.copy()
+        kwargs['show_light'] = False
+        markers = Marker.bounding_box_query(yield_per=50, **kwargs)
+        for marker in markers:
+            self.assertTrue(marker.severity != 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Existing tests had empty self.query, resulting in all testing being pass regardless of the assertions.
Updated kwargs to yield a query with actual markers; updated assertions.

[ fix #437 ]