### PR TITLE
Localize after cache

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Node.js environment
-      uses: actions/setup-node@v1.4.1
+      uses: actions/setup-node@v1.2.6
       with:
           node-version: '8.17'
     - run: npm install -g eslint@6.8.0

--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -1578,12 +1578,12 @@ def infographics_data():
             lang=lang
         )
     )
-    json_data = get_infographics_data(news_flash_id=news_flash_id, years_ago=number_of_years_ago, lang=lang)
-
-    if not json_data:
+    output = get_infographics_data(news_flash_id=news_flash_id, years_ago=number_of_years_ago, lang=lang)
+    if not output:
         log_bad_request(request)
         return abort(http_client.NOT_FOUND)
 
+    json_data = json.dumps(output, default=str)
     return Response(json_data, mimetype="application/json")
 
 

--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -18,7 +18,7 @@ from sqlalchemy import cast, Numeric
 from sqlalchemy import desc
 from flask_babel import _
 from anyway.backend_constants import BE_CONST
-from anyway.models import NewsFlash, AccidentMarkerView, InvolvedMarkerView
+from anyway.models import NewsFlash, AccidentMarkerView, InvolvedMarkerView, RoadSegments
 from anyway.parsers import resolution_dict
 from anyway.app_and_db import db
 from anyway.infographics_dictionaries import (
@@ -158,6 +158,7 @@ class Widget:
 
 class WidgetCollection:
     widgets: List[Type[Widget]] = []
+    widgets_dict: Dict[str, Widget] = {}
 
     def __init__(self):
         pass
@@ -169,16 +170,21 @@ class WidgetCollection:
     @staticmethod
     def register(widget_class: Type[Widget]) -> Type[Widget]:
         WidgetCollection.widgets.append(widget_class)
+        WidgetCollection.widgets_dict[widget_class.widget_id.name] = widget_class
+        logging.debug(f"register:{widget_class.widget_id.name}:{widget_class}\n")
         return widget_class
 
 
 @WidgetCollection.register
 class AccidentCountBySeverityWidget(Widget):
-    widget_id: WidgetId = dataclasses.field(init=False, default=WidgetId.accident_count_by_severity)
+    widget_id: WidgetId = WidgetId.accident_count_by_severity
+    name: str = widget_id.name
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accident_count_by_severity)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 1
+        logging.debug(f"AccidentCountBySeverityWidget.__init__:name:{self.name}:{WidgetId.accident_count_by_severity}")
 
     def generate_items(self) -> None:
         self.items = AccidentCountBySeverityWidget.get_accident_count_by_severity(
@@ -216,8 +222,12 @@ class AccidentCountBySeverityWidget(Widget):
 
 @WidgetCollection.register
 class MostSevereAccidentsTableWidget(Widget):
+    widget_id: WidgetId = WidgetId.most_severe_accidents_table
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.most_severe_accidents_table)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 2
 
     def generate_items(self) -> None:
@@ -277,8 +287,11 @@ class MostSevereAccidentsTableWidget(Widget):
 
 @WidgetCollection.register
 class MostSevereAccidentsWidget(Widget):
+    widget_id: WidgetId = WidgetId.most_severe_accidents
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.most_severe_accidents)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 3
 
     def generate_items(self) -> None:
@@ -305,6 +318,8 @@ class MostSevereAccidentsWidget(Widget):
 
 @WidgetCollection.register
 class StreetViewWidget(Widget):
+    widget_id: WidgetId = WidgetId.street_view
+
     def __init__(self, request_params: RequestParams):
         super().__init__(request_params, WidgetId.street_view)
         self.rank = 4
@@ -318,10 +333,12 @@ class StreetViewWidget(Widget):
 
 @WidgetCollection.register
 class HeadOnCollisionsComparisonWidget(Widget):
+    widget_id: WidgetId = WidgetId.head_on_collisions_comparison
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.head_on_collisions_comparison)
-        self.rank = 5
-        self.text = {"title": "תאונות קטלניות ע״פ סוג"}
+            super().__init__(request_params, WidgetId.head_on_collisions_comparison)
+            self.rank = 5
+            self.text = {"title": "תאונות קטלניות ע״פ סוג"}
 
     def generate_items(self) -> None:
         self.items = HeadOnCollisionsComparisonWidget.get_head_to_head_stat(
@@ -379,8 +396,12 @@ class HeadOnCollisionsComparisonWidget(Widget):
 
 @WidgetCollection.register
 class AccidentCountByAccidentTypeWidget(Widget):
+    widget_id: WidgetId = WidgetId.accident_count_by_accident_type
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accident_count_by_accident_type)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 6
 
     def generate_items(self) -> None:
@@ -411,8 +432,12 @@ class AccidentCountByAccidentTypeWidget(Widget):
 
 @WidgetCollection.register
 class AccidentsHeatMapWidget(Widget):
+    widget_id: WidgetId = WidgetId.accidents_heat_map
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accidents_heat_map)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 7
         self.text = {
             "title": AccidentsHeatMapWidget.get_heat_map_title(request_params.location_info)
@@ -449,8 +474,12 @@ class AccidentsHeatMapWidget(Widget):
 
 @WidgetCollection.register
 class AccidentCountByAccidentYearWidget(Widget):
+    widget_id: WidgetId = WidgetId.accident_count_by_accident_year
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accident_count_by_accident_year)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 8
         self.text = {
             "title": "כמות התאונות לפי שנה במקטע "
@@ -470,8 +499,12 @@ class AccidentCountByAccidentYearWidget(Widget):
 
 @WidgetCollection.register
 class InjuredCountByAccidentYearWidget(Widget):
+    widget_id: WidgetId = WidgetId.injured_count_by_accident_year
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.injured_count_by_accident_year)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 9
         self.text = {
             "title": "נפגעים בתאונות במקטע "
@@ -491,8 +524,12 @@ class InjuredCountByAccidentYearWidget(Widget):
 
 @WidgetCollection.register
 class AccidentCountByDayNightWidget(Widget):
+    widget_id: WidgetId = WidgetId.accident_count_by_day_night
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accident_count_by_day_night)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 10
         self.text = {"title": "כמות תאונות ביום ובלילה"}
 
