### PR TITLE
Fix incorrect loading of latest date

### DIFF
--- a/anyway/parsers/news_flash_db_adapter.py
+++ b/anyway/parsers/news_flash_db_adapter.py
@@ -155,19 +155,16 @@ class DBAdapter:
 
     def get_latest_date_of_source(self, source):
         """
-        returns latest date of news flash
         :return: latest date of news flash
         """
         latest_date = self.execute(
             "SELECT max(date) FROM news_flash WHERE source=:source",
             {"source": source},
         ).fetchone()[0] or datetime.datetime(1900, 1, 1, 0, 0, 0)
-        # The replace is because the timezone is not kept in the DB
-        return latest_date.replace(tzinfo=timezones.ISREAL_SUMMER_TIMEZONE)
+        return timezones.from_db(latest_date)
 
     def get_latest_tweet_id(self):
         """
-        get the latest tweet id
         :return: latest tweet id
         """
         latest_id = self.execute(

--- a/anyway/parsers/news_flash_db_adapter.py
+++ b/anyway/parsers/news_flash_db_adapter.py
@@ -98,9 +98,10 @@ class DBAdapter:
         return source[0]
 
     def insert_new_newsflash(self, newsflash: NewsFlash) -> None:
+        logging.info("Adding newsflash, is accident: {}, date: {}"
+                     .format(newsflash.accident, newsflash.date))
         self.db.session.add(newsflash)
         self.db.session.commit()
-        logging.info("newsflash added, is accident: " + str(newsflash.accident))
 
     def update_news_flash_bulk(self, news_flash_id_list, params_dict_list):
         if len(news_flash_id_list) > 0 and len(news_flash_id_list) == len(params_dict_list):
@@ -161,7 +162,10 @@ class DBAdapter:
             "SELECT max(date) FROM news_flash WHERE source=:source",
             {"source": source},
         ).fetchone()[0] or datetime.datetime(1900, 1, 1, 0, 0, 0)
-        return timezones.from_db(latest_date)
+        res = timezones.from_db(latest_date)
+        logging.info('Latest time fetched for source {} is {}'
+                     .format(source, res))
+        return res
 
     def get_latest_tweet_id(self):
         """

--- a/anyway/parsers/rss_sites.py
+++ b/anyway/parsers/rss_sites.py
@@ -74,7 +74,7 @@ def scrape(site_name, *, fetch_rss=_fetch, fetch_html=_fetch):
 def scrape_extract_store(site_name, db):
     latest_date = db.get_latest_date_of_source(site_name)
     for newsflash in scrape(site_name):
-        if newsflash.date < latest_date:
+        if newsflash.date <= latest_date:
             break
         newsflash.accident = classify_rss(newsflash.title)
         if newsflash.accident:

--- a/anyway/parsers/timezones.py
+++ b/anyway/parsers/timezones.py
@@ -3,6 +3,10 @@ from datetime import datetime, timezone, timedelta
 ISREAL_SUMMER_TIMEZONE = timezone(offset=timedelta(hours=3))
 
 
+def is_tz_aware(dt):
+    return dt.tzinfo.utcoffset(dt) is not None and dt.tzinfo is not None
+
+
 def parse_creation_datetime(raw_date: str):
     """Unified time format detection and parsing.
 
@@ -22,7 +26,9 @@ def parse_creation_datetime(raw_date: str):
             # GMT (walla)
             time = datetime.strptime(raw_date, "%a, %d %b %Y %H:%M:%S %Z")
             time = time.replace(tzinfo=timezone.utc)
-    return time.astimezone(tz=ISREAL_SUMMER_TIMEZONE)
+    assert is_tz_aware(time)
+    time = time.astimezone(tz=ISREAL_SUMMER_TIMEZONE)
+    return time
 
 
 def from_db(date):

--- a/anyway/parsers/timezones.py
+++ b/anyway/parsers/timezones.py
@@ -12,7 +12,7 @@ def parse_creation_datetime(raw_date: str):
     walla: 'Sun, 31 May 2020 08:26:18 GMT' or like ynet
     """
     try:
-        # +0300 (ynet or walla)
+        # +0200 or +0300 depending on daylight saving time (ynet or walla)
         time = datetime.strptime(raw_date, "%a, %d %b %Y %H:%M:%S %z")
     except ValueError:
         try:
@@ -26,5 +26,5 @@ def parse_creation_datetime(raw_date: str):
 
 
 def from_db(date):
-    # The replace is because the timezone is not kept in the DB
-    return date.astimezone(tzinfo=ISREAL_SUMMER_TIMEZONE)
+    # DB holds timezone as UTC; to get local-timezone pretty-printing, we change it on load time
+    return date.astimezone(tz=ISREAL_SUMMER_TIMEZONE)

--- a/anyway/parsers/timezones.py
+++ b/anyway/parsers/timezones.py
@@ -13,16 +13,18 @@ def parse_creation_datetime(raw_date: str):
     """
     try:
         # +0300 (ynet or walla)
