### PR TITLE
Cast accident classifications to boolean

### DIFF
--- a/anyway/parsers/news_flash_db_adapter.py
+++ b/anyway/parsers/news_flash_db_adapter.py
@@ -199,7 +199,7 @@ class DBAdapter:
                 "road1": road1,
                 "road2": road2,
                 "road_segment_name": road_segment_name,
-                "accident": accident,
+                "accident": bool(accident),
                 "source": source,
             },
         )


### PR DESCRIPTION
Ensure `accidents` column is not empty.