### PR TITLE
Closes #596: Adding HeatMap for markers and clusters.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -394,6 +394,17 @@ input[type="date"],input[type="time"]{
     content: '\f0b2'
 }
 
+.heat-map-control:after{
+    font-size: 17px;
+    color: #ccc;
+    font-family: 'Material Icons';
+    content: '\e80e'
+}
+
+.heat-map-control-red:after{
+    color: #ef5350;
+}
+
 .map-button:hover .control-label{
     visibility: visible !important;
     position: fixed;

--- a/static/js/marker.js
+++ b/static/js/marker.js
@@ -35,7 +35,9 @@ var MarkerView = Backbone.View.extend({
         }
 
         this.marker.setIcon(this.getIcon());
-        this.marker.setMap(this.map);
+        if (!app.heatMapMode){
+            this.marker.setMap(this.map);
+        }
         this.marker.view = this;
 
         if (this.model.get("type") == MARKER_TYPE_DISCUSSION) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -99,6 +99,7 @@
             <div id="tour-control"></div>
             <div id="statistics-control"></div>
             <div id="full-screen-control"></div>
+            <div id="heat-map-control"></div>
         </div>
     </div>
     <div id="step2Component" class="sidebar-container sidebar-container-open" style="{{ 'display: none' if map_only }}"></div>
@@ -1015,7 +1016,7 @@
 </script>
 
 <script type="text/javascript"
-        src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBpOmft-UskZsAQth9vNl0fN6EXaRR6dZc&libraries=places&language=iw"></script>
+        src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBpOmft-UskZsAQth9vNl0fN6EXaRR6dZc&libraries=places,visualization&language=iw"></script>
 {% assets filters="rjsmin", output="js/app.min.js",
             "js/libs/jquery-1.11.3.min.js",
 "js/libs/spin.min.js",


### PR DESCRIPTION
Issue #596: Adding HeatMap for markers and clusters.

### The gist of it:
* Adding new button for toggling HeatMap On/Off.
* Said button^ changes it's color according to it's state.
* Adding "global" `app.heatMapMode` variable(use it if you need to know the state of the HeatMap in the future).
* Adding HeatMap logic to `reloadSidebar()` - checks for HeatMapMode and renders the Icons/HeatMap accordingly.
* Adding new googlemaps API library `"visualization"`.
* Adding `buildHeatMap()` function which draws the HeatMap for markers / clusters.
* Adding `toggleHeatmap()` function -> called by the HeatMap toggling button.

#### Known issues / Things to do:
* Move the HeatMap On/Off toggle button to the `"toggle-control"` switch.
* Add support for user interaction with the HeatMap "spots"(i.e. same as with the clusters: user clicks on a cluster -> the map zooms in to the cluster location, consider doing the same with the HeatMap - right now the HeatMap simply visualizes the volume of accidents in different areas in order to make it more tangible).