### PR TITLE
1200-cache-infographics-data - Create cache database tables.

### DIFF
--- a/alembic/versions/d8f0c029862a_add_infographics_data_cache_table.py
+++ b/alembic/versions/d8f0c029862a_add_infographics_data_cache_table.py
@@ -1,0 +1,43 @@
+"""add infographics data cache table
+
+Revision ID: d8f0c029862a
+Revises: c7722630e010
+Create Date: 2020-06-08 16:24:30.153844
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd8f0c029862a'
+down_revision = 'c7722630e010'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+table_name = 'infographics_data_cache'
+table_name_temp = 'infographics_data_cache_temp'
+
+def upgrade():
+    op.create_table(table_name,
+                    sa.Column('news_flash_id', sa.BigInteger(), nullable=False),
+                    sa.Column('years_ago', sa.Integer(), nullable=False),
+                    sa.Column('data', sa.types.JSON(), nullable=False),
+                    sa.PrimaryKeyConstraint('news_flash_id', 'years_ago')
+                    )
+    op.create_index('infographics_data_cache_id_years_idx', table_name, ['news_flash_id', 'years_ago'], unique=True)
+
+    op.create_table(table_name_temp,
+                    sa.Column('news_flash_id', sa.BigInteger(), nullable=False),
+                    sa.Column('years_ago', sa.Integer(), nullable=False),
+                    sa.Column('data', sa.types.JSON(), nullable=False),
+                    sa.PrimaryKeyConstraint('news_flash_id', 'years_ago')
+                    )
+
+
+def downgrade():
+    op.drop_index(op.f('infographics_data_cache_id_years_idx'), table_name=table_name)
+    op.drop_table(table_name)
+
+    op.drop_table(table_name_temp)
+

--- a/anyway/models.py
+++ b/anyway/models.py
@@ -2055,3 +2055,56 @@ class EmbeddedReports(Base):
     report_name_english = Column(String(), primary_key=True)
     report_name_hebrew = Column(String())
     url = Column(String())
+
+
+class InfographicsDataCacheFields(object):
+    news_flash_id = Column(BigInteger(), primary_key=True)
+    years_ago = Column(Integer(), primary_key=True)
+    data = Column(sqlalchemy.types.JSON())
+
+
+class InfographicsDataCache(InfographicsDataCacheFields, Base):
+    __tablename__ = 'infographics_data_cache'
+    __table_args__ = (
+        Index('infographics_data_cache_id_years_idx', 'news_flash_id', 'years_ago', unique=True),
+
+    )
+
+
+    def get_data(self):
+        return self.data
+
+
+    def serialize(self):
+        return {
+            "news_flash_id": self.news_flash_id,
+            "years_ago": self.years_ago,
+            "data": self.data
+        }
+
+
+
+class InfographicsDataCacheTemp(InfographicsDataCacheFields, Base):
+    __tablename__ = 'infographics_data_cache_temp'
+
+
+    def serialize(self):
+        return {
+            "news_flash_id": self.news_flash_id,
+            "years_ago": self.years_ago,
+            "data": self.data
+        }
+
+    # Flask-Login integration
+    def is_authenticated(self):
+        return True
+
+    def is_active(self):
+        return True
+
+    def is_anonymous(self):
+        return False
+
+    def get_id(self):
+        return self.news_flash_id
+

--- a/anyway/models.py
+++ b/anyway/models.py
@@ -27,6 +27,7 @@ from sqlalchemy import (
     and_,
     TIMESTAMP,
 )
+import sqlalchemy
 from sqlalchemy.orm import relationship, load_only, backref
 
 from . import localization


### PR DESCRIPTION
#1200 Cache infographics data. This PR contains only the database changes. I want to avoid the need to merge with other changes in case another change will be pushed before I complete the change.
It contains two tables, the cache, and a temporary table, with same fields. The temporary table is used to shorten the time the cache is not available while it is refreshed. The data is placed in the temporary table, and then it is copied to the main cache table.