@@ -509,8 +546,12 @@ class AccidentCountByDayNightWidget(Widget):
 
 @WidgetCollection.register
 class AccidentCountByHourWidget(Widget):
+    widget_id: WidgetId = WidgetId.accident_count_by_hour
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accident_count_by_hour)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 11
         self.text = {"title": "כמות תאונות לפי שעה"}
 
@@ -527,8 +568,12 @@ class AccidentCountByHourWidget(Widget):
 
 @WidgetCollection.register
 class AccidentCountByRoadLightWidget(Widget):
+    widget_id: WidgetId = WidgetId.accident_count_by_road_light
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accident_count_by_road_light)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 12
         self.text = {"title": "כמות תאונות לפי תאורה"}
 
@@ -545,8 +590,12 @@ class AccidentCountByRoadLightWidget(Widget):
 
 @WidgetCollection.register
 class TopRoadSegmentsAccidentsPerKmWidget(Widget):
+    widget_id: WidgetId = WidgetId.top_road_segments_accidents_per_km
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.top_road_segments_accidents_per_km)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 13
         self.text = {
             "title": "תאונות לכל ק״מ כביש על פי מקטע בכביש "
@@ -597,8 +646,12 @@ class TopRoadSegmentsAccidentsPerKmWidget(Widget):
 
 @WidgetCollection.register
 class InjuredCountPerAgeGroupWidget(Widget):
+    widget_id: WidgetId = WidgetId.injured_count_per_age_group
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.injured_count_per_age_group)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 14
 
     def generate_items(self) -> None:
@@ -667,8 +720,12 @@ class InjuredCountPerAgeGroupWidget(Widget):
 
 @WidgetCollection.register
 class VisionZeroWidget(Widget):
+    widget_id: WidgetId = WidgetId.vision_zero
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.vision_zero)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 15
 
     def generate_items(self) -> None:
@@ -677,8 +734,12 @@ class VisionZeroWidget(Widget):
 
 @WidgetCollection.register
 class AccidentCountByDriverTypeWidget(Widget):
+    widget_id: WidgetId = WidgetId.accident_count_by_driver_type
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accident_count_by_driver_type)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 16
         self.text = {
             "title": "מעורבות נהגים בתאונות לפי סוג במקטע "
@@ -721,8 +782,12 @@ class AccidentCountByDriverTypeWidget(Widget):
 
 @WidgetCollection.register
 class AccidentCountByCarTypeWidget(Widget):
+    widget_id: WidgetId = WidgetId.accident_count_by_car_type
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accident_count_by_car_type)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 17
         self.text = {
             "title": "השוואת אחוז הרכבים בתאונות במקטע "
@@ -821,8 +886,12 @@ class AccidentCountByCarTypeWidget(Widget):
 
 @WidgetCollection.register
 class InjuredAccidentsWithPedestriansWidget(Widget):
+    widget_id: WidgetId = WidgetId.injured_accidents_with_pedestrians
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.injured_accidents_with_pedestrians)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 18
         self.text = {"title": "נפגעים הולכי רגל ברחוב ז׳בוטינסקי, פתח תקווה"}
 
@@ -906,8 +975,12 @@ class InjuredAccidentsWithPedestriansWidget(Widget):
 
 @WidgetCollection.register
 class AccidentSeverityByCrossLocationWidget(Widget):
+    widget_id: WidgetId = WidgetId.accident_severity_by_cross_location
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.accident_severity_by_cross_location)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 19
         self.text = {"title": "הולכי רגל הרוגים ופצועים קשה ברחוב בן יהודה, תל אביב"}
 
@@ -946,8 +1019,12 @@ class AccidentSeverityByCrossLocationWidget(Widget):
 
 @WidgetCollection.register
 class MotorcycleAccidentsVsAllAccidentsWidget(Widget):
+    widget_id: WidgetId = WidgetId.motorcycle_accidents_vs_all_accidents
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.motorcycle_accidents_vs_all_accidents)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 20
         self.text = {"title": "תאונות אופנועים קשות וקטלניות בכביש 20 בהשוואה לכל הארץ"}
 
@@ -972,10 +1049,13 @@ class MotorcycleAccidentsVsAllAccidentsWidget(Widget):
 
 @WidgetCollection.register
 class AccidentCountPedestriansPerVehicleStreetVsAllWidget(Widget):
+    widget_id: WidgetId = WidgetId.accident_count_pedestrians_per_vehicle_street_vs_all
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
         Widget.__init__(
-            self, request_params, WidgetId.accident_count_pedestrians_per_vehicle_street_vs_all
-        )
+            self, request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 21
         self.text = {
             "title": _(
@@ -1009,8 +1089,12 @@ class AccidentCountPedestriansPerVehicleStreetVsAllWidget(Widget):
 
 @WidgetCollection.register
 class TopRoadSegmentsAccidentsWidget(Widget):
+    widget_id: WidgetId = WidgetId.top_road_segments_accidents
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.top_road_segments_accidents)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 22
         self.text = {"title": "5 המקטעים עם כמות התאונות הגדולה ביותר"}
 
@@ -1030,8 +1114,12 @@ class TopRoadSegmentsAccidentsWidget(Widget):
 
 @WidgetCollection.register
 class PedestrianInjuredInJunctionsWidget(Widget):
+    widget_id: WidgetId = WidgetId.pedestrian_injured_in_junctions
+    name: str = widget_id.name
+
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.pedestrian_injured_in_junctions)
+        super().__init__(request_params, type(self).widget_id)
+        self.name = type(self).widget_id.name
         self.rank = 23
         self.text = {"title": "מספר נפגעים הולכי רגל בצמתים - רחוב בן יהודה, תל אביב"}
 
