### PR TITLE
WIP - added swagger documentation to news-flash and infographics-data

### DIFF
--- a/anyway/app_and_db.py
+++ b/anyway/app_and_db.py
@@ -1,11 +1,30 @@
 from anyway import utilities
 from flask_sqlalchemy import SQLAlchemy
+import flask_restx
+from http import HTTPStatus
 
 from anyway.backend_constants import BE_CONST
 from anyway.config import SERVER_ENV
 
+
+class FlexRootApi(flask_restx.Api):
+    def __init__(self, inner_app, **kwargs):
+        self.render_root_method = None
+        super().__init__(inner_app, **kwargs)
+
+    def render_root(self):
+        if self.render_root_method is not None:
+            return self.render_root_method()
+        else:
+            self.abort(HTTPStatus.NOT_FOUND)
+
+    def set_render_root_function(self, func):
+        self.render_root_method = func
+
+
 app = utilities.init_flask()
 db = SQLAlchemy(app)
+api = FlexRootApi(app, doc="/swagger")
 
 
 def get_cors_config() -> dict:

--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -1067,7 +1067,7 @@ def acc_in_area_query():
             "polygon parameter is mandatory and must be sent as part of the request - http://{host:port}/markers/polygon?polygon=POLYGON(({lon} {"
             "lat},{lon} {lat},........,{lonN},{latN}))"
         )
-        raise abort(Response(msg))  # pylint
+        raise abort(Response(msg))  # pylint: disable=all
 
     query_obj = (
         db.session.query(AccidentMarker)

--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -1067,7 +1067,7 @@ def acc_in_area_query():
             "polygon parameter is mandatory and must be sent as part of the request - http://{host:port}/markers/polygon?polygon=POLYGON(({lon} {"
             "lat},{lon} {lat},........,{lonN},{latN}))"
         )
-        raise abort(Response(msg))  # pylint disable=all
+        raise abort(Response(msg))  # pylint: disable=all
 
     query_obj = (
         db.session.query(AccidentMarker)

--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -1067,7 +1067,7 @@ def acc_in_area_query():
             "polygon parameter is mandatory and must be sent as part of the request - http://{host:port}/markers/polygon?polygon=POLYGON(({lon} {"
             "lat},{lon} {lat},........,{lonN},{latN}))"
         )
-        raise abort(Response(msg))  # pylint: disable=all
+        raise abort(Response(msg))  # pylint
 
     query_obj = (
         db.session.query(AccidentMarker)
@@ -1221,7 +1221,7 @@ class RetrieveNewsFlash(Resource):
         res = news_flash_new(args)
         for d in res:
             d['date'] = datetime_to_str(d['date']) if 'date' in d else 'None'
-        return res
+        return {'news_flashes': res}
 
 
 def return_json_error(error_code: int, *argv) -> Response:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Babel==1.0.0
 Flask-Compress==1.5.0
 Flask-Login==0.5.0
 Flask-SQLAlchemy==2.4.1
+flask-restx==0.4.0
 Jinja2==2.11.2
 SQLAlchemy==1.3.17
 Werkzeug==1.0.1

--- a/tests/test_news_flash_api.py
+++ b/tests/test_news_flash_api.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import patch
-import mock
 from sqlalchemy.orm import sessionmaker
 from anyway.app_and_db import db
 from anyway.views.news_flash.api import (
@@ -68,35 +67,31 @@ class NewsFlashApiTestCase(unittest.TestCase):
 
     def test_gen_news_flash_query(self):
 
-        m = mock.MagicMock()
-        values = {"id": None, "limit": 1, "road_number": 12345678}
-        m.values = values
         orig_supported_resolutions = BE_CONST.SUPPORTED_RESOLUTIONS
-        with mock.patch("anyway.views.news_flash.api.request", m):
-            BE_CONST.SUPPORTED_RESOLUTIONS = [
-                BE_CONST.ResolutionCategories.DISTRICT
-            ]
-            actual = gen_news_flash_query(self.session)
-            news_flashes = actual.all()
-            self.assertEqual(len(news_flashes), 1, "single news flash")
-            self.assertEqual(news_flashes[0].description, self.district_description,
-                             "district description")
+        BE_CONST.SUPPORTED_RESOLUTIONS = [
+          BE_CONST.ResolutionCategories.DISTRICT
+        ]
+        actual = gen_news_flash_query(self.session, road_number=12345678)
+        news_flashes = actual.all()
+        self.assertEqual(len(news_flashes), 1, "single news flash")
+        self.assertEqual(news_flashes[0].description, self.district_description,
+                         "district description")
 
-            BE_CONST.SUPPORTED_RESOLUTIONS = [
-                BE_CONST.ResolutionCategories.REGION
-            ]
-            actual = gen_news_flash_query(self.session)
-            news_flashes = actual.all()
-            self.assertEqual(len(news_flashes), 1, "single news flash")
-            self.assertEqual(news_flashes[0].description, self.region_description,
-                             "region description")
+        BE_CONST.SUPPORTED_RESOLUTIONS = [
+          BE_CONST.ResolutionCategories.REGION
+        ]
+        actual = gen_news_flash_query(self.session, road_number=12345678)
+        news_flashes = actual.all()
+        self.assertEqual(len(news_flashes), 1, "single news flash")
+        self.assertEqual(news_flashes[0].description, self.region_description,
+                         "region description")
 
-            BE_CONST.SUPPORTED_RESOLUTIONS = [
-                BE_CONST.ResolutionCategories.CITY
-            ]
-            actual = gen_news_flash_query(self.session)
-            news_flashes = actual.all()
-            self.assertEqual(len(news_flashes), 0, "zero news flash")
+        BE_CONST.SUPPORTED_RESOLUTIONS = [
+          BE_CONST.ResolutionCategories.CITY
+        ]
+        actual = gen_news_flash_query(self.session, road_number=12345678)
+        news_flashes = actual.all()
+        self.assertEqual(len(news_flashes), 0, "zero news flash")
 
         BE_CONST.SUPPORTED_RESOLUTIONS = orig_supported_resolutions
 


### PR DESCRIPTION
This is still WIP, just to get feedback on the documentation. Currently the code mostly does not use the swagger definitions, they only contribute the documentation (reachable via `/` url)
Added Swagger documentation to api/news-flash-new, api/news-flash/<id>, and api/infographics-data
Regarding `/api/news-flash`. I think Swagger does not support marshaling of a list on the outer level (only pairs of fields and values). So I put the documentation on `...-new`.
Please comment.
Should I continue to add URLs, or move to actually use Swagger definition to retrieve input parameters for above URLs?