### PR TITLE
DB: remove pool recycle option - use default engine options

### DIFF
--- a/anyway/config.py
+++ b/anyway/config.py
@@ -11,7 +11,7 @@ import os
 SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "postgresql://postgres@localhost/anyway")
 SQLALCHEMY_TRACK_MODIFICATIONS = True
 ENTRIES_PER_PAGE = os.environ.get("ENTRIES_PER_PAGE", 1000)
-SQLALCHEMY_POOL_RECYCLE = 60
+SQLALCHEMY_ENGINE_OPTIONS = {}
 
 # available languages
 LANGUAGES = {"en": "English", "he": "עברית"}


### PR DESCRIPTION
SQLALCHEMY_POOL_RECYCLE is deprecated, connections should be configured via SQLALCHEMY_ENGINE_OPTIONS

we should use default values for SQLALCHEMY_ENGINE_OPTIONS options, pool recycle might cause the errors in #1410