@@ -1237,6 +1325,7 @@ def get_latest_accident_date(table_obj, filters):
 
 def generate_widgets(request_params: RequestParams, to_cache: bool = True) -> List[Widget]:
     widgets = []
+    logging.debug(f"{WidgetCollection.widgets_dict}")
     # for w in WidgetId:
     for w in WidgetCollection.get():
         # widget: Optional[Widget] = create_widget(w, request_params)
@@ -1247,6 +1336,7 @@ def generate_widgets(request_params: RequestParams, to_cache: bool = True) -> Li
             )
         elif widget.is_in_cache() == to_cache and widget.is_included():
             widgets.append(widget)
+            logging.debug(f"name:{widget.name}, class:{WidgetCollection.widgets_dict[widget.name]}")
     return widgets
 
 
@@ -1296,7 +1386,7 @@ def get_request_params(news_flash_id: int, number_of_years_ago: int, lang: str)\
     return request_params
 
 
-def create_infographics_data(news_flash_id, number_of_years_ago, lang: str):
+def create_infographics_data(news_flash_id, number_of_years_ago, lang: str) -> Dict:
     try:
         request_params = get_request_params(news_flash_id, number_of_years_ago, lang)
         if request_params is None:
@@ -1333,7 +1423,7 @@ def create_infographics_data(news_flash_id, number_of_years_ago, lang: str):
     return json.dumps(output, default=str)
 
 
-def get_infographics_data(news_flash_id, years_ago, lang):
+def get_infographics_data(news_flash_id, years_ago, lang: str) -> Dict:
     if os.environ.get("FLASK_ENV") == "development":
         return create_infographics_data(news_flash_id, years_ago, lang)
     else:

--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -165,20 +165,24 @@ class Widget:
 
 
 class WidgetCollection:
-    widgets: List[Type[Widget]] = []
-    widgets_dict: Dict[str, Widget] = {}
+    # widgets: List[Type[Widget]] = []
+    __widgets_dict: Dict[str, Type[Widget]] = {}
 
     def __init__(self):
         pass
 
     @staticmethod
     def get() -> List[Type[Widget]]:
-        return WidgetCollection.widgets
+        return list(WidgetCollection.__widgets_dict.values())
+
+    @staticmethod
+    def get_widget_class(name: str) -> Type[Widget]:
+        return WidgetCollection.__widgets_dict[name]
 
     @staticmethod
     def register(widget_class: Type[Widget]) -> Type[Widget]:
-        WidgetCollection.widgets.append(widget_class)
-        WidgetCollection.widgets_dict[widget_class.widget_id.name] = widget_class
+        # WidgetCollection.widgets.append(widget_class)
+        WidgetCollection.__widgets_dict[widget_class.widget_id.name] = widget_class
         logging.debug(f"register:{widget_class.widget_id.name}:{widget_class}\n")
         return widget_class
 
@@ -1343,7 +1347,7 @@ def generate_widgets(request_params: RequestParams, to_cache: bool = True) -> Li
             )
         elif widget.is_in_cache() == to_cache and widget.is_included():
             widgets.append(widget)
-            logging.debug(f"name:{widget.name}, class:{WidgetCollection.widgets_dict[widget.name]}")
+            logging.debug(f"name:{widget.name}, class:{WidgetCollection.get_widget_class(widget.name)}")
     return widgets
 
 
@@ -1469,7 +1473,7 @@ def localize_after_cache(request_params: RequestParams, items_list: List[Dict]) 
     res = []
     for items in items_list:
         if "name" in items:
-            res.append(WidgetCollection.widgets_dict[items["name"]].localize_items(request_params, items))
+            res.append(WidgetCollection.get_widget_class(items["name"]).localize_items(request_params, items))
         else:
             logging.error(f"localize_after_cache: bad input (missing 'name' key):{items}")
     return res

--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -144,7 +144,9 @@ class Widget:
     @staticmethod
     def localize_items(request_params: RequestParams, items: Dict) -> Dict:
         if "name" in items:
-            logging.debug(f"Widget.localize_items: widget {items['name']} should implement localize_items method")
+            logging.debug(
+                f"Widget.localize_items: widget {items['name']} should implement localize_items method"
+            )
         else:
             logging.error(f"Widget.localize_items: bad input (missing 'name' key):{items}")
         return items
@@ -164,30 +166,24 @@ class Widget:
         return output
 
 
-class WidgetCollection:
-    # widgets: List[Type[Widget]] = []
-    __widgets_dict: Dict[str, Type[Widget]] = {}
-
-    def __init__(self):
-        pass
-
-    @staticmethod
-    def get() -> List[Type[Widget]]:
-        return list(WidgetCollection.__widgets_dict.values())
-
-    @staticmethod
-    def get_widget_class(name: str) -> Type[Widget]:
-        return WidgetCollection.__widgets_dict[name]
-
-    @staticmethod
-    def register(widget_class: Type[Widget]) -> Type[Widget]:
-        # WidgetCollection.widgets.append(widget_class)
-        WidgetCollection.__widgets_dict[widget_class.widget_id.name] = widget_class
-        logging.debug(f"register:{widget_class.widget_id.name}:{widget_class}\n")
-        return widget_class
+widgets_dict: Dict[str, Type[Widget]] = {}
 
 
-@WidgetCollection.register
+def get_widget_classes() -> List[Type[Widget]]:
+    return list(widgets_dict.values())
+
+
+def get_widget_class_by_name(name: str) -> Type[Widget]:
+    return widgets_dict[name]
+
+
+def register(widget_class: Type[Widget]) -> Type[Widget]:
+    widgets_dict[widget_class.widget_id.name] = widget_class
+    logging.debug(f"register:{widget_class.widget_id.name}:{widget_class}\n")
+    return widget_class
+
+
+@register
 class AccidentCountBySeverityWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_count_by_severity
     name: str = widget_id.name
