### PR TITLE
get_db_matching_location: Dont remove NaN, don't catch exceptions

### DIFF
--- a/anyway/parsers/location_extraction.py
+++ b/anyway/parsers/location_extraction.py
@@ -74,7 +74,8 @@ def get_db_matching_location(db, latitude, longitude, resolution, road_no=None):
     # CREATE DISTANCE FIELD
     markers["dist_point"] = markers.apply(
         lambda x: geod.Inverse(latitude, longitude, x["latitude"], x["longitude"])["s12"], axis=1,
-    )
+    ).replace({np.nan: None})
+
     most_fit_loc = (
         markers.loc[markers["dist_point"] == markers["dist_point"].min()].iloc[0].to_dict()
     )


### PR DESCRIPTION
Using `fillna` was a mistake. <s>: None cannot be put in the DataFrame.</s> So an exception was thrown, and got caught by `except Exception`, without logging the actual reason for the failure. 

This PR <s>simply remove both operations.</s> reverts the use of `fillna` to `replace`, and removes the `try-except` block.