### PR TITLE
Improved data processing (fix #662)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask-SQLAlchemy==2.1
 Flask-Login==0.3.2
 Jinja2==2.7.1
 MarkupSafe==0.18
-SQLAlchemy==0.9
+SQLAlchemy>=1.1
 Werkzeug==0.10.4
 blinker==1.3
 newrelic==2.36.0.30


### PR DESCRIPTION
This also seems to improve the performance of the importing. The default batch size is 100, but perhaps there is a better number. I didn't play with it.

Note that existing environments will need to run `pip install -r requirements.txt` again in order to upgrade SQLAlchemy. The new version is needed for using the bulk operations.