### PR TITLE
sidebar icons positioned when icon type is dots

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -733,12 +733,27 @@ input[type='checkbox']{
 
 .current-view .gmnoprint{
     position: relative;
+}
+
+.sidebar-pin .gmnoprint{
     top: 33px;
     left: 15px;
+}
+
+.sidebar-dot .gmnoprint{
+    top:5px;
 }
 
 .current-view a > div:first-child{
     float: right;
     display: inline;
+}
+
+.sidebar-pin a > div:first-child{
     margin-left: 7px;
+}
+
+.sidebar-dot a > div:first-child{
+    margin: 15px;
+    margin-right: 0px;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -446,8 +446,6 @@ $(function () {
                 $(toggleDiv).toggleClass('dot');
                 this.iconTypeChanged = true;
                 this.toggleMarkerIconType();
-                /*this.$el.find(".current-view").toggleClass("sidebar-pin");
-                this.$el.find(".current-view").toggleClass("sidebar-dot");*/
             }.bind(this));
 
             toggleBGDiv.appendChild(toggleDiv);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -189,6 +189,12 @@ $(function () {
             }
             this.updateFilterString();
             this.chooseMarker();
+            if(this.iconTypeChanged == true){
+                this.$el.find(".current-view").toggleClass("sidebar-pin");
+                this.$el.find(".current-view").toggleClass("sidebar-dot");
+                this.iconTypeChanged = false;
+            }
+
         },
         buildMarkersParams: function (isForUrl) {
             var bounds = this.map.getBounds();
@@ -438,7 +444,10 @@ $(function () {
             google.maps.event.addDomListener(toggleBGDiv, 'click', function () {
                 $(toggleDiv).toggleClass('pin');
                 $(toggleDiv).toggleClass('dot');
+                this.iconTypeChanged = true;
                 this.toggleMarkerIconType();
+                /*this.$el.find(".current-view").toggleClass("sidebar-pin");
+                this.$el.find(".current-view").toggleClass("sidebar-dot");*/
             }.bind(this));
 
             toggleBGDiv.appendChild(toggleDiv);

--- a/templates/index.html
+++ b/templates/index.html
@@ -422,7 +422,7 @@
                 <input type="checkbox" id="checkbox-discussions" onclick="app.loadFilter()" checked/>
                 <label for="checkbox-discussions" class="btn two left">דיונים</label>
             </div>
-            <ul class="current-view"></ul>
+            <ul class="current-view sidebar-pin"></ul>
         </div>
 
         <!-- FILTER INFO (HOMRA)-->


### PR DESCRIPTION
I figured that when you change the icons type they are not positioned right so I made their style affected by the class of the current-view. the class toggle looks bad if it is executed before the markers are fetched so I added it after the markers are reloaded.