### PR TITLE
DevOps: move project containers to github package using git workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,86 +5,84 @@ on:
       - master
       - dev
 env:
-  DOCKER_REPOSITORY_ANYWAY: "anywayteam/anyway"
-  DOCKER_REPOSITORY_DB: "anywayteam/db"
-  DOCKER_REPOSITORY_DB_BACKUP: "anywayteam/db_backup"
-  DOCKER_REPOSITORY_NGINX: "anywayteam/nginx"
+  DOCKER_REPOSITORY_ANYWAY: "${{ github.repository }}/anyway"
+  DOCKER_REPOSITORY_DB: "${{ github.repository }}/db"
+  DOCKER_REPOSITORY_DB_BACKUP: "${{ github.repository }}/db_backup"
+  DOCKER_REPOSITORY_NGINX: "${{ github.repository }}/nginx"
+  SERVER: "docker.pkg.github.com"
 jobs:
   Build-anyway:
-    if: github.repository == 'hasadna/anyway'
+    if: github.repository == "${{ github.repository_owner }}/anyway"
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Build and push anyway Docker image
-      uses: docker/build-push-action@v1.0.1
+      uses: docker/build-push-action@v1.1.1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        name: ${{ env.DOCKER_REPOSITORY_ANYWAY }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
         repository: ${{ env.DOCKER_REPOSITORY_ANYWAY }}
         tag_with_ref: true
         tag_with_sha: true
         cache_froms: ${{ env.DOCKER_REPOSITORY_ANYWAY }}:dev
   Build-db:
-    if: github.repository == 'hasadna/anyway'
+    if: github.repository == "${{ github.repository_owner }}/anyway"
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Build and push database Docker image
-      uses: docker/build-push-action@v1.0.1
+      uses: docker/build-push-action@v1.1.1
       with:
-        path: 'db_docker'
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: docker.pkg.github.com
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ env.DOCKER_REPOSITORY_DB }}
+        path: 'db_docker'
         tag_with_ref: true
         tag_with_sha: true
         cache_froms: ${{ env.DOCKER_REPOSITORY_DB }}:dev
   Build-db-backup:
-    if: github.repository == 'hasadna/anyway'
+    if: github.repository == "${{ github.repository_owner }}/anyway"
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Build and push database backup Docker image
-      uses: docker/build-push-action@v1.0.1
+      uses: docker/build-push-action@v1.1.1
       with:
-        path: 'db_docker'
-        dockerfile: 'db_docker/backup.Dockerfile'
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: docker.pkg.github.com
         repository: ${{ env.DOCKER_REPOSITORY_DB_BACKUP }}
+        dockerfile: 'db_docker/backup.Dockerfile'
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        path: 'db_docker'
         tag_with_ref: true
         tag_with_sha: true
         cache_froms: ${{ env.DOCKER_REPOSITORY_DB_BACKUP }}:dev
   Build-nginx:
-    if: github.repository == 'hasadna/anyway'
+    if: github.repository == "${{ github.repository_owner }}/anyway"
     needs: Build-anyway
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        name: ${{ env.DOCKER_REPOSITORY_NGINX }} 
+        DOCKER_USERNAME: ${{ github.repository_owner }}
+        DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         DOCKER_REPOSITORY_ANYWAY: ${{ env.DOCKER_REPOSITORY_ANYWAY }}
         DOCKER_REPOSITORY_NGINX: ${{ env.DOCKER_REPOSITORY_NGINX }}
       run: |
-        REF_TAG="${GITHUB_REF##*/}" &&\
-        SHA_TAG=sha-`git rev-parse --short $GITHUB_SHA` &&\
+        export REF_TAG="${GITHUB_REF##*/}" &&\
+        export SHA_TAG=sha-`git rev-parse --short $GITHUB_SHA` &&\
         echo REF_TAG=$REF_TAG &&\
         echo SHA_TAG=$SHA_TAG &&\
