### PR TITLE
Celery experiment - Take 2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
     - PYTHON: "C:\\Python27\\"
       DATABASE_URL: 'postgresql://postgres@localhost/anyway'
+      ANYWAY_DISABLE_CELERY: "1"
 
 services:
  - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
 
 services:
   - postgresql
+  - rabbitmq
 
 sudo: false
 
@@ -41,6 +42,7 @@ install:
 before_script:
   - psql -c 'create database anyway;' -U postgres
   - alembic upgrade head
+  - celery worker -A anyway.clusters_calculator -D
 
 script:
   - pylint -j $(nproc) anyway tests main.py

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 web: NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program gunicorn anyway:app
-worker: celery worker -A clusters_calculator -D
-
+worker: celery worker -A anyway.clusters_calculator

--- a/README.md
+++ b/README.md
@@ -43,19 +43,17 @@ platform specific tutorials. Developing by using a [virtual
 environment](https://www.youtube.com/watch?v=N5vscPTWKOk) is highly recommended.
 
 ### Ubuntu
-`sudo apt-get install python2-pip python2-dev libpq-dev`
+1. `sudo apt-get install python2-pip python2-dev libpq-dev rabbitmq-server`
+1. `systemctl enable --now rabbitmq-server`
 
 ### Fedora
 1. `sudo dnf upgrade python-setuptools`
-1. `sudo dnf install python-pip`
-
-### CentOS
-1. `sudo yum upgrade python-setuptools`
-1. `sudo yum install python-pip`
+1. `sudo dnf install python-pip rabbitmq-server`
+1. `systemctl enable --now rabbitmq-server`
 
 ### OS X
 1. `sudo easy_install pip setuptools`
-1. Install postgresql: `brew install postgresql` (after installing [brew](http://brew.sh))
+1. Install and activate [RabbitMQ](https://www.rabbitmq.com/install-standalone-mac.html)
 
 ### For all platforms:
 1. Activate your virtualenv (in case of using one): `source *env-name*/bin/activate`
@@ -79,6 +77,7 @@ See the [Wiki](https://github.com/hasadna/anyway/wiki/Setting-up-a-Python-develo
 1. Run the app: `python main.py testserver`: do this whenever you start working and want to try out your code.
 1. Navigate to http://127.0.0.1:5000 in your browser.
 1. If the site fails to load properly, make sure you have JDK installed on your machine
+1. If your platform supports RabbitMQ, you should lunch a Celery worker by running `celery worker -A anyway.clusters_calculator -D`. Otherwise, export the environment variable `ANYWAY_DISABLE_CELERY` to disable the use of Celery.
 1. If you wish to share your app on the local network, you can expose flask by running `python
     main.py testserver --open` (Please note that this would expose your machine on port 5000 to all
     local nodes)

--- a/anyway/task_queue.py
+++ b/anyway/task_queue.py
@@ -1,0 +1,35 @@
+import os
+import itertools
+
+
+if os.environ.get("ANYWAY_DISABLE_CELERY"):
+    from functools import partial
+
+    class MockTaskQueue(object):
+        @staticmethod
+        def task(f):
+            f.delay = f
+            return f
+
+    task_queue = MockTaskQueue
+
+    task_signature = partial
+
+    def map_task(task, candidates):
+        return list(itertools.chain.from_iterable(task(candidate) for candidate in candidates))
+
+else:
+    from celery import Celery, group
+
+    task_queue = Celery('tasks',
+                        backend=os.environ.get('CELERY_BACKEND_URL', 'rpc://'),
+                        broker=os.environ.get('CELERY_BROKER_URL', 'amqp://guest@localhost//'))
+
+    def task_signature(task, *args, **kwargs):
+        return task.s(*args, **kwargs)
+
+    def map_task(task, candidates):
+        job = group([task.clone([candidate]) for candidate in candidates])
+        result = job.apply_async()
+        result.join()
+        return list(itertools.chain.from_iterable(result.get()))

--- a/docker-compose-pgsql.yml
+++ b/docker-compose-pgsql.yml
@@ -8,9 +8,30 @@ services:
       - "8080:5000"
     environment:
       - DATABASE_URL=postgresql://anyway:anyway@db/anyway
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq
     volumes:
       - ./static:/anyway/static
     restart: always
+    depends_on:
+      - db
+      - rabbitmq
+
+  anyway_celery:
+    build: .
+    image: hasadna/anyway:latest
+    environment:
+      - DATABASE_URL=postgresql://anyway:anyway@db/anyway
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq
+    restart: always
+    entrypoint: ''
+    command: celery worker -A anyway.clusters_calculator
+    depends_on:
+      - db
+      - rabbitmq
+
+  rabbitmq:
+    image: rabbitmq
+
   db:
     image: postgres:alpine
     environment:

--- a/docker-compose-sqlite.yml
+++ b/docker-compose-sqlite.yml
@@ -8,6 +8,24 @@ services:
       - "8080:5000"
     environment:
       - DATABASE_URL=sqlite:////anyway/local.db
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq
     volumes:
       - ./static:/anyway/static
     restart: always
+    depends_on:
+      - rabbitmq
+
+  anyway_celery:
+    build: .
+    image: hasadna/anyway:latest
+    environment:
+      - DATABASE_URL=postgresql://anyway:anyway@db/anyway
+      - CELERY_BROKER_URL=amqp://guest:guest@rabbitmq
+    restart: always
+    entrypoint: ''
+    command: celery worker -A anyway.clusters_calculator
+    depends_on:
+      - rabbitmq
+
+  rabbitmq:
+    image: rabbitmq

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-cd /anyway
+set -u
 
 alembic upgrade head
 python main.py process cbs

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ Flask-Admin==1.1.0
 Flask-Security==1.7.5
 WTForms==2.0.2
 sendgrid==1.4.0
-futures==2.1.6
 python-dateutil==2.4.2
 alembic==0.8.2
 apscheduler==2.1.2
@@ -29,3 +28,4 @@ rauth==0.7.2
 requests
 click
 six
+celery[redis]


### PR DESCRIPTION
Same as before, but as suggested [here](https://stackoverflow.com/questions/25490542/celery-beat-on-heroku-vs-worker-and-clock-processes#25490945) we now run Celery in Heroku without the `-D` flag, which means the process will not detach itself from its creator. Maybe now we can see some informative logs when something goes wrong.