### PR TITLE
Unify the database initialization (fix #752)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ env:
     - SAUCE_USERNAME=anyway
     - secure: "RYGbTO5b15B5BJnmLQAajWskG7F/lDT+BO/P2EjP8xU5P70hME3PNgaZPJ1phPq49XRS4Oe2t4c7ta6V1JdDMc10MkihmEqgdsRyxw4UhVtz6i4mDYFZFrgntYofqbvfrc5r9Z4C81y8a79wY6D/H10L2ocpEeEsZWilh+N8mWE="
     - secure: "HmWdkaHFKlvFKgpTc/TFtOwPxgu/FE+/J27sTMsXkFxf7MCSa4817CtEs6BumlVAuoPtnxy9es6RYsUoqv5+eIJBwCryx+DtmxjUqMtRM2RlNOPtRABOjZ/QECqgaRtNEAsSxQH3XWWWkniqQgXFCS6crKUhA+elpvivKgf9iyQ="
-    - DATABASE_URL='postgresql://postgres@localhost/anyway'
 
   matrix:
-    - BROWSER=Chrome
-    - BROWSER=Firefox
+    - BROWSER=Chrome DATABASE_URL='postgresql://postgres@localhost/anyway'
+    - BROWSER=Firefox DATABASE_URL='postgresql://postgres@localhost/anyway'
+    - BROWSER=Firefox DATABASE_URL='sqlite:///testing.db'
 
 services:
   - postgresql

--- a/anyway/base.py
+++ b/anyway/base.py
@@ -2,13 +2,17 @@ from flask import session, redirect
 from flask import request
 from .models import User
 from functools import wraps
+from .utilities import init_flask
+from flask.ext.sqlalchemy import SQLAlchemy
+app = init_flask(__name__)
+db = SQLAlchemy(app)
 
 def set_user(user):
     session["user"] = user.id
 
 def get_user():
     if "user" in session:
-        return User.query.filter(User.id == session["user"]).scalar()
+        return db.session.query(User).filter(User.id == session["user"]).scalar()
     else:
         return None
 

--- a/anyway/database.py
+++ b/anyway/database.py
@@ -1,12 +1,9 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from . import config
 
 
 engine = create_engine(config.SQLALCHEMY_DATABASE_URI, convert_unicode=True, echo=False)
-db_session = scoped_session(sessionmaker(autocommit=False, autoflush=True, bind=engine))
 Base = declarative_base()
-Base.query = db_session.query_property()
 
 

--- a/anyway/process.py
+++ b/anyway/process.py
@@ -376,7 +376,7 @@ def import_to_datastore(directory, provider_code, batch_size):
 
         accidents = (accident for accident
                      in import_accidents(provider_code=provider_code, **files_from_lms)
-                     if  Marker.query.filter(
+                     if  db.session.query(Marker).filter(
                              and_(Marker.id == accident["id"],
                                   Marker.provider_code == accident["provider_code"])).scalar() is None)
 

--- a/anyway/united.py
+++ b/anyway/united.py
@@ -313,7 +313,7 @@ def import_to_db(collection, path):
         return 0
 
     new_ids = [m["id"] for m in accidents
-               if 0 == Marker.query.filter(and_(Marker.id == m["id"],
+               if 0 == db.session.query(Marker).filter(and_(Marker.id == m["id"],
                                                 Marker.provider_code == m["provider_code"])).count()]
     if not new_ids:
         logging.info("\t\tNothing loaded, all accidents already in DB")
@@ -330,7 +330,7 @@ def update_db(collection):
     """
     app = init_flask(__name__)
     db = SQLAlchemy(app)
-    united = Marker.query.filter(Marker.provider_code == 2)
+    united = db.session.query(Marker).filter(Marker.provider_code == 2)
     for accident in united:
         if not accident.weather:
             accident.weather = process_weather_data(collection, accident.latitude, accident.longitude)


### PR DESCRIPTION
So far we've had two methods for initializing the database - one is using flask-sqlalchemy and the
other is using the session object in the database module.

When specifying a relative path for an SQLite database, the default behavior of SQLAlchemy is to
use the file relative to the current working directory. However, the behavior of flask-sqlalchemy
is different. flask-sqlalchemy tries to use the file relative to the Flask application root.

Before 0274aeabd17cfcefb218656e029ce5927cda91bb the working directory and the Flask application root
were effectively the same directory, but since now they are different directories, it causes two
different SQLite databases to be created - one in the working directory and the other in the Flask
application root.

The solution is to unify these methods and always use flask-sqlalchemy to initialize the database.

The use of SQLite database will also be checked in Travis from now on.