-        docker pull "${DOCKER_REPOSITORY_ANYWAY}:${SHA_TAG}" &&\
-        if docker pull "${DOCKER_REPOSITORY_NGINX}:${REF_TAG}"; then
-          CACHE_FROM=" --cache-from ${DOCKER_REPOSITORY_NGINX}:${REF_TAG} "
-        else
-          CACHE_FROM=""
-        fi &&\
-        docker tag "${DOCKER_REPOSITORY_ANYWAY}:${SHA_TAG}" anywayteam/anyway:latest &&\
-        docker build $CACHE_FROM -t "${DOCKER_REPOSITORY_NGINX}:${SHA_TAG}" nginx_docker &&\
-        docker tag "${DOCKER_REPOSITORY_NGINX}:${SHA_TAG}" "${DOCKER_REPOSITORY_NGINX}:${REF_TAG}" &&\
-        echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin &&\
-        docker push "${DOCKER_REPOSITORY_NGINX}:${SHA_TAG}" &&\
-        docker push "${DOCKER_REPOSITORY_NGINX}:${REF_TAG}"
+        bin/docker_login.sh &&\
+        bin/docker_build.sh &&\
+        bin/docker_push_latest.sh &&\
+        bin/docker_push_sha.sh
   deploy:
-    if: github.repository == 'hasadna/anyway' && github.ref == 'refs/heads/master'
+    if: github.repository == "${{ github.repository_owner }}/anyway" && github.ref == 'refs/heads/master'
     needs:
     - Build-anyway
     - Build-db
@@ -94,10 +92,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - env:
-        DOCKER_REPOSITORY_ANYWAY: ${{ env.DOCKER_REPOSITORY_ANYWAY }}
-        DOCKER_REPOSITORY_DB: ${{ env.DOCKER_REPOSITORY_DB }}
-        DOCKER_REPOSITORY_DB_BACKUP: ${{ env.DOCKER_REPOSITORY_DB_BACKUP }}
-        DOCKER_REPOSITORY_NGINX: ${{ env.DOCKER_REPOSITORY_NGINX }}
+        DOCKER_REPOSITORY_ANYWAY: ${{ env.SERVER }}/${{ env.DOCKER_REPOSITORY_ANYWAY }}
+        DOCKER_REPOSITORY_DB: ${{ env.SERVER }}/${{ env.DOCKER_REPOSITORY_DB }}
+        DOCKER_REPOSITORY_DB_BACKUP: ${{ env.SERVER }}/${{ env.DOCKER_REPOSITORY_DB_BACKUP }}
+        DOCKER_REPOSITORY_NGINX: ${{ env.SERVER }}/${{ env.DOCKER_REPOSITORY_NGINX }}
         HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
       run: |
         SHA_TAG=sha-`git rev-parse --short $GITHUB_SHA` &&\

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -1,0 +1,15 @@
+# !/usr/bin/env bash
+
+ANYWAY_IMG_URL="${SERVER}/${DOCKER_REPOSITORY_ANYWAY}"
+NGINX_IMG_URL="${SERVER}/${DOCKER_REPOSITORY_NGINX}"
+
+echo ANYWAY_IMG_URL="${SERVER}/${DOCKER_REPOSITORY_ANYWAY}" 
+echo NGINX_IMG_URL="${SERVER}/${DOCKER_REPOSITORY_NGINX}" 
+
+docker pull "${ANYWAY_IMG_URL}:${SHA_TAG}" &&\
+if docker pull "${NGINX_IMG_URL}:${REF_TAG}"; then
+    CACHE_FROM=" --cache-from ${NGINX_IMG_URL}:${REF_TAG} "
+else
+    CACHE_FROM=""
+fi &&\
+docker build $CACHE_FROM -t "${NGINX_IMG_URL}:${SHA_TAG}" nginx_docker

--- a/bin/docker_login.sh
+++ b/bin/docker_login.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "${DOCKER_PASSWORD}" | docker login ${SERVER} -u "${DOCKER_USERNAME}" --password-stdin

