### PR TITLE
Use publication date as date for twitter too

### DIFF
--- a/anyway/parsers/news_flash_db_adapter.py
+++ b/anyway/parsers/news_flash_db_adapter.py
@@ -102,7 +102,7 @@ class DBAdapter:
         source,
         title,
         link,
-        date_parsed,
+        date,
         author,
         description,
         location=None,
@@ -132,7 +132,7 @@ class DBAdapter:
         :param road_segment_name: urban segment name
         :param title: title of the news_flash
         :param link: link to the news_flash
-        :param date_parsed: parsed date of the news_flash
+        :param date: parsed date of the news_flash
         :param author: author of the news_flash
         :param description: description of the news flash
         :param location: location of the news flash (textual)
@@ -147,7 +147,7 @@ class DBAdapter:
         temp = [
             title,
             link,
-            date_parsed,
+            date,
             author,
             description,
             location,
@@ -167,7 +167,7 @@ class DBAdapter:
             source,
             tweet_id,
         ]
-        title, link, date_parsed, author, description, location, lat, lon, resolution, region_hebrew, district_hebrew, yishuv_name, street1_hebrew, street2_hebrew, non_urban_intersection_hebrew, road1, road2, road_segment_name, accident, source, tweet_id = pd.Series(
+        title, link, date, author, description, location, lat, lon, resolution, region_hebrew, district_hebrew, yishuv_name, street1_hebrew, street2_hebrew, non_urban_intersection_hebrew, road1, road2, road_segment_name, accident, source, tweet_id = pd.Series(
             temp
         ).replace(
             {pd.np.nan: None, "": None, 0: None, -1: None, " ": None}
@@ -186,7 +186,7 @@ class DBAdapter:
                 "tweet_id": tweet_id,
                 "title": title,
                 "link": link,
-                "date": date_parsed,
+                "date": date,
                 "author": author,
                 "description": description,
                 "location": location,

--- a/anyway/parsers/rss_sites.py
+++ b/anyway/parsers/rss_sites.py
@@ -57,9 +57,7 @@ def scrape(site_name, *, fetch_rss=_fetch, fetch_html=_fetch):
         raw_date = item_rss_soup.pubdate.get_text()
         link = item_rss_soup.guid.get_text()
 
-        date_parsed = datetime.datetime.strptime(raw_date, config["time_format"]).replace(
-            tzinfo=None
-        )
+        date = datetime.datetime.strptime(raw_date, config["time_format"]).replace(tzinfo=None)
 
         html_text = fetch_html(link)
         item_html_soup = BeautifulSoup(html_text, "lxml")
@@ -67,7 +65,7 @@ def scrape(site_name, *, fetch_rss=_fetch, fetch_html=_fetch):
         author, title, description = config["parser"](item_rss_soup, item_html_soup)
         yield {
             "link": link,
-            "date_parsed": date_parsed,
+            "date": date,
             "source": site_name,
             "author": author,
             "title": title,
@@ -78,7 +76,7 @@ def scrape(site_name, *, fetch_rss=_fetch, fetch_html=_fetch):
 def scrape_extract_store(site_name, db):
     latest_date = db.get_latest_date_of_source(site_name) or datetime.date.min
     for item in scrape(site_name):
-        if item["date_parsed"] < latest_date:
+        if item["date"] < latest_date:
             break
         item["accident"] = classify_rss(item["title"])
         if item["accident"]:

--- a/anyway/parsers/twitter.py
+++ b/anyway/parsers/twitter.py
@@ -41,6 +41,7 @@ def parse_creation_datetime(created_at):
 
 
 def extract_accident_time(text):
+    # Currently unused
     reg_exp = r"בשעה (\d{2}:\d{2})"
     time_search = re.search(reg_exp, text)
     if time_search:
@@ -51,7 +52,7 @@ def extract_accident_time(text):
 def parse_tweet(tweet, screen_name):
     return {
         "link": "https://twitter.com/{}/status/{}".format(screen_name, tweet["id_str"]),
-        "date_parsed": parse_creation_datetime(tweet["created_at"]),
+        "date": parse_creation_datetime(tweet["created_at"]),
         "source": "twitter",
         "author": to_hebrew[screen_name],
         "title": tweet["full_text"],
@@ -64,15 +65,10 @@ def parse_tweet(tweet, screen_name):
 def scrape_extract_store(screen_name, db):
     latest_date = db.get_latest_date_of_source("twitter")
     for item in scrape(screen_name, db.get_latest_tweet_id()):
-        if item["date_parsed"] < latest_date:
+        if item["date"] < latest_date:
             # We can break if we're guaranteed the order is descending
             continue
         item["accident"] = classify_tweets(item["title"])
         if item["accident"]:
-            item["date"] = (
-                item["date_parsed"].strftime("%Y-%m-%d")
-                + " "
-                + extract_accident_time(item["description"])
-            )
             extract_geo_features(item)
         db.insert_new_flash_news(**item)

--- a/tests/test_news_flash.py
+++ b/tests/test_news_flash.py
@@ -31,7 +31,7 @@ def fetch_rss_ynet(link):
 def test_scrape_walla():
     items_expected = [
         {
-            "date_parsed": datetime.datetime(2020, 5, 23, 16, 55),
+            "date": datetime.datetime(2020, 5, 23, 16, 55),
             "title": 'פרקליטי רה"מ יתלוננו נגד רביב דרוקר על שיבוש הליכי משפט',
             "link": "https://news.walla.co.il/break/3362504",
             "source": "walla",
@@ -39,7 +39,7 @@ def test_scrape_walla():
             "description": 'פרקליטיו של ראש הממשלה בנימין נתניהו מתכוונים להגיש הערב (שבת) תלונה ליועץ המשפטי לממשלה, אביחי מנדלבליט, נגד העיתונאי רביב דרוקר בטענה ששיבש הליכי משפט והדיח עד בתוכניתו "המקור". התלונה מתייחסת לראיונות שנתנו לתוכנית עדי תביעה במשפטו של נתניהו, בהם שאול אלוביץ\' ומומו פילבר.]]>',
         },
         {
-            "date_parsed": datetime.datetime(2020, 5, 22, 13, 14),
+            "date": datetime.datetime(2020, 5, 22, 13, 14),
             "title": "פקיסטן: לפחות נוסע אחד שרד את התרסקות המטוס",
             "link": "https://news.walla.co.il/break/3362389",
             "source": "walla",
@@ -59,7 +59,7 @@ def test_scrape_walla():
 def test_scrape_ynet():
     items_expected = [
         {
-            "date_parsed": datetime.datetime(2020, 5, 22, 18, 27, 32),
+            "date": datetime.datetime(2020, 5, 22, 18, 27, 32),
             "title": "קפריסין הודיעה: ישראלים יוכלו להיכנס למדינה החל מה-9 ביוני",
             "link": "http://www.ynet.co.il/articles/0,7340,L-5735229,00.html",
             "source": "ynet",
@@ -67,7 +67,7 @@ def test_scrape_ynet():
             "description": ": \"שר התחבורה של קפריסין הודיע על תוכנית לפתיחת שדות התעופה וחידוש הטיסות החל מה-9 ביוני. התוכנית שאושרה בידי הממשלה חולקה לשני שלבים לפי תאריכים ומדינות שיורשו להיכנס בשעריה. עד ה-19 ביוני נוסעים מכל המקומות יצטרכו להיבדק לקורונה 72 שעות לפני מועד הטיסה. מה-20 ביוני יידרשו לכך רק נוסעים משוויץ, פולין רומניה, קרואטיה, אסטוניה וצ'כיה. בתי המלון ייפתחו ב-1 ביוני, וחובת הבידוד תבוטל ב-20 ביוני.   ",
         },
         {
-            "date_parsed": datetime.datetime(2020, 5, 22, 15, 8, 48),
+            "date": datetime.datetime(2020, 5, 22, 15, 8, 48),
             "link": "http://www.ynet.co.il/articles/0,7340,L-5735178,00.html",
             "source": "ynet",
             "author": "אלישע בן קימון",
@@ -98,7 +98,7 @@ def test_scrape_sanity_online():
 twitter_expected_list = [
     {
          'link': 'https://twitter.com/mda_israel/status/1267054794587418630',
-         'date_parsed': datetime.datetime(2020, 5, 31, 14, 26, 18),
+         'date': datetime.datetime(2020, 5, 31, 14, 26, 18),
          'source': 'twitter',
          'author': 'מגן דוד אדום',
          'title': 'בשעה 13:19 התקבל דיווח במוקד 101 של מד"א במרחב ירושלים על פועל שנפצע במהלך עבודתו במפעל באזור התעשיה עטרות בירושלים. חובשים ופראמדיקים של מד"א מעניקים טיפול רפואי ומפנים לבי"ח שערי צדק גבר בן 31 במצב קשה, עם חבלת ראש.',
@@ -108,7 +108,7 @@ twitter_expected_list = [
     },
     {
          'link': 'https://twitter.com/mda_israel/status/1267037315869880321',
-         'date_parsed': datetime.datetime(2020, 5, 31, 13, 16, 51),
+         'date': datetime.datetime(2020, 5, 31, 13, 16, 51),
          'source': 'twitter',
          'author': 'מגן דוד אדום',
          'title': 'בשעה 12:38 התקבל דיווח במוקד 101 של מד"א במרחב ירדן על ת.ד סמוך למסעדה. חובשים ופראמדיקים של מד"א מעניקים טיפול רפואי ל4 פצועים, בהם 1 מחוסר הכרה.',


### PR DESCRIPTION
Currently there's mismatch between the meaning of the column `date` for rss sites (publication date) and twitter (estimated accident date). This PR keeps only the former meaning, since it is not estimated and gives a rigid upper bound on the estimated date.