### PR TITLE
Actually test the cluster view

### DIFF
--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -117,12 +117,12 @@ class TestSite(unittest.TestCase):
           self.assertTrue(resp['markers'][i]['locationAccuracy'] in (2,3))
 
     def test_clusters(self):
-        rv = self.app.get("/clusters?ne_lat=34.430273343405844&ne_lng=44.643749999999955&sw_lat=28.84061194106889&sw_lng=22.385449218749955&zoom=6&thin_markers=true&start_date=1104537600&end_date=1486944000&show_fatal=1&show_severe=1&show_light=1&approx=1&accurate=1&show_markers=&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
+        rv = self.app.get("/clusters?ne_lat=34.430273343405844&ne_lng=44.643749999999955&sw_lat=28.84061194106889&sw_lng=22.385449218749955&zoom=6&thin_markers=true&start_date=1104537600&end_date=1486944000&show_fatal=1&show_severe=1&show_light=1&approx=1&accurate=1&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
         self.assertEqual(rv.status, '200 OK')
         #print(rv.data)
         resp = json.loads(rv.data)
         self.assertIn('clusters', resp)
-        self.assertEqual(len(resp['clusters']), 0)
+        self.assertGreater(len(resp['clusters']), 0)
 
     def test_single_marker(self):
         rv = self.app.get("/markers/2014027147")


### PR DESCRIPTION
I'm not sure whether it was done on purpose but the current test for clusters doesn't set `show_markers`, so effectively the cluster view returns an empty list.