### PR TITLE
Fix setup & tests errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:19.10 AS builder
+FROM ubuntu:20.04 AS builder
 
 # Install system tools
 RUN apt-get clean && \
     apt-get -y update && \
     apt-get install -y \
-        python3.7-dev \
+        python3-dev \
         build-essential \
         libpq-dev \
         virtualenv && \
@@ -24,7 +24,7 @@ RUN . /venv3/bin/activate && \
 RUN find /venv3 -name '*.so' | xargs strip
 
 
-FROM ubuntu:19.10 AS runtime
+FROM ubuntu:20.04 AS runtime
 
 RUN apt-get clean && \
     apt-get -y update && \

--- a/db_docker/restore_db.sh
+++ b/db_docker/restore_db.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-RETRIES=20
+RETRIES=40
 
 until psql $DATABASE_URL -c "select 1" > /dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
   echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
-  sleep 10
+  sleep 20
 done
 
 if [ "${ALLOW_ALEMBIC_UPGRADE}" == "yes" ]; then


### PR DESCRIPTION
*Ubuntu 19.10 is End of life - and so our tests are failing as the URLs for apt have changed to old release
*Some times anyway server is starting before the DB dump is finish loading
*Change from sh to bash, as sh don't support pushd