--- a/bin/docker_push_latest.sh
+++ b/bin/docker_push_latest.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if github.ref == 'refs/heads/master'; then
+    ANYWAY_IMG_URL="${SERVER}/${DOCKER_REPOSITORY_ANYWAY}"
+    docker tag "${ANYWAY_IMG_URL}:${SHA_TAG}" "${ANYWAY_IMG_URL}:latest"
+fi

--- a/bin/docker_push_sha.sh
+++ b/bin/docker_push_sha.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+IMG_URL="${SERVER}/${DOCKER_REPOSITORY_NGINX}"
+
+docker tag "${IMG_URL}:${SHA_TAG}" "${IMG_URL}:${REF_TAG}" &&\
+docker push "${IMG_URL}:${SHA_TAG}" &&\
+docker push "${IMG_URL}:${REF_TAG}"

--- a/docker-compose-production.override.yml
+++ b/docker-compose-production.override.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   nginx:
     build: nginx_docker
-    image: anywayteam/nginx:latest
+    image: docker.pkg.github.com/hasadna/anyway/nginx:latest
     depends_on:
       - anyway
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   anyway:
     build: .
-    image: anywayteam/anyway:latest
+    image: docker.pkg.github.com/hasadna/anyway/anyway:latest
     container_name: anyway
     ports:
       - "8080:5000"
@@ -18,7 +18,7 @@ services:
 
   db:
     build: db_docker
-    image: anywayteam/db:latest
+    image: docker.pkg.github.com/hasadna/anyway/db:latest
     container_name: db
     environment:
       - DBRESTORE_AWS_ACCESS_KEY_ID

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -35,19 +35,30 @@ Instructions
 Otherwise, to build an existing environment with the most updated DB, remove DB volume by running `docker volume rm anyway_db_data`.
 Note - this will delete all of your local DB data!
 