-        return datetime.strptime(raw_date, "%a, %d %b %Y %H:%M:%S %z").replace(
-            tzinfo=ISREAL_SUMMER_TIMEZONE
-        )
-    except ValueError as ex:
-        print(ex)
+        time = datetime.strptime(raw_date, "%a, %d %b %Y %H:%M:%S %z")
+    except ValueError:
         try:
             # +0000 (twitter)
             time = datetime.strptime(raw_date, "%a %b %d %H:%M:%S %z %Y")
-        except ValueError as ex:
-            print(ex)
+        except ValueError:
             # GMT (walla)
             time = datetime.strptime(raw_date, "%a, %d %b %Y %H:%M:%S %Z")
-        return time.replace(tzinfo=timezone.utc).astimezone(tz=ISREAL_SUMMER_TIMEZONE)
+            time = time.replace(tzinfo=timezone.utc)
+    return time.astimezone(tz=ISREAL_SUMMER_TIMEZONE)
+
+
+def from_db(date):
+    # The replace is because the timezone is not kept in the DB
+    return date.astimezone(tzinfo=ISREAL_SUMMER_TIMEZONE)

--- a/anyway/parsers/twitter.py
+++ b/anyway/parsers/twitter.py
@@ -60,7 +60,7 @@ def parse_tweet(tweet, screen_name):
 def scrape_extract_store(screen_name, db: DBAdapter):
     latest_date = db.get_latest_date_of_source("twitter")
     for newsflash in scrape(screen_name, db.get_latest_tweet_id()):
-        if newsflash.date < latest_date:
+        if newsflash.date <= latest_date:
             # We can break if we're guaranteed the order is descending
             continue
         newsflash.accident = classify_tweets(newsflash.description)

--- a/tests/test_news_flash.py
+++ b/tests/test_news_flash.py
@@ -72,8 +72,9 @@ def test_scrape_walla():
 
 def test_scrape_ynet():
     items_expected = [
+        # note: the file holds date in winter timezone, so here it is described as summer timezone - +1 hour
         NewsFlash(
-            date=datetime.datetime(2020, 5, 22, 18, 27, 32, tzinfo=timezones.ISREAL_SUMMER_TIMEZONE),
+            date=datetime.datetime(2020, 5, 22, 19, 27, 32, tzinfo=timezones.ISREAL_SUMMER_TIMEZONE),
             title="קפריסין הודיעה: ישראלים יוכלו להיכנס למדינה החל מה-9 ביוני",
             link="http://www.ynet.co.il/articles/0,7340,L-5735229,00.html",
             source="ynet",
@@ -81,7 +82,7 @@ def test_scrape_ynet():
             description=": \"שר התחבורה של קפריסין הודיע על תוכנית לפתיחת שדות התעופה וחידוש הטיסות החל מה-9 ביוני. התוכנית שאושרה בידי הממשלה חולקה לשני שלבים לפי תאריכים ומדינות שיורשו להיכנס בשעריה. עד ה-19 ביוני נוסעים מכל המקומות יצטרכו להיבדק לקורונה 72 שעות לפני מועד הטיסה. מה-20 ביוני יידרשו לכך רק נוסעים משוויץ, פולין רומניה, קרואטיה, אסטוניה וצ'כיה. בתי המלון ייפתחו ב-1 ביוני, וחובת הבידוד תבוטל ב-20 ביוני.   ",
         ),
         NewsFlash(
-            date=datetime.datetime(2020, 5, 22, 15, 8, 48, tzinfo=timezones.ISREAL_SUMMER_TIMEZONE),
+            date=datetime.datetime(2020, 5, 22, 16, 8, 48, tzinfo=timezones.ISREAL_SUMMER_TIMEZONE),
             link="http://www.ynet.co.il/articles/0,7340,L-5735178,00.html",
             source="ynet",
             author="אלישע בן קימון",


### PR DESCRIPTION
Fix #1362: replace [`replace`](https://docs.python.org/3.8/library/datetime.html#datetime.date.replace) with [`astimezone`](https://docs.python.org/3.8/library/datetime.html#datetime.datetime.astimezone).

An alternative fix would be to not touch the timezone at all. It's only there so people will see local time when printing it.

Also
* Skip when `>=`, not when `>`
* Unify handling of timezone loading from DB.
* Remove inappropriate `print`

