### PR TITLE
pytest: fix marker warning, ignore library warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+addopts = --strict-markers
+
+markers =
+    browser: tests that require browser (deselect with '-m "not slow"')
+
+filterwarnings =
+    ignore:.*SQLALCHEMY_POOL_RECYCLE.*:DeprecationWarning
+    ignore:.*collections.abc.*:DeprecationWarning


### PR DESCRIPTION
Fix #1264 by adding `pytest.ini`

Fixed: register marker in pytest.ini:
```
tests/test_browser.py:64
  /anyway/tests/test_browser.py:64: PytestUnknownMarkWarning: Unknown pytest.mark.browser - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    @pytest.mark.browser
```

Ignored:
```
/venv3/lib/python3.7/site-packages/flask_sqlalchemy/utils.py:44
  /venv3/lib/python3.7/site-packages/flask_sqlalchemy/utils.py:44: DeprecationWarning: The `SQLALCHEMY_POOL_RECYCLE` config option is deprecated and will be removed in v3.0.  Use `SQLALCHEMY_ENGINE_OPTIONS['pool_recycle']` instead.
    DeprecationWarning
```

Ignored:
```
tests/test_news_flash.py::test_parse_walla
  /venv3/lib/python3.7/site-packages/bs4/builder/_lxml.py:61: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    if isinstance(parser, collections.Callable):
```