### PR TITLE
Allow scrolling info windows by using the mouse wheel

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -434,7 +434,8 @@ $(function () {
                 zoomControl: !MAP_ONLY,
                 panControl: !MAP_ONLY,
                 streetViewControl: !MAP_ONLY,
-                styles: MAP_STYLE
+                styles: MAP_STYLE,
+                gestureHandling: "greedy"
             };
             this.map = new google.maps.Map(this.$el.find("#map_canvas").get(0), mapOptions);
 
@@ -711,6 +712,7 @@ $(function () {
                 this.updateUrl();
                 $(document).off('keydown',app.ESCinfoWindow);
             }
+            app.map.gestureHandling = "greedy";
         },
         clickMap: function (e) {
             this.closeInfoWindow();

--- a/static/js/marker.js
+++ b/static/js/marker.js
@@ -260,6 +260,7 @@ var MarkerView = Backbone.View.extend({
             });
         }
 
+        app.map.gestureHandling = "cooperative";
         $(document).keydown(app.ESCinfoWindow);
     },
     clickShare : function() {


### PR DESCRIPTION
Currently, trying to use the mouse wheel to scroll an info window results in the map zooming in or out instead of scrolling the info window. This patch fixes this behavior by settings the map gesture handling to cooperative only when an info window is active. This means that while an info window is active, zooming is done by holding the control key together with the mouse wheel, allowing to use the mouse wheel to scroll the info window. Once the info window is closed, zooming is performed only by using the mouse wheel.