### PR TITLE
Remove u""-literals

### DIFF
--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -951,7 +951,7 @@ def index(marker=None, message=None):
             context['coordinates'] = (marker.latitude, marker.longitude)
             context['marker'] = marker.id
         else:
-            message = u"תאונה לא נמצאה: " + request.values['marker']
+            message = "תאונה לא נמצאה: " + request.values['marker']
     elif 'discussion' in request.values:
         discussions = DiscussionMarker.get_by_identifier(
             request.values['discussion'])
@@ -960,7 +960,7 @@ def index(marker=None, message=None):
             context['coordinates'] = (marker.latitude, marker.longitude)
             context['discussion'] = marker.identifier
         else:
-            message = gettext(u"Discussion not found:") + \
+            message = gettext("Discussion not found:") + \
                 request.values['discussion']
     if 'start_date' in request.values:
         context['start_date'] = string2timestamp(request.values['start_date'])
@@ -987,21 +987,21 @@ def index(marker=None, message=None):
     if message:
         context['message'] = message
     pref_accident_severity = []
-    pref_light = PreferenceObject('prefLight', '2', u"קלה")
-    pref_severe = PreferenceObject('prefSevere', '1', u"חמורה")
-    pref_fatal = PreferenceObject('prefFatal', '0', u"קטלנית")
+    pref_light = PreferenceObject('prefLight', '2', "קלה")
+    pref_severe = PreferenceObject('prefSevere', '1', "חמורה")
+    pref_fatal = PreferenceObject('prefFatal', '0', "קטלנית")
     pref_accident_severity.extend([pref_light, pref_severe, pref_fatal])
     context['pref_accident_severity'] = pref_accident_severity
     pref_accident_report_severity = []
-    pref_report_light = PreferenceObject('prefReportLight', '2', u"קלה")
-    pref_report_severe = PreferenceObject('prefReportSevere', '1', u"חמורה")
-    pref_report_fatal = PreferenceObject('prefReportFatal', '0', u"קטלנית")
+    pref_report_light = PreferenceObject('prefReportLight', '2', "קלה")
+    pref_report_severe = PreferenceObject('prefReportSevere', '1', "חמורה")
+    pref_report_fatal = PreferenceObject('prefReportFatal', '0', "קטלנית")
     pref_accident_report_severity.extend(
         [pref_report_light, pref_report_severe, pref_report_fatal])
     context['pref_accident_report_severity'] = pref_accident_report_severity
     pref_historical_report_periods = []
-    month_strings = [u"אחד", u"שניים", u"שלושה", u"ארבעה", u"חמישה", u"שישה", u"שבעה", u"שמונה", u"תשעה",
-                     u"עשרה", u"אחד עשר", u"שניים עשר"]
+    month_strings = ["אחד", "שניים", "שלושה", "ארבעה", "חמישה", "שישה", "שבעה", "שמונה", "תשעה",
+                     "עשרה", "אחד עשר", "שניים עשר"]
     for x in range(0, 12):
         pref_historical_report_periods.append(
             PreferenceObject('prefHistoricalReport' + str(x + 1) + 'Month', str(x + 1), month_strings[x]))

--- a/anyway/models.py
+++ b/anyway/models.py
@@ -153,7 +153,7 @@ class MarkerMixin(Point):
         if field in localization.get_supported_tables():
             value = decode_hebrew(localization.get_field(field, value), db_encoding)
         name = decode_hebrew(localization.get_field(field), db_encoding)
-        return u"{0}: {1}".format(name, value)
+        return "{0}: {1}".format(name, value)
 
 
 class HighlightPoint(Point, Base):

