### PR TITLE
Disabling the dots/icons switch when the user is in ClusterMode or HeatMapMode.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -454,6 +454,38 @@ input[type="date"],input[type="time"]{
     font-family: 'Material Icons';
 }
 
+.toggle-control-disabled:hover{
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(236,82,82,0.6) !important;
+    border-color: #F44336 !important;
+}
+
+.toggle-control-disabled-label{
+    position: fixed;
+    visibility: hidden;
+}
+
+.toggle-control-disabled:hover + .toggle-control-disabled-label{
+    visibility: visible !important;
+    position: absolute;
+    top: 0;
+    right: 50px;
+    margin-right: 10px;
+    height: 28px;
+    width: auto;
+    white-space: nowrap;
+    text-align: right;
+    padding-right: 10px;
+    padding-left: 12px;
+    line-height: 28px;
+    font-size: 15px;
+    color: #999999;
+    background-color: white;
+    border-radius: 3px;
+    border-color: #ccc;
+    border-width: 1px;
+    border-style: solid;
+}
+
 .pin:after{
     content: '\e55f';
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -546,13 +546,21 @@ $(function () {
                 toggleDiv.style = "display:none";
             toggleDiv.title = 'שנה תצוגת אייקונים';
             google.maps.event.addDomListener(toggleBGDiv, 'click', function () {
-                $(toggleDiv).toggleClass('pin');
-                $(toggleDiv).toggleClass('dot');
-                this.iconTypeChanged = true;
-                this.toggleMarkerIconType();
+                if(! ( this.heatMapMode || this.clusterMode() ) ) {
+                    $(toggleDiv).toggleClass('pin');
+                    $(toggleDiv).toggleClass('dot');
+                    this.iconTypeChanged = true;
+                    this.toggleMarkerIconType();
+                }
             }.bind(this));
 
             toggleBGDiv.appendChild(toggleDiv);
+
+            var toggleDivLabel = document.createElement('div');
+            toggleDivLabel.className = 'toggle-control-disabled-label';
+            toggleDivLabel.innerHTML = 'שינוי תצוגת אייקונים אינו זמין במצב זה';
+            toggleBGDiv.appendChild(toggleDivLabel);
+
             this.map.controls[google.maps.ControlPosition.TOP_RIGHT].push(toggleBGDiv);
 
             google.maps.event.addListener(this.searchBox, 'places_changed', function () {
@@ -643,6 +651,9 @@ $(function () {
                     this.fetchMarkers();
                 }
             }.bind(this) );
+            google.maps.event.addListener(this.map, "zoom_changed", function(){
+                this.indicatingAvailabilityOfIconsDotsSwitch();
+            }.bind(this));
             google.maps.event.addListener(this.map, "click", _.bind(this.clickMap, this) );
             this.sidebar.setResponsively();
             return this;
@@ -1112,6 +1123,8 @@ $(function () {
         toggleHeatmap: function() {
             // Toggle heatMapButton color grey/red
             $(".heat-map-control").toggleClass('heat-map-control-red');
+            // Indicating switch availability
+            this.indicatingAvailabilityOfIconsDotsSwitch();
             if (this.heatMapMode){
                 this.oms.unspiderfy();
 
@@ -1217,6 +1230,18 @@ $(function () {
             } else {
                 $("#filter-string").empty()
                     .append("<p>התקרב על מנת לקבל נתוני סינון</p>");
+            }
+        },
+        indicatingAvailabilityOfIconsDotsSwitch: function() {
+            if (this.heatMapMode || this.clusterMode()){
+                // Indicating that the icons/dots switch is disabled
+                $(".map-button.toggle-control").addClass("toggle-control-disabled");
+                $(".map-button.toggle-control")[0].title = 'שינוי תצוגת אייקונים אינו זמין במצב זה';
+            } else {
+                // Remove indication that the icons/dots switch is disabled
+                $(".map-button.toggle-control").removeClass("toggle-control-disabled");
+                $(".map-button.toggle-control")[0].title = 'שנה תצוגת אייקונים';
+
             }
         }
     });


### PR DESCRIPTION
Issue #621: Disabling the dots/icons switch when the user is in Cluster or HeatMap mode.

### The gist of it:

* `toggleBGDiv` "click" event function will now be disabled when the user is either in HeatMap or in Cluster mode.
* Adding a label for the switch which tells the user that it is currently disabled.
* Changing the css so when the switch is disabled the border and shadow colors will change from blue to red - indicating that the switch is disabled.
* Checking availability of the switch on 2 cases: HeatMap toggling and zoom changing, and changing the indication accordingly.

@danielhers , feel free to change the name of the last function to a more succinct one. Or let me know if you want me to change it.