### PR TITLE
Celery experiment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ node_js:
 
 services:
   - postgresql
+  - rabbitmq
 
 sudo: false
 
@@ -23,6 +24,7 @@ before_script:
   - psql -c 'create database anyway;' -U postgres
   - export DATABASE_URL='postgresql://postgres@localhost/anyway'
   - python models.py
+  - celery worker -A clusters_calculator -D
 
 script:
   - pylint -j $(nproc) *.py tests
@@ -30,3 +32,6 @@ script:
   - python process.py
   - python united.py --light
   - pytest tests
+
+after_script:
+  - kill $(cat celeryd.pid)

--- a/clusters_calculator.py
+++ b/clusters_calculator.py
@@ -1,27 +1,25 @@
+import itertools
+from celery import Celery, group
 from models import Marker
 from static.pymapcluster import calculate_clusters
-import logging
-import concurrent.futures
 import multiprocessing
+
+
+celery_app = Celery('tasks', backend='rpc://', broker='pyamqp://guest@localhost//')
+
+@celery_app.task
+def calculate_marker_box(kwargs, marker_box):
+    kwargs.update(marker_box)
+    markers_in_box = Marker.bounding_box_query(**kwargs).markers.all()
+    return calculate_clusters(markers_in_box, kwargs['zoom'])
 
 
 def retrieve_clusters(**kwargs):
     marker_boxes = divide_to_boxes(kwargs['ne_lat'], kwargs['ne_lng'], kwargs['sw_lat'], kwargs['sw_lng'])
-    result_futures = []
-    logging.info('number of cores: ' + str(multiprocessing.cpu_count()))
-    with concurrent.futures.ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()) as executor:
-        for marker_box in marker_boxes:
-
-            kwargs.update(marker_box)
-            markers_in_box = Marker.bounding_box_query(**kwargs).markers.all()
-            result_futures.append(executor.submit(calculate_clusters, markers_in_box, kwargs['zoom']))
-
-    completed_futures = concurrent.futures.wait(result_futures)
-    result = []
-    for future in completed_futures.done:
-        result.extend(future.result())
-
-    return result
+    job = group([calculate_marker_box.s(kwargs, marker_box) for marker_box in marker_boxes])
+    result = job.apply_async()
+    result.join()
+    return list(itertools.chain.from_iterable(result.get()))
 
 
 def divide_to_boxes(ne_lat, ne_lng, sw_lat, sw_lng):

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,10 @@ Flask-Admin==1.1.0
 Flask-Security==1.7.5
 WTForms==2.0.2
 sendgrid==1.4.0
-futures==2.1.6
 python-dateutil==2.4.2
 alembic==0.8.2
 apscheduler==2.1.2
 Flask-Compress==1.3.0
 rauth==0.7.2
 requests==2.4.3
+celery


### PR DESCRIPTION
I did a little experiment with #685. On my computer (Intel i7-7700k), it takes a bit more than 8 seconds to calculate the cluster used in the unit tests. The way we currently do parallalization is by using `ThreadPoolExecutor`. This has two drawbacks:

1. We suffer performance penalty due to Python's GIL
2. We spawn a pool of N workers (where N being the numbers of CPUs) for each request. This means that when we have M cluster requests at the same time, we spawn M * N threads, which is pretty bad.

In order to solve problem number 1, I tried changing `ThreadPoolexecutor` into `ProcessPoolExecutor`. This took more RAM due to spawning processes instead of threads, but decreased the time it takes to calculate the cluster from 8 seconds to about 5. However, this made problem number 2 much worse, as spawning N * M processes is an even worse idea.

In order to solve both problems I started using [Celery](http://www.celeryproject.org/). It's a task queue system that spawns N workers that sit and wait for jobs. I spawned N workers (number of CPUs) and also made the database retrieval parallel, which now decreased the time it takes to calculate the cluster to 3 seconds. Problem number 2 is solved because we have a fixed amount of workers. If multiple requests for calculating clusters come at the same time, they will share the same amount of workers.

I don't know if that's enough to close #685 but I think it's a major improvement. However, it makes deployment a bit more complex because we now depend on another service. I don't know which method is used to deploy in production, nor do I have experience with Heroku, but I think this branch should be deployed in Heroku so we can play with it a bit. I'll gladly help with the deployment of this branch if needed.