--- a/anyway/parsers/cbs.py
+++ b/anyway/parsers/cbs.py
@@ -243,11 +243,11 @@ def get_street(yishuv_symbol, street_sign, streets):
     """
     if yishuv_symbol not in streets:
         # Changed to return blank string instead of None for correct presentation (Omer)
-        return u""
+        return ""
     street_name = [x[field_names.street_name] for x in streets[yishuv_symbol] if
                    x[field_names.street_sign] == street_sign]
     # there should be only one street name, or none if it wasn't found.
-    return street_name[0] if len(street_name) == 1 else u""
+    return street_name[0] if len(street_name) == 1 else ""
 
 
 def get_address(accident, streets):
@@ -260,7 +260,7 @@ def get_address(accident, streets):
                         accident.get(field_names.street1),
                         streets)
     if not street:
-        return u""
+        return ""
 
     # the house_number field is invalid if it's empty or if it contains 9999
     house_number = int(accident.get(field_names.house_number)) if not pd.isnull(accident.get(field_names.house_number)) \
@@ -271,11 +271,11 @@ def get_address(accident, streets):
     if not house_number and not settlement:
         return street
     if not house_number and settlement:
-        return u"{}, {}".format(street, settlement)
+        return "{}, {}".format(street, settlement)
     if house_number and not settlement:
-        return u"{} {}".format(street, house_number)
+        return "{} {}".format(street, house_number)
 
-    return u"{} {}, {}".format(street, house_number, settlement)
+    return "{} {}, {}".format(street, house_number, settlement)
 
 
 def get_streets(accident, streets):
@@ -337,28 +337,28 @@ def get_junction(accident, roads):
         junction = roads.get(key, None)
         if junction:
             if accident.get(field_names.km) - junc_km > 0:
-                direction = u"צפונית" if accident.get(field_names.road1) % 2 == 0 else u"מזרחית"
+                direction = "צפונית" if accident.get(field_names.road1) % 2 == 0 else "מזרחית"
             else:
-                direction = u"דרומית" if accident.get(field_names.road1) % 2 == 0 else u"מערבית"
+                direction = "דרומית" if accident.get(field_names.road1) % 2 == 0 else "מערבית"
             if abs(float(accident["KM"] - junc_km) / 10) >= 1:
-                string = str(abs(float(accident["KM"]) - junc_km) / 10) + u" ק״מ " + direction + u" ל" + \
+                string = str(abs(float(accident["KM"]) - junc_km) / 10) + " ק״מ " + direction + " ל" + \
                          junction
             elif 0 < abs(float(accident["KM"] - junc_km) / 10) < 1:
                 string = str(int((abs(
-                    float(accident.get(field_names.km)) - junc_km) / 10) * 1000)) + u" מטרים " + direction + u" ל" + \
+                    float(accident.get(field_names.km)) - junc_km) / 10) * 1000)) + " מטרים " + direction + " ל" + \
                          junction
             else:
                 string = junction
             return string
         else:
-            return u""
+            return ""
 
     elif accident.get(field_names.non_urban_intersection) is not None:
         key = accident.get(field_names.road1), accident.get(field_names.road2), accident.get(field_names.km)
         junction = roads.get(key, None)
-        return junction if junction else u""
+        return junction if junction else ""
     else:
-        return u""
+        return ""
 
 
 def parse_date(accident):

--- a/anyway/parsers/news_flash_classifiers.py
+++ b/anyway/parsers/news_flash_classifiers.py
@@ -7,7 +7,7 @@ def tweet_with_accident_veichle_and_person(text):
     if (('הולך רגל' in text or 'הולכת רגל' in text or 'נהג' in text
          or 'אדם' in text)
             and ('רכב' in text or 'מכונית' in text or 'אופנוע' in text
-                 or u"ג'יפ" in text or 'טרקטור' in text or 'משאית' in text
+                 or "ג'יפ" in text or 'טרקטור' in text or 'משאית' in text
                  or 'אופניים' in text or 'קורקינט' in text)):
         return True
     return False
@@ -29,7 +29,7 @@ def tweet_with_veichles(text):
     :param text: tweet text
     :return: boolean, true if tweet contains veichle, false for others
     """
-    if 'רכב' in text or 'מכונית' in text or 'אופנוע' in text or u"ג'יפ" in text or 'טרקטור' in text or 'משאית' in text or \
+    if 'רכב' in text or 'מכונית' in text or 'אופנוע' in text or "ג'יפ" in text or 'טרקטור' in text or 'משאית' in text or \
         'אופניים' in text or 'קורקינט' in text:
         return True
     return False
@@ -53,7 +53,7 @@ def classify_ynet(text):
     """
     accident_words = ['תאונ', ]
     working_accidents_words = ['תאונת עבודה', 'תאונות עבודה']
-    involved_words = ['רכב', 'אוטובוס', u"ג'יפ", 'משאית', 'קטנוע', 'טרקטור',
+    involved_words = ['רכב', 'אוטובוס', "ג'יפ", 'משאית', 'קטנוע', 'טרקטור',
                       'אופנוע', 'אופניים', 'קורקינט', 'הולך רגל', 'הולכת רגל',
                       'הולכי רגל']
     hurt_words = ['פגע', 'פגיע', 'פגוע', 'הרג', 'הריג', 'הרוג', 'פצע', 'פציע',

--- a/anyway/parsers/road_segments.py
+++ b/anyway/parsers/road_segments.py
@@ -12,7 +12,7 @@ db = SQLAlchemy(app)
 
 def _iter_rows(filename):
     workbook = load_workbook(filename, read_only=True)
-    sheet = workbook[u"tv_ktaim"]
+    sheet = workbook["tv_ktaim"]
     rows = sheet.rows
     first_row = next(rows)
     headers = ['mezahe_keta', 'kvish', 'keta', 'km_me', 'shem_km_me', 'ad_km', 'shem_km_ad']

--- a/anyway/parsers/rsa.py
+++ b/anyway/parsers/rsa.py
@@ -16,7 +16,7 @@ db = SQLAlchemy(app)
 
 def _iter_rows(filename):
     workbook = load_workbook(filename, read_only=True)
-    sheet = workbook[u"Worksheet1"]
+    sheet = workbook["Worksheet1"]
     rows = sheet.rows
     first_row = next(rows)
     headers = ['מזהה', 'תאריך דיווח', 'סטטוס', 'סוג עבירה', 'סוג רכב', 'סוג לוחית רישוי', 'רמת חומרה', 'נ״צ סופי']


### PR DESCRIPTION
Fix an omission in #1279, which only dealt with u''-literals.

This change also makes it easier to read lists of Hebrew words with ' in them.