### PR TITLE
Browser tests (fix #606)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,4 +36,4 @@ test_script:
 
     python main.py import_united_data --light
 
-    python -m pytest tests
+    python -m pytest -m "not browser" tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,21 @@ python:
 node_js:
   - "6"
 
+addons:
+  sauce_connect: true
+
+env:
+  global:
+    - SAUCELABS_USERNAME=anyway
+    - SAUCE_USERNAME=anyway
+    - secure: "RYGbTO5b15B5BJnmLQAajWskG7F/lDT+BO/P2EjP8xU5P70hME3PNgaZPJ1phPq49XRS4Oe2t4c7ta6V1JdDMc10MkihmEqgdsRyxw4UhVtz6i4mDYFZFrgntYofqbvfrc5r9Z4C81y8a79wY6D/H10L2ocpEeEsZWilh+N8mWE="
+    - secure: "HmWdkaHFKlvFKgpTc/TFtOwPxgu/FE+/J27sTMsXkFxf7MCSa4817CtEs6BumlVAuoPtnxy9es6RYsUoqv5+eIJBwCryx+DtmxjUqMtRM2RlNOPtRABOjZ/QECqgaRtNEAsSxQH3XWWWkniqQgXFCS6crKUhA+elpvivKgf9iyQ="
+    - DATABASE_URL='postgresql://postgres@localhost/anyway'
+
+  matrix:
+    - BROWSER=Chrome
+    - BROWSER=Firefox
+
 services:
   - postgresql
 
@@ -21,7 +36,6 @@ install:
 
 before_script:
   - psql -c 'create database anyway;' -U postgres
-  - export DATABASE_URL='postgresql://postgres@localhost/anyway'
   - ./main.py init_db
 
 script:
@@ -29,4 +43,4 @@ script:
   - eslint static/js --ignore-path=static/js/.eslintignore
   - ./main.py process_data
   - ./main.py import_united_data --light
-  - pytest tests
+  - pytest tests --driver SauceLabs --capability browserName $BROWSER --capability tunnelIdentifier $TRAVIS_JOB_NUMBER

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ It is useful to add the following to your `~/.bashrc` (fixing for the correct pa
 Then you can simply start working by running the `anyway` command.
 
 ## Testing
-To run tests: `pylint -j $(nproc) anyway tests && pytest ./tests`
+To run tests: `pylint -j $(nproc) anyway tests && pytest -m "not browser" ./tests`
+
+If you also wish to run the real browser tests, replace`-m "not browser"` with `--driver Chrome` or specify the browser of your choice. To learn more, read about [pytest-selenium](http://pytest-selenium.readthedocs.io/en/latest/user_guide.html#specifying-a-browser).
 
 ## Docker
 See [DOCKER](docs/DOCKER.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ alembic==0.8.2
 apscheduler==2.1.2
 Flask-Compress==1.3.0
 rauth==0.7.2
-requests==2.4.3
+requests
 click

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pylint
 urlobject
+pytest-selenium

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+import requests
+from anyway import app
+from threading import Thread
+from time import sleep
+from urlobject import URLObject
+from werkzeug.serving import make_server
+
+
+class ServerThread(Thread):
+    def __init__(self):
+        super(ServerThread, self).__init__()
+        self.srv = make_server('127.0.0.1', 5000, app)
+        self.ctx = app.app_context()
+        self.ctx.push()
+
+    def run(self):
+        self.srv.serve_forever()
+
+    def shutdown(self):
+        self.srv.shutdown()
+
+
+@pytest.fixture(scope="session")
+def anyway_server():
+    server_thread = ServerThread()
+    server_thread.start()
+    sleep(0.1)
+
+    url = URLObject("http://127.0.0.1:5000")
+    response = requests.get(url)
+    response.raise_for_status()
+
+    yield url
+
+    server_thread.shutdown()

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+import pytest
+from selenium.common.exceptions import (StaleElementReferenceException,
+                                        TimeoutException, WebDriverException)
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+_WAIT_TIME = 30
+
+def _get_info_window_markers(selenium):
+    return selenium.find_elements_by_xpath("//div[@class='info-window']//div[contains(@title,'תאונה')]")
+
+
+def _ajax_finished(selenium):
+    return selenium.execute_script("return jQuery.active == 0")
+
+
+def _check_accidents(selenium):
+    accidents_element = WebDriverWait(selenium, 30).until(
+        EC.visibility_of_element_located((By.XPATH, "//a[@onclick = 'showFilter(FILTER_MARKERS)']")))
+    try:
+        accidents = int(accidents_element.text)
+    except StaleElementReferenceException:
+        return False
+
+    if not accidents:
+        return False
+
+    markers_in_info_window = _get_info_window_markers(selenium)
+    if accidents != len(markers_in_info_window):
+        return False
+
+    return accidents
+
+
+def _go_to_location(selenium, location):
+    selenium.find_element_by_id("pac-input").send_keys(location + "\n")
+
+
+def _click_a_cluster(selenium):
+    elements = selenium.find_elements_by_xpath("//div[@class='cluster']/div")
+    for element in elements:
+        if not (element.is_displayed() and element.is_enabled()):
+            continue
+
+        try:
+            element.click()
+        except WebDriverException:
+            continue
+
+        try:
+            WebDriverWait(selenium, 3).until(
+                EC.visibility_of_element_located((By.XPATH, "//a[@onclick = 'showFilter(FILTER_MARKERS)']")))
+        except TimeoutException:
+            continue
+        else:
+            return True
+
+    return False
+
+
+@pytest.mark.browser
+def test_sanity(selenium, anyway_server):
+    selenium.get(anyway_server)
+
+    _go_to_location(selenium, location=u'מגדל משה אביב')
+    WebDriverWait(selenium, _WAIT_TIME).until(_ajax_finished)
+
+    first_accidents = WebDriverWait(selenium, _WAIT_TIME).until(_check_accidents)
+    zoom_out_button = WebDriverWait(selenium, _WAIT_TIME).until(EC.element_to_be_clickable((By.XPATH, "//div[@title='הקטנת התצוגה']")))
+
+    zoom_out_button.click()
+    WebDriverWait(selenium, _WAIT_TIME).until(_ajax_finished)
+    WebDriverWait(selenium, _WAIT_TIME).until(lambda selenium: _check_accidents(selenium) > first_accidents)
+
+    zoom_out_button.click()
+    zoom_out_button.click()
+    WebDriverWait(selenium, _WAIT_TIME).until(_ajax_finished)
+    WebDriverWait(selenium, _WAIT_TIME).until(lambda selenium: len(_get_info_window_markers(selenium)) == 0)
+    WebDriverWait(selenium, _WAIT_TIME).until(_click_a_cluster)
+
+    WebDriverWait(selenium, _WAIT_TIME).until(_ajax_finished)
+    WebDriverWait(selenium, _WAIT_TIME).until(_check_accidents)


### PR DESCRIPTION
This patch adds a test with a real browser by using Selenium.

The included test goes to מגדל משה אביב, checks for accidents, zooms out until the view turns into a cluster view, clicks on a cluster and then checks the accidents again.

There are many more things that we might wish to test using a real browser, but I feel like this is a good start.

The tests run in Travis against Firefox and Chrome. The [SauceLabs](https://saucelabs.com/) account was created by me and the access key is encrypted in `.travis.yml`. I will hand the password to @simonaho and @danielhers in private.