### PR TITLE
Parameterized markers filter testing

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pylint
+urlobject

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -2,10 +2,16 @@
 from anyway import app as flask_app
 import json
 import pytest
+from functools import partial
+from urlobject import URLObject
+from collections import Counter
 
 @pytest.fixture
 def app():
     return flask_app.test_client()
+
+
+query_flag = partial(pytest.mark.parametrize, argvalues=["1", ""])
 
 
 def test_main(app):
@@ -26,16 +32,11 @@ def test_markers_empty(app):
     #print(rv.data)
 
 
-# this was the request I saw when I loaded the main page
-def test_markers(app):
-    rv = app.get("/markers?ne_lat=32.08656790211843&ne_lng=34.80611543655391&sw_lat=32.08003198103277&sw_lng=34.793884563446&zoom=17&thin_markers=false&start_date=1104537600&end_date=1484697600&show_fatal=1&show_severe=1&show_light=1&approx=1&accurate=1&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
-    assert rv.status == '200 OK'
-    assert rv.headers['Content-Type'] == 'application/json'
-    #print(rv.data)
-    resp = json.loads(rv.data)
-    assert 'markers' in resp
-    assert len(resp['markers']) == 41
-    #print(len(resp['markers']))
+@pytest.fixture(scope="module")
+def marker_counter():
+    counter = Counter()
+    yield counter
+    assert counter['markers'] == 1688
 
 
 def test_bad_date(app):
@@ -53,86 +54,32 @@ def test_markers_2014086707(app):
         assert json.loads(rv.data) == json.load(fh)
 
 
-def test_markers_fatal_only(app):
-    rv = app.get("/markers?ne_lat=32.082754580757744&ne_lng=34.79886274337764&sw_lat=32.072645555012734&sw_lng=34.77712612152095&zoom=16&thin_markers=false&start_date=1104537600&end_date=1485129600&show_fatal=1&show_severe=&show_light=&approx=1&accurate=1&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
+@query_flag("show_fatal")
+@query_flag("show_severe")
+@query_flag("show_light")
+@query_flag("show_approx")
+@query_flag("show_accurate")
+def test_markers(app, show_fatal, show_severe, show_light, show_accurate, show_approx, marker_counter):
+    url = URLObject('/markers').set_query_params({
+        "ne_lat": "32.085413468822", "ne_lng": "34.797736215591385", "sw_lat": "32.07001357040486", "sw_lng": "34.775548982620194", "zoom": "16", "thin_markers": "false",
+        "start_date": "1104537600", "end_date": "1484697600", "show_fatal": show_fatal, "show_severe": show_severe, "show_light": show_light, "approx": show_approx, "accurate": show_accurate, "show_markers": "1",
+        "show_discussions": "1", "show_urban": "3", "show_intersection": "3", "show_lane": "3", "show_day": "7", "show_holiday": "0", "show_time": "24", "start_time": "25",
+        "end_time": "25", "weather": "0", "road": "0", "separation": "0", "surface": "0", "acctype": "0", "controlmeasure": "0", "district": "0", "case_type": "0"})
+
+    rv = app.get(url)
     assert rv.status == '200 OK'
-    #print(rv.data)
+    assert rv.headers['Content-Type'] == 'application/json'
+
     resp = json.loads(rv.data)
-    assert 'markers' in resp
-    assert len(resp['markers']) == 1
 
+    marker_counter["markers"] += len(resp['markers'])
 
-def test_markers_fatal_only_response(app):
-    rv = app.get("/markers?ne_lat=32.082754580757744&ne_lng=34.79886274337764&sw_lat=32.072645555012734&sw_lng=34.77712612152095&zoom=16&thin_markers=false&start_date=1104537600&end_date=1485129600&show_fatal=1&show_severe=&show_light=&approx=1&accurate=1&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
-    assert rv.status == '200 OK'
-    #print(rv.data)
-    resp = json.loads(rv.data)
-    assert 'markers' in resp
-    #assert len(resp['markers']) == 16
-    for i in range(0,len(resp['markers'])):
-        assert resp['markers'][i]['severity'] == 1
-
-
-def test_markers_severe_only(app):
-    rv = app.get("/markers?ne_lat=32.082754580757744&ne_lng=34.79886274337764&sw_lat=32.072645555012734&sw_lng=34.77712612152095&zoom=16&thin_markers=false&start_date=1104537600&end_date=1485129600&show_fatal=&show_severe=1&show_light=&approx=1&accurate=1&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
-    assert rv.status == '200 OK'
-    #print(rv.data)
-    resp = json.loads(rv.data)
-    assert 'markers' in resp
-    assert len(resp['markers']) == 16
-
-
-def test_markers_severve_only_response(app):
-    rv = app.get("/markers?ne_lat=32.082754580757744&ne_lng=34.79886274337764&sw_lat=32.072645555012734&sw_lng=34.77712612152095&zoom=16&thin_markers=false&start_date=1104537600&end_date=1485129600&show_fatal=&show_severe=1&show_light=&approx=1&accurate=1&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
-    assert rv.status == '200 OK'
-    #print(rv.data)
-    resp = json.loads(rv.data)
-    assert 'markers' in resp
-    #assert len(resp['markers']) == 16
-    for i in range(0,len(resp['markers'])):
-        assert resp['markers'][i]['severity'] == 2
-
-
-def test_markers_light_only(app):
-    rv = app.get("/markers?ne_lat=32.082754580757744&ne_lng=34.79886274337764&sw_lat=32.072645555012734&sw_lng=34.77712612152095&zoom=16&thin_markers=false&start_date=1104537600&end_date=1485129600&show_fatal=&show_severe=&show_light=1&approx=1&accurate=1&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
-    assert rv.status == '200 OK'
-    #print(rv.data)
-    resp = json.loads(rv.data)
-    assert 'markers' in resp
-    assert len(resp['markers']) == 110
-
-
-def test_markers_light_only_response(app):
-    rv = app.get("/markers?ne_lat=32.082754580757744&ne_lng=34.79886274337764&sw_lat=32.072645555012734&sw_lng=34.77712612152095&zoom=16&thin_markers=false&start_date=1104537600&end_date=1485129600&show_fatal=&show_severe=&show_light=1&approx=1&accurate=1&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
-    assert rv.status == '200 OK'
-    #print(rv.data)
-    resp = json.loads(rv.data)
-    assert 'markers' in resp
-    #assert len(resp['markers']) == 16
-    for i in range(0,len(resp['markers'])):
-        assert resp['markers'][i]['severity'] == 3
-
-
-def test_markers_accurate_only(app):
-    rv = app.get("/markers?ne_lat=32.082754580757744&ne_lng=34.79886274337764&sw_lat=32.072645555012734&sw_lng=34.77712612152095&zoom=16&thin_markers=false&start_date=1104537600&end_date=1485129600&show_fatal=1&show_severe=1&show_light=1&approx=&accurate=1&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
-    assert rv.status == '200 OK'
-    #print(rv.data)
-    resp = json.loads(rv.data)
-    assert 'markers' in resp
-    #assert len(resp['markers']) == 16
-    for i in range(0,len(resp['markers'])):
-        assert resp['markers'][i]['locationAccuracy'] == 1
-
-
-def test_markers_approx_only(app):
-    rv = app.get("/markers?ne_lat=32.082754580757744&ne_lng=34.79886274337764&sw_lat=32.072645555012734&sw_lng=34.77712612152095&zoom=16&thin_markers=false&start_date=1104537600&end_date=1485129600&show_fatal=1&show_severe=1&show_light=1&approx=1&accurate=&show_markers=1&show_discussions=1&show_urban=3&show_intersection=3&show_lane=3&show_day=7&show_holiday=0&show_time=24&start_time=25&end_time=25&weather=0&road=0&separation=0&surface=0&acctype=0&controlmeasure=0&district=0&case_type=0")
-    assert rv.status == '200 OK'
-    #print(rv.data)
-    resp = json.loads(rv.data)
-    assert 'markers' in resp
-    #assert len(resp['markers']) == 16
-    for i in range(0,len(resp['markers'])):
-        assert resp['markers'][i]['locationAccuracy'] in (2,3)
+    for marker in resp['markers']:
+        assert show_fatal or marker['severity'] != 1
+        assert show_severe or marker['severity'] != 2
+        assert show_light or marker['severity'] != 3
+        assert show_accurate or marker['locationAccuracy'] != 1
+        assert show_approx or marker['locationAccuracy'] == 1
 
 
 def test_clusters(app):


### PR DESCRIPTION
This patch removes all the hard-coded cases for markers filtering and replace them with a
parameterized testing.

Pytest expands test_markers into multiple tests, containing a test for the entire Cartesian product of the filtering flags.

Each test checks that results that were supposed to be filtered out got in, and at the end of all tests the marker_counter fixtures makes sure that we got the expected amount of result in total by comparing it against a hard-coded number. This number should be updated if we ever add more parameters to the test, or import additional marker data into the testing environment.