### PR TITLE
Add Python 3.6 to both Travis and AppVeyor. Python 3 is not allowed to fail anymore.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python27\\"
+    - PYTHON: "C:\\Python27"
       DATABASE_URL: 'postgresql://postgres@localhost/anyway'
       ANYWAY_DISABLE_CELERY: "1"
 
@@ -8,33 +8,23 @@ services:
  - postgresql
 
 init:
-- ps: >-
+- ps: |
     Set-Content "c:\program files\postgresql\9.6\data\pg_hba.conf" "host    all             all             ::1/128            trust"
-
     Add-Content "c:\program files\postgresql\9.6\data\pg_hba.conf" "host    all             all             127.0.0.1/32            trust"
-
-    $env:Path += ";c:\program files\postgresql\9.6\bin"
-
-    $env:Path += ";$python\bin"
+    $env:PATH += ";c:\program files\postgresql\9.6\bin"
+    $env:PATH = "$env:Python;$env:Python\Scripts;$env:PATH"
 
 install:
-- ps: >-
-    python -m pip install -U --no-cache-dir pip wheel
-
-    python -m pip install --no-cache-dir -r requirements.txt -r test_requirements.txt
+  - python --version
+  - python -m pip install -U --no-cache-dir pip wheel
+  - python -m pip install --no-cache-dir -r requirements.txt -r test_requirements.txt
 
 build: off
 
 test_script:
-- ps: >-
-    psql -U postgres -c "CREATE ROLE appveyor LOGIN SUPERUSER CREATEDB CREATEROLE;"
-
-    createdb anyway
-
-    alembic upgrade head
-
-    python main.py process cbs
-
-    python main.py process united --light
-
-    python -m pytest -m "not browser" tests
+  - psql -U postgres -c "CREATE ROLE appveyor LOGIN SUPERUSER CREATEDB CREATEROLE;"
+  - createdb anyway
+  - alembic upgrade head
+  - python main.py process cbs
+  - python main.py process united --light
+  - python -m pytest -m "not browser" tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ cache:
 python:
   - 2.7.11
   - 3.5
-
-matrix:
-  allow_failures:
-    - python: 3.5
+  - 3.6
 
 node_js:
   - "6"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ You should be familiar with setting up Python in your computer. You can consult 
 platform specific tutorials. Developing by using a [virtual
 environment](https://www.youtube.com/watch?v=N5vscPTWKOk) is highly recommended.
 
+### Choosing a Python Version
+The project is currently transitioning to Python 3. Both Python 2 and 3 are supported at the moment, and the code is tested in Travis against both versions. If you are setting a new environment, it is recommended that you choose Python 3 for future compatibility. The instructions below are relevant for Python 2.
+
 ### Ubuntu
 1. `sudo apt-get install python2-pip python2-dev libpq-dev rabbitmq-server`
 1. `systemctl enable --now rabbitmq-server`
@@ -59,7 +62,7 @@ environment](https://www.youtube.com/watch?v=N5vscPTWKOk) is highly recommended.
 1. Activate your virtualenv (in case of using one): `source *env-name*/bin/activate`
 1. Run `pip install -r requirements.txt -r test_requirements.txt`
 
-### Windows (experimental)
+### Windows
 See the [Wiki](https://github.com/hasadna/anyway/wiki/Setting-up-a-Python-development-environment-in-Windows).
 
 ## Local first run (all platforms)


### PR DESCRIPTION
I prepared the AppVeyor for running Python 3, but I encountered some problems specific to Python 3
in Windows. I will update AppVeyor when these problems are resolved