-**5.** Start the container, go to the **anyway** directory and run:
+**5.** Anyway images stored on github package, to be able to pull the images you need to login to github using docker login.
+if you already logged in with docker to github source jump to the next step.
+
+#### **docker login**
+First, to login to github go to [this link](https://github.com/settings/tokens) of your github account and generate token with `read:packages` permission.
+
+Second, copy the token that you just generate to file and save the file, now run docker login command like this when `USERNAME` is your github username and `TOKEN.txt` is the file the stor the token.
+```bash
+$ cat TOKEN.txt | docker login docker.pkg.github.com -u USERNAME --password-stdin
+```
+
+**6.** Start the container, go to the **anyway** directory and run:
     `docker-compose up`
 It will take a few minutes until it's done.
 
-**6.** **You're all set!** ANYWAY is up and running with the DB data - connect to http://127.0.0.1:8080
+**7.** **You're all set!** ANYWAY is up and running with the DB data - connect to http://127.0.0.1:8080
 Note - you won't see the map since the key works in production.
 If you need to see the map contact atalya via slack to get a developer key.  
 The developer key need to replace the production key in the file /anyway/blob/dev/templates/index.html where you can find: "https://maps.googleapis.com/maps/api/js?key=AIzaSyDUIWsBLkvIUwzLHMHos9qFebyJ63hEG2M&libraries=places,visualization&language=iw" (google maps url)
 So if the developer key is "12345" the new url need to be is: "https://maps.googleapis.com/maps/api/js?key=12345&libraries=places,visualization&language=iw"
 
-**7.** To stop the containers run: `docker-compose down`
+**8.** To stop the containers run: `docker-compose down`
 
-**8.** To restore fresh DB data, delete all existing volumes: `docker-compose down -v` then restart from step 6
+**9.** To restore fresh DB data, delete all existing volumes: `docker-compose down -v` then restart from step 7 
 
 **For Ubuntu:**
 
@@ -55,11 +66,22 @@ So if the developer key is "12345" the new url need to be is: "https://maps.goog
 Otherwise, to build an existing environment with the most updated DB, remove DB volume by running `sudo docker volume rm anyway_db_data`.
 Note - this will delete all of your local DB data!
 
-**5.** Start the container, go to the **anyway** directory and run:
+**5.** Anyway images stored on github package, to be able to pull the images you need to login to github using docker login.
+if you already logged in with docker to github source jump to the next step.
+
+#### **docker login**
+First, to login to github go to [this link](https://github.com/settings/tokens) of your github account and generate token with `read:packages` permission.
+
+Second, copy the token that you just generate to file and save the file, now run docker login command like this when `USERNAME` is your github username and `TOKEN.txt` is the file the stor the token.
+```bash
+$ cat TOKEN.txt | docker login docker.pkg.github.com -u USERNAME --password-stdin
+```
+
+**6.** Start the container, go to the **anyway** directory and run:
     `sudo docker-compose up`
 It will take a few minutes until it's done.
 
-**6.** **You're all set!** ANYWAY is up and running with the DB data - connect to http://127.0.0.1:8080
+**7.** **You're all set!** ANYWAY is up and running with the DB data - connect to http://127.0.0.1:8080
 Note - you won't see the map since the key works in production.
 If you need to see the map for development email us [anyway@anyway.co.il](mailto:anyway@anyway.co.il) to get a developer key.  
 The developer key need to replace the production key in the file /anyway/blob/dev/templates/index.html where you can find: "https://maps.googleapis.com/maps/api/js?key=AIzaSyDUIWsBLkvIUwzLHMHos9qFebyJ63hEG2M&libraries=places,visualization&language=iw" (google maps url)
@@ -67,7 +89,7 @@ So if the developer key is "12345" the new url need to be is: "https://maps.goog
 
 **7.** To stop the containers run: `sudo docker-compose down`
 
-**8.** To restore fresh DB data, delete all existing volumes: `docker-compose down -v` then restart from step 6
+**8.** To restore fresh DB data, delete all existing volumes: `docker-compose down -v` then restart from step 7
 
 ## Additional Docker commands
 Use `sudo` before each docker commands if you are using ubuntu.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -41,9 +41,9 @@ if you already logged in with docker to github source jump to the next step.
 #### **docker login**
 First, to login to github go to [this link](https://github.com/settings/tokens) of your github account and generate token with `read:packages` permission.
 
-Second, copy the token that you just generate to file and save the file, now run docker login command like this when `USERNAME` is your github username and `TOKEN.txt` is the file the stor the token.
+Second, copy the token that you just generate and run docker login command like this when `USERNAME` is your github username, and paste the token when prompt will ask the password.
 ```bash
-$ cat TOKEN.txt | docker login docker.pkg.github.com -u USERNAME --password-stdin
+$ docker login docker.pkg.github.com -u USERNAME 
 ```
 
 **6.** Start the container, go to the **anyway** directory and run:
@@ -72,9 +72,9 @@ if you already logged in with docker to github source jump to the next step.
 #### **docker login**
 First, to login to github go to [this link](https://github.com/settings/tokens) of your github account and generate token with `read:packages` permission.
 
-Second, copy the token that you just generate to file and save the file, now run docker login command like this when `USERNAME` is your github username and `TOKEN.txt` is the file the stor the token.
+Second, copy the token that you just generate and run docker login command like this when `USERNAME` is your github username, and paste the token when prompt will ask the password.
 ```bash
-$ cat TOKEN.txt | docker login docker.pkg.github.com -u USERNAME --password-stdin
+$ docker login docker.pkg.github.com -u USERNAME 
 ```
 
 **6.** Start the container, go to the **anyway** directory and run:

--- a/nginx_docker/Dockerfile
+++ b/nginx_docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM anywayteam/anyway:latest AS builder
+FROM docker.pkg.github.com/hasadna/anyway/anyway:latest AS builder
 RUN flask assets build
 
 FROM nginx:stable


### PR DESCRIPTION
According to the last news from the docker hub we moving all containers of all projects to store the project's images on GitHub, using github packages.

This PR change and refactor the git workflow CI that already exists.

    change: deploy file - push images to GitHub package.
    refactor: deploy file - extract git action shell code to specific scripts (bin/ directory).
    refactor: deploy file - step condition will works now for all users that will fork the project.
    change: change docker-compose files to pull images from github package.