@@ -196,7 +192,9 @@ class AccidentCountBySeverityWidget(Widget):
         super().__init__(request_params, type(self).widget_id)
         self.name = type(self).widget_id.name
         self.rank = 1
-        logging.debug(f"AccidentCountBySeverityWidget.__init__:name:{self.name}:{WidgetId.accident_count_by_severity}")
+        logging.debug(
+            f"AccidentCountBySeverityWidget.__init__:name:{self.name}:{WidgetId.accident_count_by_severity}"
+        )
 
     def generate_items(self) -> None:
         self.items = AccidentCountBySeverityWidget.get_accident_count_by_severity(
@@ -232,7 +230,7 @@ class AccidentCountBySeverityWidget(Widget):
         return items
 
 
-@WidgetCollection.register
+@register
 class MostSevereAccidentsTableWidget(Widget):
     widget_id: WidgetId = WidgetId.most_severe_accidents_table
     name: str = widget_id.name
@@ -297,7 +295,7 @@ class MostSevereAccidentsTableWidget(Widget):
         return accidents
 
 
-@WidgetCollection.register
+@register
 class MostSevereAccidentsWidget(Widget):
     widget_id: WidgetId = WidgetId.most_severe_accidents
 
@@ -328,7 +326,7 @@ class MostSevereAccidentsWidget(Widget):
         )
 
 
-@WidgetCollection.register
+@register
 class StreetViewWidget(Widget):
     widget_id: WidgetId = WidgetId.street_view
 
@@ -343,7 +341,7 @@ class StreetViewWidget(Widget):
         }
 
 
-@WidgetCollection.register
+@register
 class HeadOnCollisionsComparisonWidget(Widget):
     widget_id: WidgetId = WidgetId.head_on_collisions_comparison
 
@@ -406,7 +404,7 @@ class HeadOnCollisionsComparisonWidget(Widget):
         }
 
 
-@WidgetCollection.register
+@register
 class AccidentCountByAccidentTypeWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_count_by_accident_type
     name: str = widget_id.name
@@ -442,7 +440,7 @@ class AccidentCountByAccidentTypeWidget(Widget):
         return merged_accident_type_count
 
 
-@WidgetCollection.register
+@register
 class AccidentsHeatMapWidget(Widget):
     widget_id: WidgetId = WidgetId.accidents_heat_map
     name: str = widget_id.name
@@ -484,7 +482,7 @@ class AccidentsHeatMapWidget(Widget):
         return df.to_dict(orient="records")  # pylint: disable=no-member
 
 
-@WidgetCollection.register
+@register
 class AccidentCountByAccidentYearWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_count_by_accident_year
     name: str = widget_id.name
@@ -509,7 +507,7 @@ class AccidentCountByAccidentYearWidget(Widget):
         )
 
 
-@WidgetCollection.register
+@register
 class InjuredCountByAccidentYearWidget(Widget):
     widget_id: WidgetId = WidgetId.injured_count_by_accident_year
     name: str = widget_id.name
@@ -534,7 +532,7 @@ class InjuredCountByAccidentYearWidget(Widget):
         )
 
 
-@WidgetCollection.register
+@register
 class AccidentCountByDayNightWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_count_by_day_night
     name: str = widget_id.name
@@ -556,7 +554,7 @@ class AccidentCountByDayNightWidget(Widget):
         )
 
 
-@WidgetCollection.register
+@register
 class AccidentCountByHourWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_count_by_hour
     name: str = widget_id.name
@@ -578,7 +576,7 @@ class AccidentCountByHourWidget(Widget):
         )
 
 
-@WidgetCollection.register
+@register
 class AccidentCountByRoadLightWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_count_by_road_light
     name: str = widget_id.name
@@ -600,7 +598,7 @@ class AccidentCountByRoadLightWidget(Widget):
         )
 
 
-@WidgetCollection.register
+@register
 class TopRoadSegmentsAccidentsPerKmWidget(Widget):
     widget_id: WidgetId = WidgetId.top_road_segments_accidents_per_km
     name: str = widget_id.name
@@ -656,7 +654,7 @@ class TopRoadSegmentsAccidentsPerKmWidget(Widget):
         return result.to_dict(orient="records")  # pylint: disable=no-member
 
 
-@WidgetCollection.register
+@register
 class InjuredCountPerAgeGroupWidget(Widget):
     widget_id: WidgetId = WidgetId.injured_count_per_age_group
     name: str = widget_id.name
@@ -730,7 +728,7 @@ class InjuredCountPerAgeGroupWidget(Widget):
         return items
 
 
-@WidgetCollection.register
+@register
 class VisionZeroWidget(Widget):
     widget_id: WidgetId = WidgetId.vision_zero
     name: str = widget_id.name
@@ -744,7 +742,7 @@ class VisionZeroWidget(Widget):
         self.items = ["vision_zero_2_plus_1"]
 
 
-@WidgetCollection.register
+@register
 class AccidentCountByDriverTypeWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_count_by_driver_type
     name: str = widget_id.name
@@ -792,7 +790,7 @@ class AccidentCountByDriverTypeWidget(Widget):
         return output
 
 
