### PR TITLE
Query city and year

### DIFF
--- a/custom_queries/README.md
+++ b/custom_queries/README.md
@@ -1,0 +1,16 @@
+Custom Queries
+==============
+
+This directory provides specialised views and queries. Those are written in the dialect of PostgreSQL 9
+and are not expected to work on Sqlite.
+
+* view_lamas_markers_by_city_and_date.sql: Provides following items
+  * lamas_markers_by_city_and_date view: Extracts city name, year, month and day of week from Lamas data. Note
+that Ihud Hatzala data is not supported here, since there's not consistent way to extract the city name by parsing
+the address fields etc.
+  * lamas_marker_counts_by_city_year_and_severity view: Tabulates the data in view_lamas_markers_by_city_and_date to give
+yearly total accident counts by city and severity
+  * severity_to_weight stored procedure: Gives a weight by severity, so that severe accidents are given a higher weight in
+the total counts
+* accidents_yoy_by_city.sql: A stored procedure that tabulates the total weighted accident count for the
+specified cities and its year-on-year difference 

--- a/custom_queries/view_lamas_markers_by_city_and_date.sql
+++ b/custom_queries/view_lamas_markers_by_city_and_date.sql
@@ -10,3 +10,8 @@ SELECT
 	FROM markers WHERE provider_code = 3 AND address ~ ',';
 
 COMMENT ON COLUMN lamas_markers_by_city_and_date.day_of_week IS 'Sunday = 0 to Saturday = 6';
+
+CREATE OR REPLACE VIEW
+lamas_marker_counts_by_city_year_and_severity AS
+	SELECT city ,year, severity, COUNT(DISTINCT id) FROM lamas_markers_by_city_and_date
+	GROUP BY city, year, severity;

--- a/custom_queries/view_lamas_markers_by_city_and_date.sql
+++ b/custom_queries/view_lamas_markers_by_city_and_date.sql
@@ -1,0 +1,11 @@
+﻿CREATE OR REPLACE VIEW
+lamas_markers_by_city_and_date AS
+SELECT
+	id,
+	trim(both '* ' FROM (regexp_split_to_array(address, ',\s*'))[2]) AS city,
+	CAST(date_part('year',  created) AS INTEGER) AS year,
+	CAST(date_part('month', created) AS INTEGER) AS month,
+	CAST(date_part('dow',   created) AS INTEGER) AS day_of_week
+	FROM markers WHERE provider_code = 3 AND address ~ ',';
+
+COMMENT ON COLUMN lamas_markers_by_city_and_date.day_of_week IS 'Sunday = 0 to Saturday = 6';

--- a/custom_queries/view_lamas_markers_by_city_and_date.sql
+++ b/custom_queries/view_lamas_markers_by_city_and_date.sql
@@ -3,6 +3,7 @@ lamas_markers_by_city_and_date AS
 SELECT
 	id,
 	trim(both '* ' FROM (regexp_split_to_array(address, ',\s*'))[2]) AS city,
+	severity,
 	CAST(date_part('year',  created) AS INTEGER) AS year,
 	CAST(date_part('month', created) AS INTEGER) AS month,
 	CAST(date_part('dow',   created) AS INTEGER) AS day_of_week

--- a/custom_queries/view_lamas_markers_by_city_and_date.sql
+++ b/custom_queries/view_lamas_markers_by_city_and_date.sql
@@ -11,7 +11,24 @@ SELECT
 
 COMMENT ON COLUMN lamas_markers_by_city_and_date.day_of_week IS 'Sunday = 0 to Saturday = 6';
 
+CREATE OR REPLACE FUNCTION severity_to_weight(INTEGER) RETURNS INTEGER
+AS $$
+BEGIN
+	CASE ($1)
+	WHEN 1 THEN -- Fatal
+		RETURN 7;
+	WHEN 2 THEN -- Serious injury
+		RETURN 5;
+	ELSE
+		RETURN 1;
+	END CASE;
+END
+$$ LANGUAGE plpgsql IMMUTABLE;
+
 CREATE OR REPLACE VIEW
 lamas_marker_counts_by_city_year_and_severity AS
-	SELECT city ,year, severity, COUNT(DISTINCT id) FROM lamas_markers_by_city_and_date
+	SELECT city ,year, severity,
+	COUNT(DISTINCT id) AS count,
+	severity_to_weight(severity) * COUNT(DISTINCT id) AS weighted_count
+	FROM lamas_markers_by_city_and_date
 	GROUP BY city, year, severity;

--- a/custom_queries/yoy_weighted_count_delta.sql
+++ b/custom_queries/yoy_weighted_count_delta.sql
@@ -7,9 +7,14 @@ AS $$
 		sum(weighted_count) AS total_weighted_count,
 		sum(weighted_count) - lag(sum(weighted_count)) OVER (PARTITION BY city ORDER BY year) AS weighted_count_yoy_delta
 	FROM lamas_marker_counts_by_city_year_and_severity
-	WHERE city = ANY($1)
+	WHERE cardinality($1) = 0 OR city = ANY($1)
 GROUP BY city, year
 $$ LANGUAGE SQL;
 
--- Example invocation:
--- SELECT accidents_yoy_by_city(ARRAY[ 'רמת גן', 'חיפה' ]);
+COMMENT ON FUNCTION accidents_yoy_by_city(TEXT ARRAY) IS
+'Tabulate the total weighted accident count for the specified cities and its year-on-year difference. When an empty array of cities is specified, give results for all cities';
+
+-- Example invocation with a specific list of cities:
+--SELECT accidents_yoy_by_city(ARRAY[ 'רמת גן', 'חיפה' ]);
+-- Example invocation with no filtering for city name:
+--SELECT accidents_yoy_by_city(ARRAY[]::TEXT[]);

--- a/custom_queries/yoy_weighted_count_delta.sql
+++ b/custom_queries/yoy_weighted_count_delta.sql
@@ -1,0 +1,15 @@
+﻿CREATE OR REPLACE FUNCTION accidents_yoy_by_city(TEXT ARRAY)
+RETURNS TABLE(city TEXT, year INTEGER, total_weighted_count NUMERIC, weighted_count_yoy_delta NUMERIC)
+AS $$
+	SELECT
+		city,
+		year,
+		sum(weighted_count) AS total_weighted_count,
+		sum(weighted_count) - lag(sum(weighted_count)) OVER (PARTITION BY city ORDER BY year) AS weighted_count_yoy_delta
+	FROM lamas_marker_counts_by_city_year_and_severity
+	WHERE city = ANY($1)
+GROUP BY city, year
+$$ LANGUAGE SQL;
+
+-- Example invocation:
+-- SELECT accidents_yoy_by_city(ARRAY[ 'רמת גן', 'חיפה' ]);


### PR DESCRIPTION
Initial implementation of the per-city year-on-year comparison suggested by Simona. Currently it provides useful views that can be queried by city name (Lamas only), year, month and day of week, and a tabulation of year-on-year differences.
Since this is still work in progress, perhaps it would be better to merge it into a topic branch.