-@WidgetCollection.register
+@register
 class AccidentCountByCarTypeWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_count_by_car_type
     name: str = widget_id.name
@@ -896,7 +894,7 @@ class AccidentCountByCarTypeWidget(Widget):
         )
 
 
-@WidgetCollection.register
+@register
 class InjuredAccidentsWithPedestriansWidget(Widget):
     widget_id: WidgetId = WidgetId.injured_accidents_with_pedestrians
     name: str = widget_id.name
@@ -985,7 +983,7 @@ class InjuredAccidentsWithPedestriansWidget(Widget):
         ]
 
 
-@WidgetCollection.register
+@register
 class AccidentSeverityByCrossLocationWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_severity_by_cross_location
     name: str = widget_id.name
@@ -1029,7 +1027,7 @@ class AccidentSeverityByCrossLocationWidget(Widget):
         ]
 
 
-@WidgetCollection.register
+@register
 class MotorcycleAccidentsVsAllAccidentsWidget(Widget):
     widget_id: WidgetId = WidgetId.motorcycle_accidents_vs_all_accidents
     name: str = widget_id.name
@@ -1059,14 +1057,13 @@ class MotorcycleAccidentsVsAllAccidentsWidget(Widget):
         ]
 
 
-@WidgetCollection.register
+@register
 class AccidentCountPedestriansPerVehicleStreetVsAllWidget(Widget):
     widget_id: WidgetId = WidgetId.accident_count_pedestrians_per_vehicle_street_vs_all
     name: str = widget_id.name
 
     def __init__(self, request_params: RequestParams):
-        Widget.__init__(
-            self, request_params, type(self).widget_id)
+        Widget.__init__(self, request_params, type(self).widget_id)
         self.name = type(self).widget_id.name
         self.rank = 21
         self.text = {
@@ -1099,7 +1096,7 @@ class AccidentCountPedestriansPerVehicleStreetVsAllWidget(Widget):
         ]
 
 
-@WidgetCollection.register
+@register
 class TopRoadSegmentsAccidentsWidget(Widget):
     widget_id: WidgetId = WidgetId.top_road_segments_accidents
     name: str = widget_id.name
@@ -1124,7 +1121,7 @@ class TopRoadSegmentsAccidentsWidget(Widget):
         ]
 
 
-@WidgetCollection.register
+@register
 class PedestrianInjuredInJunctionsWidget(Widget):
     widget_id: WidgetId = WidgetId.pedestrian_injured_in_junctions
     name: str = widget_id.name
@@ -1338,7 +1335,7 @@ def get_latest_accident_date(table_obj, filters):
 def generate_widgets(request_params: RequestParams, to_cache: bool = True) -> List[Widget]:
     widgets = []
     # for w in WidgetId:
-    for w in WidgetCollection.get():
+    for w in get_widget_classes():
         # widget: Optional[Widget] = create_widget(w, request_params)
         widget: Optional[Widget] = w(request_params)
         if widget is None:
@@ -1347,12 +1344,13 @@ def generate_widgets(request_params: RequestParams, to_cache: bool = True) -> Li
             )
         elif widget.is_in_cache() == to_cache and widget.is_included():
             widgets.append(widget)
-            logging.debug(f"name:{widget.name}, class:{WidgetCollection.get_widget_class(widget.name)}")
+            logging.debug(f"name:{widget.name}, class:{get_widget_class_by_name(widget.name)}")
     return widgets
 
 
-def get_request_params(news_flash_id: int, number_of_years_ago: int, lang: str)\
-        -> Optional[RequestParams]:
+def get_request_params(
+    news_flash_id: int, number_of_years_ago: int, lang: str
+) -> Optional[RequestParams]:
     try:
         number_of_years_ago = int(number_of_years_ago)
     except ValueError:
@@ -1392,7 +1390,7 @@ def get_request_params(news_flash_id: int, number_of_years_ago: int, lang: str)\
         gps=gps,
         start_time=start_time,
         end_time=end_time,
-        lang=lang
+        lang=lang,
     )
     logging.debug(f"Ending get_request_params. params: {request_params}")
     return request_params
@@ -1473,7 +1471,9 @@ def localize_after_cache(request_params: RequestParams, items_list: List[Dict]) 
     res = []
     for items in items_list:
         if "name" in items:
-            res.append(WidgetCollection.get_widget_class(items["name"]).localize_items(request_params, items))
+            res.append(
+                get_widget_class_by_name(items["name"]).localize_items(request_params, items)
+            )
         else:
             logging.error(f"localize_after_cache: bad input (missing 'name' key):{items}")
     return res

--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -4,8 +4,6 @@ import datetime
 import json
 import os
 from functools import lru_cache
-import enum
-from enum import Enum, auto
 from typing import Optional, Dict, List, Union, Any, Type
 from dataclasses import dataclass
 import traceback
@@ -27,33 +25,6 @@ from anyway.infographics_dictionaries import (
 )
 from anyway.parsers import infographics_data_cache_updater
 from anyway.constants import CONST
-
-
-@enum.unique
-class WidgetId(Enum):
-    accident_count_by_severity = auto()
-    most_severe_accidents_table = auto()
-    most_severe_accidents = auto()
-    street_view = auto()
-    head_on_collisions_comparison = auto()
-    accident_count_by_accident_type = auto()
-    accidents_heat_map = auto()
-    accident_count_by_accident_year = auto()
-    injured_count_by_accident_year = auto()
-    accident_count_by_day_night = auto()
-    accident_count_by_hour = auto()
-    accident_count_by_road_light = auto()
-    top_road_segments_accidents_per_km = auto()
-    injured_count_per_age_group = auto()
-    vision_zero = auto()
-    accident_count_by_driver_type = auto()
-    accident_count_by_car_type = auto()
-    injured_accidents_with_pedestrians = auto()
-    accident_severity_by_cross_location = auto()
-    motorcycle_accidents_vs_all_accidents = auto()
-    accident_count_pedestrians_per_vehicle_street_vs_all = auto()
-    top_road_segments_accidents = auto()
-    pedestrian_injured_in_junctions = auto()
 
 
 @dataclass
@@ -79,11 +50,10 @@ class RequestParams:
 class Widget:
     """
     Base class for widgets. Each widget will be a class that is derived from Widget, and instantiated
-    with RequestParams and WidgetId instances.
+    with RequestParams and its name.
     The Serialize() method returns the data that the API returns, and has structure that is specified below.
     To add a new widget sub-class:
     - Make is subclass of Widget
-    - Add an additional value in WidgetId class, and set it as a parameter to the super constructor.
     - Set attribute rank
     - Implement method generate_items()
     - Optionally set additional attributes if needed, and alter the returned values of `is_in_cache()` and
@@ -102,30 +72,25 @@ class Widget:
     """
 
     request_params: RequestParams
-    widget_id: WidgetId
     name: str
     rank: int
     items: Union[Dict, List]
     text: Dict
     meta: Optional[Dict]
 
-    def __init__(self, request_params: RequestParams, widget_id: WidgetId):
+    def __init__(self, request_params: RequestParams, name: str):
         self.request_params = request_params
-        self.widget_id = widget_id
-        self.name = self.widget_id.name
+        self.name = name
         self.rank = -1
         self.items = {}
         self.text = {}
         self.meta = None
 
     def get_name(self) -> str:
-        return self.widget_id.name
+        return self.name
 
     def get_rank(self) -> int:
         return self.rank
-
-    def get_widget_id(self) -> WidgetId:
-        return self.widget_id
 
     # noinspection PyMethodMayBeStatic
     def is_in_cache(self) -> bool:
@@ -178,23 +143,19 @@ def get_widget_class_by_name(name: str) -> Type[Widget]:
 
 
 def register(widget_class: Type[Widget]) -> Type[Widget]:
-    widgets_dict[widget_class.widget_id.name] = widget_class
-    logging.debug(f"register:{widget_class.widget_id.name}:{widget_class}\n")
+    widgets_dict[widget_class.name] = widget_class
+    logging.debug(f"register:{widget_class.name}:{widget_class}\n")
     return widget_class
 
 
 @register
 class AccidentCountBySeverityWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_count_by_severity
-    name: str = widget_id.name
+    name: str = "accident_count_by_severity"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 1
-        logging.debug(
-            f"AccidentCountBySeverityWidget.__init__:name:{self.name}:{WidgetId.accident_count_by_severity}"
-        )
+        logging.debug(f"AccidentCountBySeverityWidget.__init__:name:{self.name}:{type(self).name}")
 
     def generate_items(self) -> None:
         self.items = AccidentCountBySeverityWidget.get_accident_count_by_severity(
@@ -232,12 +193,10 @@ class AccidentCountBySeverityWidget(Widget):
 
 @register
 class MostSevereAccidentsTableWidget(Widget):
-    widget_id: WidgetId = WidgetId.most_severe_accidents_table
-    name: str = widget_id.name
+    name: str = "most_severe_accidents_table"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 2
 
     def generate_items(self) -> None:
@@ -297,11 +256,10 @@ class MostSevereAccidentsTableWidget(Widget):
 
 @register
 class MostSevereAccidentsWidget(Widget):
-    widget_id: WidgetId = WidgetId.most_severe_accidents
+    name: str = "most_severe_accidents"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 3
 
     def generate_items(self) -> None:
@@ -328,10 +286,10 @@ class MostSevereAccidentsWidget(Widget):
 
 @register
 class StreetViewWidget(Widget):
-    widget_id: WidgetId = WidgetId.street_view
+    name: str = "street_view"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.street_view)
+        super().__init__(request_params, type(self).name)
         self.rank = 4
 
     def generate_items(self) -> None:
@@ -343,10 +301,10 @@ class StreetViewWidget(Widget):
 
 @register
 class HeadOnCollisionsComparisonWidget(Widget):
-    widget_id: WidgetId = WidgetId.head_on_collisions_comparison
+    name: str = "head_on_collisions_comparison"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, WidgetId.head_on_collisions_comparison)
+        super().__init__(request_params, type(self).name)
         self.rank = 5
         self.text = {"title": "תאונות קטלניות ע״פ סוג"}
 
@@ -406,12 +364,10 @@ class HeadOnCollisionsComparisonWidget(Widget):
 
 @register
 class AccidentCountByAccidentTypeWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_count_by_accident_type
-    name: str = widget_id.name
+    name: str = "accident_count_by_accident_type"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 6
 
     def generate_items(self) -> None:
@@ -442,12 +398,10 @@ class AccidentCountByAccidentTypeWidget(Widget):
 
 @register
 class AccidentsHeatMapWidget(Widget):
-    widget_id: WidgetId = WidgetId.accidents_heat_map
-    name: str = widget_id.name
+    name: str = "accidents_heat_map"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 7
         self.text = {
             "title": AccidentsHeatMapWidget.get_heat_map_title(request_params.location_info)
@@ -484,12 +438,10 @@ class AccidentsHeatMapWidget(Widget):
 
 @register
 class AccidentCountByAccidentYearWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_count_by_accident_year
-    name: str = widget_id.name
+    name: str = "accident_count_by_accident_year"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 8
         self.text = {
             "title": "כמות התאונות לפי שנה במקטע "
@@ -509,12 +461,10 @@ class AccidentCountByAccidentYearWidget(Widget):
 
 @register
 class InjuredCountByAccidentYearWidget(Widget):
-    widget_id: WidgetId = WidgetId.injured_count_by_accident_year
-    name: str = widget_id.name
+    name: str = "injured_count_by_accident_year"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 9
         self.text = {
             "title": "נפגעים בתאונות במקטע "
@@ -534,12 +484,10 @@ class InjuredCountByAccidentYearWidget(Widget):
 
 @register
 class AccidentCountByDayNightWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_count_by_day_night
-    name: str = widget_id.name
+    name: str = "accident_count_by_day_night"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 10
         self.text = {"title": "כמות תאונות ביום ובלילה"}
 
@@ -556,12 +504,10 @@ class AccidentCountByDayNightWidget(Widget):
 
 @register
 class AccidentCountByHourWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_count_by_hour
-    name: str = widget_id.name
+    name: str = "accident_count_by_hour"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 11
         self.text = {"title": "כמות תאונות לפי שעה"}
 
@@ -578,12 +524,10 @@ class AccidentCountByHourWidget(Widget):
 
 @register
 class AccidentCountByRoadLightWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_count_by_road_light
-    name: str = widget_id.name
+    name: str = "accident_count_by_road_light"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 12
         self.text = {"title": "כמות תאונות לפי תאורה"}
 
@@ -600,12 +544,10 @@ class AccidentCountByRoadLightWidget(Widget):
 
 @register
 class TopRoadSegmentsAccidentsPerKmWidget(Widget):
-    widget_id: WidgetId = WidgetId.top_road_segments_accidents_per_km
-    name: str = widget_id.name
+    name: str = "top_road_segments_accidents_per_km"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 13
         self.text = {
             "title": "תאונות לכל ק״מ כביש על פי מקטע בכביש "
@@ -656,12 +598,10 @@ class TopRoadSegmentsAccidentsPerKmWidget(Widget):
 
 @register
 class InjuredCountPerAgeGroupWidget(Widget):
-    widget_id: WidgetId = WidgetId.injured_count_per_age_group
-    name: str = widget_id.name
+    name: str = "injured_count_per_age_group"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 14
 
     def generate_items(self) -> None:
@@ -730,12 +670,10 @@ class InjuredCountPerAgeGroupWidget(Widget):
 
 @register
 class VisionZeroWidget(Widget):
-    widget_id: WidgetId = WidgetId.vision_zero
-    name: str = widget_id.name
+    name: str = "vision_zero"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 15
 
     def generate_items(self) -> None:
@@ -744,12 +682,10 @@ class VisionZeroWidget(Widget):
 
 @register
 class AccidentCountByDriverTypeWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_count_by_driver_type
-    name: str = widget_id.name
+    name: str = "accident_count_by_driver_type"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 16
         self.text = {
             "title": "מעורבות נהגים בתאונות לפי סוג במקטע "
@@ -792,12 +728,10 @@ class AccidentCountByDriverTypeWidget(Widget):
 
 @register
 class AccidentCountByCarTypeWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_count_by_car_type
-    name: str = widget_id.name
+    name: str = "accident_count_by_car_type"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 17
         self.text = {
             "title": "השוואת אחוז הרכבים בתאונות במקטע "
@@ -896,12 +830,10 @@ class AccidentCountByCarTypeWidget(Widget):
 
 @register
 class InjuredAccidentsWithPedestriansWidget(Widget):
-    widget_id: WidgetId = WidgetId.injured_accidents_with_pedestrians
-    name: str = widget_id.name
+    name: str = "injured_accidents_with_pedestrians"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 18
         self.text = {"title": "נפגעים הולכי רגל ברחוב ז׳בוטינסקי, פתח תקווה"}
 
@@ -985,12 +917,10 @@ class InjuredAccidentsWithPedestriansWidget(Widget):
 
 @register
 class AccidentSeverityByCrossLocationWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_severity_by_cross_location
-    name: str = widget_id.name
+    name: str = "accident_severity_by_cross_location"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 19
         self.text = {"title": "הולכי רגל הרוגים ופצועים קשה ברחוב בן יהודה, תל אביב"}
 
@@ -1029,12 +959,10 @@ class AccidentSeverityByCrossLocationWidget(Widget):
 
 @register
 class MotorcycleAccidentsVsAllAccidentsWidget(Widget):
-    widget_id: WidgetId = WidgetId.motorcycle_accidents_vs_all_accidents
-    name: str = widget_id.name
+    name: str = "motorcycle_accidents_vs_all_accidents"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 20
         self.text = {"title": "תאונות אופנועים קשות וקטלניות בכביש 20 בהשוואה לכל הארץ"}
 
@@ -1059,12 +987,10 @@ class MotorcycleAccidentsVsAllAccidentsWidget(Widget):
 
 @register
 class AccidentCountPedestriansPerVehicleStreetVsAllWidget(Widget):
-    widget_id: WidgetId = WidgetId.accident_count_pedestrians_per_vehicle_street_vs_all
-    name: str = widget_id.name
+    name: str = "accident_count_pedestrians_per_vehicle_street_vs_all"
 
     def __init__(self, request_params: RequestParams):
-        Widget.__init__(self, request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        Widget.__init__(self, request_params, type(self).name)
         self.rank = 21
         self.text = {
             "title": _(
@@ -1098,12 +1024,10 @@ class AccidentCountPedestriansPerVehicleStreetVsAllWidget(Widget):
 
 @register
 class TopRoadSegmentsAccidentsWidget(Widget):
-    widget_id: WidgetId = WidgetId.top_road_segments_accidents
-    name: str = widget_id.name
+    name: str = "top_road_segments_accidents"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 22
         self.text = {"title": "5 המקטעים עם כמות התאונות הגדולה ביותר"}
 
@@ -1123,12 +1047,10 @@ class TopRoadSegmentsAccidentsWidget(Widget):
 
 @register
 class PedestrianInjuredInJunctionsWidget(Widget):
-    widget_id: WidgetId = WidgetId.pedestrian_injured_in_junctions
-    name: str = widget_id.name
+    name: str = "pedestrian_injured_in_junctions"
 
     def __init__(self, request_params: RequestParams):
-        super().__init__(request_params, type(self).widget_id)
-        self.name = type(self).widget_id.name
+        super().__init__(request_params, type(self).name)
         self.rank = 23
         self.text = {"title": "מספר נפגעים הולכי רגל בצמתים - רחוב בן יהודה, תל אביב"}
 
@@ -1334,15 +1256,10 @@ def get_latest_accident_date(table_obj, filters):
 
 def generate_widgets(request_params: RequestParams, to_cache: bool = True) -> List[Widget]:
     widgets = []
-    # for w in WidgetId:
+    # noinspection PyArgumentList
     for w in get_widget_classes():
-        # widget: Optional[Widget] = create_widget(w, request_params)
-        widget: Optional[Widget] = w(request_params)
-        if widget is None:
-            logging.error(
-                f"generate_widgets: failed to generate widget for {w} and {request_params}"
-            )
-        elif widget.is_in_cache() == to_cache and widget.is_included():
+        widget: Widget = w(request_params)
+        if widget.is_in_cache() == to_cache and widget.is_included():
             widgets.append(widget)
             logging.debug(f"name:{widget.name}, class:{get_widget_class_by_name(widget.name)}")
     return widgets

--- a/anyway/parsers/infographics_data_cache_updater.py
+++ b/anyway/parsers/infographics_data_cache_updater.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime
+from typing import Dict
 from sqlalchemy import not_
 from anyway.models import InfographicsDataCache, InfographicsDataCacheTemp, NewsFlash
 from anyway.constants import CONST
@@ -55,7 +56,7 @@ def add_news_flash_to_cache(news_flash):
         return False
 
 
-def get_infographics_data_from_cache(news_flash_id, years_ago):
+def get_infographics_data_from_cache(news_flash_id, years_ago) -> Dict:
     db_item = (
         db.session.query(InfographicsDataCache)
         .filter(InfographicsDataCache.news_flash_id == news_flash_id)
@@ -151,3 +152,5 @@ def main(update, info):
         logging.info("Refreshing infographics cache Done")
     if info:
         logging.info(get_cache_info())
+    else:
+        logging.debug(f'{info}')

--- a/anyway/parsers/infographics_data_cache_updater.py
+++ b/anyway/parsers/infographics_data_cache_updater.py
@@ -153,4 +153,4 @@ def main(update, info):
     if info:
         logging.info(get_cache_info())
     else:
-        logging.debug(f'{info}')
+        logging.debug(f"{info}")

--- a/tests/test_infographic_api.py
+++ b/tests/test_infographic_api.py
@@ -110,6 +110,7 @@ class Test_Infographic_Api:
         start_time = datetime.date(2020, 1, 1)
         request_params = infographics_utils.RequestParams(
             news_flash_obj=None,
+            years_ago=1,
             location_text='',
             location_info=None,
             resolution={},

--- a/tests/test_infographics_data_cache.py
+++ b/tests/test_infographics_data_cache.py
@@ -1,4 +1,5 @@
 import os
+import ast
 import unittest
 from unittest import TestCase
 from unittest.mock import Mock, patch
@@ -19,14 +20,14 @@ class Test_infographics_data_from_cache(TestCase):
     @patch("anyway.infographics_utils.infographics_data_cache_updater")
     @patch.dict(os.environ, {"FLASK_ENV": "test"})
     def test_get_existing(self, get_from_cache):
-        expected = {"data": "data"}
+        expected = {"data": "data", "widgets": []}
         get_from_cache.get_infographics_data_from_cache.return_value = expected
         create_infographics_data = Mock()
         res = get_infographics_data(7, 1, "he")
         get_from_cache.get_infographics_data_from_cache.assert_called_with(7, 1)
         get_from_cache.create_infographics_data.assert_not_called()
         create_infographics_data.assert_not_called()
-        self.assertEqual(res, expected, f"{expected} should be found in cache")
+        self.assertEqual(res, expected, f"got:{str}, but {expected} should be found in cache")
 
     @patch("anyway.infographics_utils.infographics_data_cache_updater")
     @patch.dict(os.environ, {"FLASK_ENV": "test"})
@@ -42,7 +43,7 @@ class Test_infographics_data_from_cache(TestCase):
         get_from_cache.get_infographics_data_from_cache.side_effect = RuntimeError
         res = get_infographics_data(7, 1, "he")
         get_from_cache.get_infographics_data_from_cache.assert_called_with(7, 1)
-        self.assertEqual(res, {}, f"returned value in case of exception should be empty dict")
+        self.assertEqual(res, {}, f"returned value in case of exception should be None")
 
     @patch("anyway.infographics_utils.create_infographics_data")
     def test_add_unqualified_news_flash(self, utils):

--- a/tests/test_infographics_data_cache.py
+++ b/tests/test_infographics_data_cache.py
@@ -1,5 +1,4 @@
 import os
-import ast
 import unittest
 from unittest import TestCase
 from unittest.mock import Mock, patch


### PR DESCRIPTION
Updated widget creation to allow localization after retrieval from cache. A static method was added to base class `Widget` to perform the localization. Each widget subclass needs to implement it. Function is static because after cache we do not have the widget instances. The function receives the items that were generated by that widget instance, and `request_params`.