### PR TITLE
Fix walla scraping: author not always a link

### DIFF
--- a/anyway/parsers/rss_sites.py
+++ b/anyway/parsers/rss_sites.py
@@ -8,7 +8,7 @@ def parse_html_walla(item_rss, html_soup):
     # For some reason there's html here
     description = BeautifulSoup(item_rss["summary"], features="lxml").text
 
-    author = html_soup.find("div", class_="author").find("a").get_text()
+    author = html_soup.find("div", class_="author").get_text().strip()
     return author, description
 
 

--- a/tests/3448092.html
+++ b/tests/3448092.html
@@ -1,0 +1,6123 @@
+<!doctype html>
+<html lang="he">
+
+<head>
+    <script id="vad-hb-snippet" data-publisher="wallacoil">!function () {
+            var o, t, a; !function () {
+                window.googletag = window.googletag || { cmd: [] };
+                var o = window.googletag; o.cmd = o.cmd || [],
+                    o.cmd.push(function () { o.pubads().disableInitialLoad() })
+            }(),
+                o = Date.now(), t = o - o % 864e5, (a = window.top.document.createElement("script")).type = "text/javascript",
+                a.setAttribute("data-publisher", "wallacoil"), a.id = "vad-hb-script", a.async = !0,
+                a.src = "//cdn.valuad.cloud/hb/wallacoil-prod.js?timestamp=" + t, window.top.document.head.appendChild(a),
+                setTimeout(function () {
+                    !function () {
+                        window.googletag = window.googletag || { cmd: [] };
+                        var o = window.googletag; o.cmd.push(function () { window._vadHb || o.pubads().refresh() })
+                    }()
+                }, 3e3)
+        }();</script>
+    <script>
+        var isAAB = ('; ' + document.cookie).split('; sdfgh45678=').pop().split(';').shift() || '0';
+        var pageNumberInSession = ('; ' + document.cookie).split('; _wpnis=').pop().split(';').shift() || '1';
+        var fatherSessionInSession = ('; ' + document.cookie).split('; _wfsis=').pop().split(';').shift() || document.referrer || document.location.origin || '';
+
+        dataLayer = [{ "verticalId": 1, "verticalName": "חדשות", "categoryId": 22, "itemId": "3448092", "itemTypeId": 110, "itemTitle": "פקיסטן: שמונה הרוגים בפיצוץ באוטובוס", "itemPubliactionDate": "09:10 14/07/2021", "itemLastUpdate": "09:15 14/07/2021", "itemTitleWordsCount": 5, "itemSubTitleWordsCount": "", "itemPicCount": "", "itemTagsCount": 1, "ContentProvider": "רויטרס", "contentProvider": "רויטרס", "ContentProviderId": 125, "itemAuthor": "", "itemAuthorId": "", "tags": "פקיסטן", "item_type": "newsflash", "IsPlaybuzzOnPage": "no", "IsRecipe": "false", "IsPoll": "", "IsSurvey": "no", "IsTrivia": "no", "itemSectionsWordsCount": "20", "itemWordCountRange": "20-70", "exclusive": "not", "videoGenre": "", "videoMovieName": "", "categoryName": "newsflash", "AgeLimit": "false", "mobile": "0", "adb": "0", "FatherSessionInSession": "", "vertical_eng_name": "news", "IsLive": "no", "IsPodcast": "no", "IsTaboolaOnPage": "1", adb: isAAB, Pagenumberinsession: pageNumberInSession, FatherSessionInSession: fatherSessionInSession }];
+        window.wallaEnv = { "BUILD_TIME": "2021-07-14 14:05:33", "WALLA_ENV": "prod", "WALLA_MODE": "deploy" }
+    </script>
+    <script>window.slotslist = { data: { desktop: { slots: {} }, phone: { slots: {} }, events: {} } };</script>
+    <script>(function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s),
+                dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-T728TH');</script>
+    <script>(function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s),
+                dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-WGMK7ZS');</script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta property="og:site_name" content="וואלה!" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link href="https://img.wcdn.co.il" rel="preconnect" />
+    <title data-react-helmet="true">פקיסטן: שמונה הרוגים בפיצוץ באוטובוס - וואלה! חדשות</title>
+    <meta property="og:title" content="פקיסטן: שמונה הרוגים בפיצוץ באוטובוס - וואלה! חדשות" />
+    <meta name="description" content="פקיסטן: שמונה הרוגים בפיצוץ באוטובוס - וואלה! חדשות" />
+    <meta property="og:description" content="פקיסטן: שמונה הרוגים בפיצוץ באוטובוס - וואלה! חדשות" />
+    <meta property="og:image" content="https://img.wcdn.co.il/f_auto,q_auto,w_1200,t_54/0/n/u/l/null-46.jpg" />
+    <meta name="vr:image" content="https://img.wcdn.co.il/f_auto,q_auto,w_1200,t_54/0/n/u/l/null-46.jpg" />
+    <meta property="vr:image" content="https://img.wcdn.co.il/f_auto,q_auto,w_1200,t_54/0/n/u/l/null-46.jpg" />
+    <meta name="twitter:title" content="פקיסטן: שמונה הרוגים בפיצוץ באוטובוס - וואלה! חדשות" />
+    <meta name="twitter:description" content="פקיסטן: שמונה הרוגים בפיצוץ באוטובוס - וואלה! חדשות" />
+    <meta name="twitter:image" content="https://img.wcdn.co.il/f_auto,q_auto,w_1200,t_54/0/n/u/l/null-46.jpg" />
+    <meta property="og:published_time" content="2021-07-14 09:10" />
+    <meta http-equiv="refresh" content="300" />
+    <meta property="og:type" content="website" />
+    <meta property="walla:canonical" content="https://news.walla.co.il/break/3448092" />
+    <meta property="og:url" content="https://news.walla.co.il/break/3448092" />
+    <meta name="robots" content="noindex, follow" />
+    <link rel="canonical" href="https://news.walla.co.il/break/3448092" />
+    <script>window.WallaTargeting = { "item_id": "3448092", "vertical_id": 1, "vertical_name": "חדשות", "category_id": 22, "categoryName": "newsflash", "item_type": "newsflash", "exclusive": "not", "providerid": 125, "ContentProvider": "רויטרס", "mobile": "0", "vertical_eng_name": "news", "itemTypeId": 110, "itemTitle": "פקיסטן: שמונה הרוגים בפיצוץ באוטובוס", "itemPubliactionDate": "09:10 14/07/2021", "itemLastUpdate": "09:15 14/07/2021", "itemTitleWordsCount": 5, "itemSubTitleWordsCount": 0, "itemPicCount": 0, "itemTagsCount": 1, "itemSectionsWordsCount": "20", "itemWordCountRange": "20-70", "itemAuthor": "", "itemAuthorId": "", "IsPlaybuzzOnPage": "no", "IsRecipe": "false", "IsPoll": "", "IsSurvey": "no", "IsTrivia": "no", "tags": "פקיסטן", "IsLive": "no", "IsPodcast": "no", "isTaboolaOnPage": {} }</script>
+</head>
+
+<body class=""><noscript> <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T728TH" height="0" width="0"
+            style="display:none;visibility:hidden"></iframe> <iframe
+            src="https://www.googletagmanager.com/ns.html?id=GTM-WGMK7ZS" height="0" width="0"
+            style="display:none;visibility:hidden"></iframe> </noscript>
+    <div id="modal-root"></div>
+    <div id="root">
+        <style
+            data-emotion="css yo1ldo lwohc9 18l7q8n 1dz0pb ltupjm 1njwyst 156b48k gt9fym 16qwp7k 1ppv781 hi2koi jmywp2 1jokk5w 1unvu1o 1s9m7en 1t8246r 11qnumn 1p27pre">
+            @media (max-width: 969px) {
+                body {
+                    padding-top: 94px;
+                }
+
+                body.mobile-app,
+                body.no-main-header,
+                body.vod,
+                body.sheee {
+                    padding-top: 0;
+                }
+
+                body.zahav {
+                    padding-top: 48px;
+                }
+
+                body.without-horizontal-nav:not(.mobile-app) {
+                    padding-top: 54px;
+                }
+
+                body.with-top-mobile-app-header.with-top-mobile-app-header {
+                    padding-top: 70px;
+                    padding-bottom: 30px;
+                }
+
+                body.new-hp {
+                    padding-top: 43px;
+                }
+            }
+
+            @-webkit-keyframes animation-lwohc9 {
+                0% {
+                    top: -54px;
+                }
+
+                100% {
+                    top: 0;
+                }
+            }
+
+            @keyframes animation-lwohc9 {
+                0% {
+                    top: -54px;
+                }
+
+                100% {
+                    top: 0;
+                }
+            }
+
+            @-webkit-keyframes animation-18l7q8n {
+                0% {
+                    -webkit-transform: translateY(2px);
+                    -moz-transform: translateY(2px);
+                    -ms-transform: translateY(2px);
+                    transform: translateY(2px);
+                }
+
+                20% {
+                    -webkit-transform: translateY(-2px);
+                    -moz-transform: translateY(-2px);
+                    -ms-transform: translateY(-2px);
+                    transform: translateY(-2px);
+                }
+
+                90% {
+                    -webkit-transform: translateY(3px);
+                    -moz-transform: translateY(3px);
+                    -ms-transform: translateY(3px);
+                    transform: translateY(3px);
+                }
+
+                100% {
+                    -webkit-transform: translateY(2px);
+                    -moz-transform: translateY(2px);
+                    -ms-transform: translateY(2px);
+                    transform: translateY(2px);
+                }
+            }
+
+            @keyframes animation-18l7q8n {
+                0% {
+                    -webkit-transform: translateY(2px);
+                    -moz-transform: translateY(2px);
+                    -ms-transform: translateY(2px);
+                    transform: translateY(2px);
+                }
+
+                20% {
+                    -webkit-transform: translateY(-2px);
+                    -moz-transform: translateY(-2px);
+                    -ms-transform: translateY(-2px);
+                    transform: translateY(-2px);
+                }
+
+                90% {
+                    -webkit-transform: translateY(3px);
+                    -moz-transform: translateY(3px);
+                    -ms-transform: translateY(3px);
+                    transform: translateY(3px);
+                }
+
+                100% {
+                    -webkit-transform: translateY(2px);
+                    -moz-transform: translateY(2px);
+                    -ms-transform: translateY(2px);
+                    transform: translateY(2px);
+                }
+            }
+
+            body.adBackground .walla-core-container {
+                padding-right: 10px;
+                padding-left: 10px;
+            }
+
+            body.adBackground [data-slot-name='skyscraper_desktop'],
+            body.adBackground .shdera {
+                display: none;
+            }
+
+            body.adBackground .adBox.adBackround {
+                margin-top: 0 !important;
+                margin-bottom: 25px !important;
+            }
+
+            .slot-prestitial-desktop {
+                background-color: var(--white, #ffffff);
+                width: 100%;
+                position: fixed;
+                z-index: 99999999999;
+                top: 0;
+                right: 0;
+                left: 0;
+                bottom: 0;
+                display: none;
+                overflow: visible !important;
+            }
+
+            .slot-hidden {
+                display: none;
+            }
+
+            @-webkit-keyframes animation-ltupjm {
+                0% {
+                    bottom: -100%;
+                }
+
+                100% {
+                    bottom: 0;
+                }
+            }
+
+            @keyframes animation-ltupjm {
+                0% {
+                    bottom: -100%;
+                }
+
+                100% {
+                    bottom: 0;
+                }
+            }
+
+            @-webkit-keyframes animation-1njwyst {
+                0% {
+                    opacity: 0;
+                }
+
+                100% {
+                    opacity: .5;
+                }
+            }
+
+            @keyframes animation-1njwyst {
+                0% {
+                    opacity: 0;
+                }
+
+                100% {
+                    opacity: .5;
+                }
+            }
+
+            .screen-reader {
+                position: absolute;
+                top: -10000px;
+                right: auto;
+                width: 1px;
+                height: 1px;
+                overflow: hidden;
+            }
+
+            .a11y-grey-shades {
+                -webkit-filter: grayscale(100%);
+                filter: grayscale(100%);
+            }
+
+            .a11y-large-cursor * {
+                cursor: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAtCAYAAABbAsDYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADqYAAAOpgAABdvkl/FRgAAAn5JREFUeNq0mGGOojAUx/9tpELQoEaCgrjjDbzB4klmr7A3cE8wV5ibjEfwCLPRmPAF/EACYmL3w7YEZ0BF4CVNbAv8+b33+koFgA/RlqhhnPPS1gHgiesGaMlo7vcrgDWAlzaEOCGEA5DNa9pdFABUVcVwOGyViGuaxufzeS2iuyQAoCgKXNeFYRhyaCmEXpoMPBRFgaZpsvsmUvtXoyIAoOs6JpNJnuhHXSJaNKjrOgzDACEEgqQWES2bkDHKZZ0kWjYmIoX6/f5XordGRUqI0LiIFBoOh2CMQbiMC6rmRACAEALLsqCqajsk0hhjsG27MhGt+lbPENFnAskYw3Q6zZefD0JIKVHn6YyhFL1eD1EUDe4VU1qnJlmWhcVikbmOEFJIRGsXP0phmmY+GbzGRWSMZrNZKVEjIjLryog6dR9+uVxwOp2y/ng8RhAESJIEhJA1ABCx/cK27coCvu8jiqK713XqEAiBI4BtKyI5F20BrDjn7ayTR62QJAgCxHGMJEmyMVVV89lTrwoHQYAwDK8EACBJEvi+D+kWSrNbBwA8Qoj3kIgkELYS2SfbJk3TTLzb7crFt8ydDG6LlBHcMsdxHtqWad4dXwg2RTfEcYzz+Zz1R6PRYyJxHOfddNPCMMRut7sSqhL434KibGHJ+XfO+bfME/VLfrSXimyFi44lInL+L4ArEtM0b27HVLzd6l5pKDIpxBiD4zjli5FzvpGluoqFYYjj8QjXdaEoSuMfEu9VY/OMyGfV2DRSIGWpYYwVrpvaImEYYr/fg3OOOI5xOBya209yFeFnmqZekiQIgkDO/Sk8tdawde7EzP8/8vvfHnXts6zOSfs3AJM4OXPfDeodAAAAAElFTkSuQmCC), auto !important;
+            }
+
+            .a11y-negative {
+                -webkit-filter: contrast(200%);
+                filter: contrast(200%);
+            }
+
+            .a11y-grey-shades.a11y-negative {
+                -webkit-filter: grayscale(100%) contrast(200%);
+                filter: grayscale(100%) contrast(200%);
+            }
+
+            .a11y-emphatic-link a,
+            .a11y-emphatic-link button {
+                -webkit-text-decoration: underline !important;
+                text-decoration: underline !important;
+            }
+
+            .a11y-size-100 {
+                font-size: 1px;
+            }
+
+            .a11y-size-125 {
+                font-size: 1.05px;
+            }
+
+            .a11y-size-150 {
+                font-size: 1.1px;
+            }
+
+            .a11y-size-175 {
+                font-size: 1.15px;
+            }
+
+            .a11y-size-200 {
+                font-size: 1.2px;
+            }
+
+            .a11y-on *:focus {
+                outline: 2px dotted var(--black, #000000);
+            }
+
+            .a11y-on a:hover,
+            .a11y-on button:hover {
+                outline: 2px dotted var(--black, #000000);
+            }
+
+            @-webkit-keyframes animation-gt9fym {
+                0% {
+                    background-color: var(--vertical-color);
+                    box-shadow: 0 0 5px var(--white, #ffffff);
+                }
+
+                85% {
+                    background-color: var(--white, #ffffff);
+                    box-shadow: 0 0 20px var(--white, #ffffff);
+                }
+
+                100% {
+                    background-color: var(--vertical-color);
+                    box-shadow: 0 0 5px var(--white, #ffffff);
+                }
+            }
+
+            @keyframes animation-gt9fym {
+                0% {
+                    background-color: var(--vertical-color);
+                    box-shadow: 0 0 5px var(--white, #ffffff);
+                }
+
+                85% {
+                    background-color: var(--white, #ffffff);
+                    box-shadow: 0 0 20px var(--white, #ffffff);
+                }
+
+                100% {
+                    background-color: var(--vertical-color);
+                    box-shadow: 0 0 5px var(--white, #ffffff);
+                }
+            }
+
+            @-webkit-keyframes animation-16qwp7k {
+                0% {
+                    opacity: 0.4;
+                }
+
+                100% {
+                    opacity: 1;
+                }
+            }
+
+            @keyframes animation-16qwp7k {
+                0% {
+                    opacity: 0.4;
+                }
+
+                100% {
+                    opacity: 1;
+                }
+            }
+
+            @-webkit-keyframes animation-1ppv781 {
+                0% {
+                    -webkit-transform: rotate(0deg);
+                    -webkit-transform: rotate(0deg);
+                    -moz-transform: rotate(0deg);
+                    -ms-transform: rotate(0deg);
+                    transform: rotate(0deg);
+                }
+
+                100% {
+                    -webkit-transform: rotate(360deg);
+                    -webkit-transform: rotate(360deg);
+                    -moz-transform: rotate(360deg);
+                    -ms-transform: rotate(360deg);
+                    transform: rotate(360deg);
+                }
+            }
+
+            @keyframes animation-1ppv781 {
+                0% {
+                    -webkit-transform: rotate(0deg);
+                    -webkit-transform: rotate(0deg);
+                    -moz-transform: rotate(0deg);
+                    -ms-transform: rotate(0deg);
+                    transform: rotate(0deg);
+                }
+
+                100% {
+                    -webkit-transform: rotate(360deg);
+                    -webkit-transform: rotate(360deg);
+                    -moz-transform: rotate(360deg);
+                    -ms-transform: rotate(360deg);
+                    transform: rotate(360deg);
+                }
+            }
+
+            @-webkit-keyframes animation-hi2koi {
+                0% {
+                    background-color: var(--white, #ffffff);
+                }
+
+                20% {
+                    background-color: #00aeef40;
+                }
+
+                100% {
+                    background-color: var(--white, #ffffff);
+                }
+            }
+
+            @keyframes animation-hi2koi {
+                0% {
+                    background-color: var(--white, #ffffff);
+                }
+
+                20% {
+                    background-color: #00aeef40;
+                }
+
+                100% {
+                    background-color: var(--white, #ffffff);
+                }
+            }
+
+            @-webkit-keyframes animation-jmywp2 {
+                0% {
+                    opacity: 0;
+                }
+
+                100% {
+                    opacity: 1;
+                }
+            }
+
+            @keyframes animation-jmywp2 {
+                0% {
+                    opacity: 0;
+                }
+
+                100% {
+                    opacity: 1;
+                }
+            }
+
+            html {
+                line-height: 1.15;
+                -webkit-text-size-adjust: 100%;
+            }
+
+            body {
+                margin: 0;
+            }
+
+            h1 {
+                font-size: 2em;
+                margin: 0.67em 0;
+            }
+
+            hr {
+                box-sizing: content-box;
+                height: 0;
+                overflow: visible;
+            }
+
+            pre {
+                font-family: monospace, monospace;
+                font-size: 1em;
+            }
+
+            a {
+                background-color: transparent;
+            }
+
+            abbr[title] {
+                border-bottom: 0;
+                -webkit-text-decoration: underline;
+                text-decoration: underline;
+                -webkit-text-decoration: underline dotted;
+                text-decoration: underline dotted;
+            }
+
+            b,
+            strong {
+                font-weight: bolder;
+            }
+
+            code,
+            kbd,
+            samp {
+                font-family: monospace, monospace;
+                font-size: 1em;
+            }
+
+            small {
+                font-size: 80%;
+            }
+
+            sub,
+            sup {
+                font-size: 75%;
+                line-height: 0;
+                position: relative;
+                vertical-align: baseline;
+            }
+
+            sub {
+                bottom: -0.25em;
+            }
+
+            sup {
+                top: -0.5em;
+            }
+
+            img {
+                border-style: none;
+            }
+
+            button,
+            input,
+            optgroup,
+            select,
+            textarea {
+                font-family: inherit;
+                font-size: 100%;
+                line-height: 1.15;
+                margin: 0;
+            }
+
+            button,
+            input {
+                overflow: visible;
+            }
+
+            button,
+            select {
+                text-transform: none;
+            }
+
+            button,
+            [type='button'],
+            [type='reset'],
+            [type='submit'] {
+                -webkit-appearance: button;
+            }
+
+            button::-moz-focus-inner,
+            [type='button']::-moz-focus-inner,
+            [type='reset']::-moz-focus-inner,
+            [type='submit']::-moz-focus-inner {
+                border-style: none;
+                padding: 0;
+            }
+
+            button:-moz-focusring,
+            [type='button']:-moz-focusring,
+            [type='reset']:-moz-focusring,
+            [type='submit']:-moz-focusring {
+                outline: 1px dotted ButtonText;
+            }
+
+            fieldset {
+                padding: 0.35em 0.75em 0.625em;
+            }
+
+            legend {
+                box-sizing: border-box;
+                color: inherit;
+                display: table;
+                max-width: 100%;
+                padding: 0;
+                white-space: normal;
+            }
+
+            progress {
+                vertical-align: baseline;
+            }
+
+            textarea {
+                overflow: auto;
+            }
+
+            [type='checkbox'],
+            [type='radio'] {
+                box-sizing: border-box;
+                padding: 0;
+            }
+
+            [type='number']::-webkit-inner-spin-button,
+            [type='number']::-webkit-outer-spin-button {
+                height: auto;
+            }
+
+            [type='search'] {
+                -webkit-appearance: textfield;
+                outline-offset: -2px;
+            }
+
+            [type='search']::-webkit-search-decoration {
+                -webkit-appearance: none;
+            }
+
+            ::-webkit-file-upload-button {
+                -webkit-appearance: button;
+                font: inherit;
+            }
+
+            details {
+                display: block;
+            }
+
+            summary {
+                display: -webkit-box;
+                display: -webkit-list-item;
+                display: -ms-list-itembox;
+                display: list-item;
+            }
+
+            template {
+                display: none;
+            }
+
+            [hidden] {
+                display: none;
+            }
+
+            html,
+            button,
+            input,
+            select,
+            textarea {
+                font-family: arial, helvetica, sans-serif;
+            }
+
+            button:disabled {
+                cursor: default;
+            }
+
+            *,
+            *:before,
+            *:after {
+                box-sizing: border-box;
+            }
+
+            a {
+                -webkit-text-decoration: none;
+                text-decoration: none;
+                color: inherit;
+                cursor: pointer;
+            }
+
+            img {
+                display: block;
+            }
+
+            button,
+            input[type='submit'] {
+                background-color: transparent;
+                border-width: 0;
+                padding: 0;
+                cursor: pointer;
+            }
+
+            input {
+                border-width: 0;
+            }
+
+            input::-moz-focus-inner {
+                border: 0;
+                padding: 0;
+                margin: 0;
+            }
+
+            ul,
+            ol,
+            dd {
+                margin: 0;
+                padding: 0;
+                list-style: none;
+            }
+
+            h1,
+            h2,
+            h3,
+            h4,
+            h5,
+            h6 {
+                margin: 0;
+                font-size: inherit;
+                font-weight: inherit;
+            }
+
+            p {
+                margin: 0;
+            }
+
+            cite {
+                font-style: normal;
+            }
+
+            fieldset {
+                border-width: 0;
+                padding: 0;
+                margin: 0;
+            }
+
+            iframe {
+                border-style: none;
+                border-width: 0;
+            }
+
+            form {
+                margin: 0;
+                padding: 0;
+            }
+
+            table {
+                border: 0;
+                border-spacing: 0px;
+                border-collapse: collapse;
+            }
+
+            table td {
+                padding: 0px;
+            }
+
+            input[type='number']::-webkit-inner-spin-button,
+            input[type='number']::-webkit-outer-spin-button {
+                -ms-appearance: none;
+                -moz-appearance: none;
+                -webkit-appearance: none;
+                -webkit-appearance: none;
+                -moz-appearance: none;
+                -ms-appearance: none;
+                appearance: none;
+                margin: 0;
+            }
+
+            figure {
+                margin: 0;
+            }
+
+            @font-face {
+                font-family: 'almoni-ultra-light';
+                font-display: swap;
+                src: url('/public/font/almoni/almoni-neue-aaa-200.woff') format('woff'), url('/public/font/almoni/almoni-neue-aaa-200.ttf') format('truetype');
+                font-weight: 200;
+            }
+
+            @font-face {
+                font-family: 'almoni-light';
+                font-display: swap;
+                src: url('/public/font/almoni/almoni-neue-aaa-300.woff') format('woff'), url('/public/font/almoni/almoni-neue-aaa-300.ttf') format('truetype');
+                font-weight: 300;
+            }
+
+            @font-face {
+                font-family: 'almoni-regular';
+                font-display: swap;
+                src: url('/public/font/almoni/almoni-neue-aaa-400.woff') format('woff'), url('/public/font/almoni/almoni-neue-aaa-400.ttf') format('truetype');
+                font-weight: 400;
+            }
+
+            @font-face {
+                font-family: 'almoni-medium';
+                font-display: swap;
+                src: url('/public/font/almoni/almoni-neue-aaa-500.woff') format('woff'), url('/public/font/almoni/almoni-neue-aaa-500.ttf') format('truetype');
+                font-weight: 500;
+            }
+
+            @font-face {
+                font-family: 'almoni-demi-bold';
+                font-display: swap;
+                src: url('/public/font/almoni/almoni-neue-aaa-600.woff') format('woff'), url('/public/font/almoni/almoni-neue-aaa-600.ttf') format('truetype');
+                font-weight: 600;
+            }
+
+            @font-face {
+                font-family: 'almoni-bold';
+                font-display: swap;
+                src: url('/public/font/almoni/almoni-neue-aaa-700.woff') format('woff'), url('/public/font/almoni/almoni-neue-aaa-700.ttf') format('truetype');
+                font-weight: 700;
+            }
+
+            @font-face {
+                font-family: 'almoni-ultra-bold';
+                font-display: swap;
+                src: url('/public/font/almoni/almoni-neue-aaa-800.woff') format('woff'), url('/public/font/almoni/almoni-neue-aaa-800.ttf') format('truetype');
+                font-weight: 800;
+            }
+
+            @font-face {
+                font-family: 'almoni-black';
+                font-display: swap;
+                src: url('/public/font/almoni/almoni-neue-aaa-900.woff') format('woff'), url('/public/font/almoni/almoni-neue-aaa-900.ttf') format('truetype');
+                font-weight: 900;
+            }
+
+            @font-face {
+                font-family: 'almoni-ultra-black';
+                font-display: swap;
+                src: url('/public/font/almoni/almoni-neue-aaa-900b.woff') format('woff'), url('/public/font/almoni/almoni-neue-aaa-900b.ttf') format('truetype');
+                font-weight: 900;
+            }
+
+            @font-face {
+                font-family: 'spoiler-light';
+                font-display: swap;
+                src: url('/public/font/spoiler/fbspoiler-light-webfont.woff') format('woff'), url('/public/font/spoiler/fbspoiler-light-webfont.ttf') format('truetype');
+            }
+
+            @font-face {
+                font-family: 'spoiler-regular';
+                font-display: swap;
+                src: url('/public/font/spoiler/fbspoileren-regular-webfont.woff') format('woff'), url('/public/font/spoiler/fbspoileren-regular-webfont.ttf') format('truetype');
+            }
+
+            @font-face {
+                font-family: 'spoiler-bold';
+                font-display: swap;
+                src: url('/public/font/spoiler/fbspoileren-bold-webfont.woff') format('woff'), url('/public/font/spoiler/fbspoileren-bold-webfont.ttf') format('truetype');
+            }
+
+            @font-face {
+                font-family: 'spoiler-black';
+                font-display: swap;
+                src: url('/public/font/spoiler/fbspoiler-black-webfont.woff') format('woff'), url('/public/font/spoiler/fbspoiler-black-webfont.ttf') format('truetype');
+            }
+
+            @font-face {
+                font-family: 'walla-fun';
+                src: url('/public/font/fun/games.woff') format('woff'), url('/public/font/fun/games.ttf') format('truetype');
+                font-weight: normal;
+                font-style: normal;
+            }
+
+            [class^='walla-fun-']:before,
+            [class*=' walla-fun-']:before {
+                font-family: 'walla-fun';
+                speak: none;
+                line-height: 1;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+                width: 100%;
+                height: 100%;
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+                -webkit-box-pack: center;
+                -ms-flex-pack: center;
+                -webkit-justify-content: center;
+                justify-content: center;
+                font-size: 20px;
+            }
+
+            .walla-fun-expand:before {
+                content: '\41';
+            }
+
+            .walla-fun-cards:before {
+                content: '\42';
+            }
+
+            .walla-fun-brain:before {
+                content: '\43';
+            }
+
+            .walla-fun-fashion:before {
+                content: '\44';
+            }
+
+            .walla-fun-action:before {
+                content: '\45';
+            }
+
+            .walla-fun-time:before {
+                content: '\46';
+            }
+
+            .walla-fun-star:before {
+                content: '\47';
+            }
+
+            .walla-fun-sport:before {
+                content: '\48';
+            }
+
+            .walla-fun-racing:before {
+                content: '\49';
+            }
+
+            .walla-fun-personal:before {
+                content: '\4a';
+            }
+
+            .walla-fun-motor:before {
+                content: '\4b';
+            }
+
+            .walla-fun-crazy:before {
+                content: '\4c';
+            }
+
+            .walla-fun-cooking:before {
+                content: '\4d';
+            }
+
+            .walla-fun-bubbles:before {
+                content: '\4e';
+            }
+
+            .walla-fun-arrow-left:before {
+                content: '\4f';
+            }
+
+            .walla-fun-arrow-right:before {
+                content: '\50';
+            }
+
+            .walla-fun-arcade:before {
+                content: '\51';
+            }
+
+            .walla-fun-spongebob:before {
+                content: '\52';
+            }
+
+            .walla-fun-animals:before {
+                content: '\53';
+            }
+
+            .walla-fun-cactus:before {
+                content: '\54';
+            }
+
+            .walla-fun-paint:before {
+                content: '\55';
+            }
+
+            .walla-fun-mahjong:before {
+                content: '\56';
+            }
+
+            .walla-fun-mario:before {
+                content: '\57';
+            }
+
+            @font-face {
+                font-family: 'walla-weather';
+                src: url('/public/font/weather/wallaweather.woff') format('woff'), url('/public/font/weather/wallaweather.ttf') format('truetype');
+                font-weight: normal;
+                font-style: normal;
+            }
+
+            [class^='walla-weather-']:before,
+            [class*=' walla-weather-']:before {
+                font-family: 'walla-weather';
+                speak: none;
+                line-height: 1;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+                width: 100%;
+                height: 100%;
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+                -webkit-box-pack: center;
+                -ms-flex-pack: center;
+                -webkit-justify-content: center;
+                justify-content: center;
+                font-size: 20px;
+            }
+
+            .walla-weather-air-directions:before {
+                content: 'a';
+            }
+
+            .walla-weather-air-pollution:before {
+                content: 'b';
+            }
+
+            .walla-weather-humidity:before {
+                content: 'c';
+            }
+
+            .walla-weather-moon:before {
+                content: 'd';
+            }
+
+            .walla-weather-sun:before {
+                content: 'e';
+            }
+
+            .walla-weather-temp:before {
+                content: 'f';
+            }
+
+            .walla-weather-wave-hight:before {
+                content: 'g';
+            }
+
+            .walla-weather-wave-status:before {
+                content: 'h';
+            }
+
+            .walla-weather-wind:before {
+                content: 'i';
+            }
+
+            .walla-weather-wind-2:before {
+                content: 'j';
+            }
+
+            .walla-weather-down-arrow:before {
+                content: '\6b';
+            }
+
+            .walla-weather-up-arrow:before {
+                content: '\6c';
+            }
+
+            .walla-weather-error:before {
+                content: '\6d';
+            }
+
+            @font-face {
+                font-family: 'walla-icons';
+                src: url('/public/font/fonticon/wallaicons.woff') format('woff'), url('/public/font/fonticon/wallaicons.ttf') format('truetype');
+                font-weight: 500;
+            }
+
+            [class^='walla-icon-']:before,
+            [class*=' walla-icon-']:before {
+                font-family: 'walla-icons';
+                speak: none;
+                line-height: 1;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+                width: 100%;
+                height: 100%;
+                display: -webkit-box;
+                display: -webkit-flex;
+                display: -ms-flexbox;
+                display: flex;
+                -webkit-align-items: center;
+                -webkit-box-align: center;
+                -ms-flex-align: center;
+                align-items: center;
+                -webkit-box-pack: center;
+                -ms-flex-pack: center;
+                -webkit-justify-content: center;
+                justify-content: center;
+                font-size: 20px;
+            }
+
+            [class^='walla-icon-'].small:before,
+            [class*=' walla-icon-'].small:before {
+                font-size: 17px;
+            }
+
+            .walla-icon-printer:before {
+                content: 'Z';
+            }
+
+            .walla-icon-next:before {
+                content: 'C';
+            }
+
+            .walla-icon-prev:before {
+                content: 'B';
+            }
+
+            .walla-icon-down:before {
+                content: 'w';
+            }
+
+            .walla-icon-search:before {
+                content: 'E';
+            }
+
+            .walla-icon-facebook:before {
+                content: 'j';
+            }
+
+            .walla-icon-whatsapp:before {
+                content: 'Q';
+            }
+
+            .walla-icon-twitter:before {
+                content: 'd';
+            }
+
+            .walla-icon-envelop:before {
+                content: 's';
+            }
+
+            .walla-icon-arrow-down:before {
+                content: 'w';
+            }
+
+            .walla-icon-arrow-up:before {
+                content: 'x';
+            }
+
+            .walla-icon-arrow-down:before {
+                content: 'w';
+            }
+
+            .walla-icon-x:before {
+                content: 'F';
+            }
+
+            .walla-icon-talkback:before {
+                content: '';
+                width: 18px;
+                height: 20px;
+                background: url(/public/assets/icons/talkbacks/talkbacks18x20.svg);
+                background-repeat: no-repeat;
+            }
+
+            .walla-icon-thumb:before {
+                content: '2';
+            }
+
+            .walla-icon-thumb-down:before {
+                content: '2';
+                -webkit-transform: rotate(180deg);
+                -moz-transform: rotate(180deg);
+                -ms-transform: rotate(180deg);
+                transform: rotate(180deg);
+            }
+
+            .walla-icon-X:before {
+                content: 'F';
+            }
+
+            .walla-icon-heart:before {
+                content: 'G';
+            }
+
+            .walla-icon-walla:before {
+                content: 'u';
+            }
+
+            .walla-icon-sub-talkback:before {
+                content: '(';
+            }
+
+            .walla-icon-add-talkback:before {
+                content: ')';
+            }
+
+            .walla-icon-tags:before {
+                content: 'm';
+                font-size: 12px;
+                color: rgb(70, 70, 70);
+            }
+
+            .walla-icon-share-android:before {
+                content: '0';
+            }
+
+            .walla-icon-share-iphone:before {
+                content: '1';
+                font-weight: 900;
+            }
+
+            .walla-icon-double-arrow-left:before {
+                content: '\24';
+            }
+
+            .walla-icon-double-arrow-right:before {
+                content: '\25';
+            }
+
+            .walla-icon-arrow-left:before {
+                content: 'n';
+            }
+
+            .walla-icon-left:before {
+                content: 'y';
+            }
+
+            .walla-icon-right:before {
+                content: 'z';
+            }
+
+            .walla-icon-switch-arrows:before {
+                content: '\23';
+            }
+
+            .walla-icon-play-with-border:before {
+                content: '';
+                width: 26px;
+                height: 26px;
+                background: url(/public/assets/icons/walla-sprite.svg);
+                background-repeat: no-repeat;
+                -webkit-background-position: -102px -175px;
+                background-position: -102px -175px;
+            }
+
+            .walla-icon-apple:before {
+                content: '\61';
+                -webkit-transform: translate(0, -1px);
+                -moz-transform: translate(0, -1px);
+                -ms-transform: translate(0, -1px);
+                transform: translate(0, -1px);
+            }
+
+            .walla-icon-android:before {
+                content: '\62';
+            }
+
+            .walla-icon-instagram:before {
+                content: 'H';
+            }
+
+            .walla-icon-youtube:before {
+                content: '\53';
+                font-size: 16px;
+            }
+
+            .walla-icon-magnifier:before {
+                content: 'D';
+            }
+
+            html {
+                height: 100%;
+                font-size: 1px;
+            }
+
+            html[lang="he"] body {
+                direction: rtl;
+            }
+
+            html.resize-1 {
+                font-size: 1px;
+            }
+
+            html.resize-2 {
+                font-size: 1.1px;
+            }
+
+            html.resize-3 {
+                font-size: 1.2px;
+            }
+
+            html.resize-4 {
+                font-size: 1.3px;
+            }
+
+            html.resize-5 {
+                font-size: 1.4px;
+            }
+
+            html.resize-6 {
+                font-size: 1.5px;
+            }
+
+            html.resize-7 {
+                font-size: 1.6px;
+            }
+
+            body {
+                font-family: arial, sans-serif;
+                font-size: 16rem;
+                line-height: 1.3;
+                --vertical-color: #1978bb;
+                --black: #000000;
+                --gray1: #191919;
+                --gray2: #333333;
+                --gray3: #4c4c4c;
+                --gray4: #666666;
+                --gray5: #7f7f7f;
+                --gray6: #999999;
+                --gray7: #b2b2b2;
+                --gray8: #d8d8d8;
+                --gray9: #e5e5e5;
+                --gray10: #f2f2f2;
+                --white: #ffffff;
+                --link-blue: #0067bd;
+                -webkit-transition: background-color .7s;
+                transition: background-color .7s;
+                background-color: var(--white, #ffffff);
+                color: var(--black, #000000);
+            }
+
+            body.dark {
+                --black: #ffffff;
+                --gray10: #191919;
+                --gray9: #666666;
+                --gray8: #666666;
+                --gray7: #666666;
+                --gray6: #7f7f7f;
+                --gray5: #999999;
+                --gray4: #b2b2b2;
+                --gray3: #d8d8d8;
+                --gray2: #e5e5e5;
+                --gray1: #f2f2f2;
+                --white: #202020;
+                --link-blue: #94bcff;
+            }
+
+            body.gray-background {
+                background-color: #f3f4f6;
+            }
+
+            body.gray-background.dark {
+                background-color: #3e3e3e;
+            }
+
+            body.black-background {
+                background-color: black;
+            }
+
+            body.independenceday {
+                background-image: url('/public/assets/independenceday/desktop.jpg');
+                background-repeat: no-repeat;
+                -webkit-background-position: top;
+                background-position: top;
+            }
+
+            @media (max-width: 969px) {
+                body.independenceday {
+                    background-image: url('/public/assets/independenceday/mobile.jpg');
+                    -webkit-background-size: 600px;
+                    background-size: 600px;
+                }
+            }
+
+            body.vod {
+                background: #343434;
+            }
+
+            body.viva {
+                background: #000;
+            }
+
+            body.fixed {
+                overflow: hidden;
+            }
+
+            @media (max-width: 969px) {
+
+                .no-mobile,
+                .only-desktop,
+                .only-mobile-app,
+                .only-wide-desktop,
+                .only-narrow-desktop {
+                    display: none !important;
+                }
+            }
+
+            @media (min-width: 970px) {
+
+                .only-mobile,
+                .no-desktop,
+                .only-mobile-app {
+                    display: none !important;
+                }
+            }
+
+            @media (min-width: 969px) and (max-width: 1200px) {
+
+                .no-narrow-desktop,
+                .only-wide-desktop,
+                .only-mobile {
+                    display: none !important;
+                }
+            }
+
+            @media (min-width: 1201px) {
+
+                .no-wide-desktop,
+                .only-narrow-desktop,
+                .only-mobile {
+                    display: none !important;
+                }
+            }
+
+            body.mobile-app .only-mobile-app {
+                display: block !important;
+            }
+
+            body.mobile-app .no-mobile-app {
+                display: none !important;
+            }
+
+            @media print {
+                .noprint {
+                    visibility: hidden;
+                }
+            }
+
+            @-webkit-keyframes fade-in {
+                0% {
+                    opacity: 0;
+                }
+
+                100% {
+                    opacity: 0.8;
+                }
+            }
+
+            @keyframes fade-in {
+                0% {
+                    opacity: 0;
+                }
+
+                100% {
+                    opacity: 0.8;
+                }
+            }
+
+            .lazyload-placeholder {
+                background-color: var(--gray8, #d8d8d8);
+            }
+
+            .screen-reader {
+                position: absolute;
+                left: 0;
+                top: -100000px;
+                width: 1px;
+                height: 1px;
+                overflow: hidden;
+            }
+
+            @-webkit-keyframes animation-1unvu1o {
+                0% {
+                    left: -230px;
+                }
+
+                100% {
+                    left: 0;
+                }
+            }
+
+            @keyframes animation-1unvu1o {
+                0% {
+                    left: -230px;
+                }
+
+                100% {
+                    left: 0;
+                }
+            }
+
+            @-webkit-keyframes animation-1s9m7en {
+                0% {
+                    left: 0;
+                }
+
+                100% {
+                    left: -230px;
+                }
+            }
+
+            @keyframes animation-1s9m7en {
+                0% {
+                    left: 0;
+                }
+
+                100% {
+                    left: -230px;
+                }
+            }
+
+            @-webkit-keyframes animation-1t8246r {
+                0% {
+                    bottom: -100%;
+                }
+
+                100% {
+                    bottom: 0;
+                }
+            }
+
+            @keyframes animation-1t8246r {
+                0% {
+                    bottom: -100%;
+                }
+
+                100% {
+                    bottom: 0;
+                }
+            }
+
+            html {
+                line-height: 1.15;
+                -webkit-text-size-adjust: 100%;
+            }
+
+            body {
+                margin: 0;
+            }
+
+            h1 {
+                font-size: 2em;
+                margin: 0.67em 0;
+            }
+
+            hr {
+                box-sizing: content-box;
+                height: 0;
+                overflow: visible;
+            }
+
+            pre {
+                font-family: monospace, monospace;
+                font-size: 1em;
+            }
+
+            a {
+                background-color: transparent;
+            }
+
+            abbr[title] {
+                border-bottom: 0;
+                -webkit-text-decoration: underline;
+                text-decoration: underline;
+                -webkit-text-decoration: underline dotted;
+                text-decoration: underline dotted;
+            }
+
+            b,
+            strong {
+                font-weight: bolder;
+            }
+
+            code,
+            kbd,
+            samp {
+                font-family: monospace, monospace;
+                font-size: 1em;
+            }
+
+            small {
+                font-size: 80%;
+            }
+
+            sub,
+            sup {
+                font-size: 75%;
+                line-height: 0;
+                position: relative;
+                vertical-align: baseline;
+            }
+
+            sub {
+                bottom: -0.25em;
+            }
+
+            sup {
+                top: -0.5em;
+            }
+
+            img {
+                border-style: none;
+            }
+
+            button,
+            input,
+            optgroup,
+            select,
+            textarea {
+                font-family: inherit;
+                font-size: 100%;
+                line-height: 1.15;
+                margin: 0;
+            }
+
+            button,
+            input {
+                overflow: visible;
+            }
+
+            button,
+            select {
+                text-transform: none;
+            }
+
+            button,
+            [type='button'],
+            [type='reset'],
+            [type='submit'] {
+                -webkit-appearance: button;
+            }
+
+            button::-moz-focus-inner,
+            [type='button']::-moz-focus-inner,
+            [type='reset']::-moz-focus-inner,
+            [type='submit']::-moz-focus-inner {
+                border-style: none;
+                padding: 0;
+            }
+
+            button:-moz-focusring,
+            [type='button']:-moz-focusring,
+            [type='reset']:-moz-focusring,
+            [type='submit']:-moz-focusring {
+                outline: 1px dotted ButtonText;
+            }
+
+            fieldset {
+                padding: 0.35em 0.75em 0.625em;
+            }
+
+            legend {
+                box-sizing: border-box;
+                color: inherit;
+                display: table;
+                max-width: 100%;
+                padding: 0;
+                white-space: normal;
+            }
+
+            progress {
+                vertical-align: baseline;
+            }
+
+            textarea {
+                overflow: auto;
+            }
+
+            [type='checkbox'],
+            [type='radio'] {
+                box-sizing: border-box;
+                padding: 0;
+            }
+
+            [type='number']::-webkit-inner-spin-button,
+            [type='number']::-webkit-outer-spin-button {
+                height: auto;
+            }
+
+            [type='search'] {
+                -webkit-appearance: textfield;
+                outline-offset: -2px;
+            }
+
+            [type='search']::-webkit-search-decoration {
+                -webkit-appearance: none;
+            }
+
+            ::-webkit-file-upload-button {
+                -webkit-appearance: button;
+                font: inherit;
+            }
+
+            details {
+                display: block;
+            }
+
+            summary {
+                display: -webkit-box;
+                display: -webkit-list-item;
+                display: -ms-list-itembox;
+                display: list-item;
+            }
+
+            template {
+                display: none;
+            }
+
+            [hidden] {
+                display: none;
+            }
+
+            html,
+            button,
+            input,
+            select,
+            textarea {
+                font-family: arial, helvetica, sans-serif;
+            }
+
+            button:disabled {
+                cursor: default;
+            }
+
+            *,
+            *:before,
+            *:after {
+                box-sizing: border-box;
+            }
+
+            a {
+                -webkit-text-decoration: none;
+                text-decoration: none;
+                color: inherit;
+                cursor: pointer;
+            }
+
+            img {
+                display: block;
+            }
+
+            button,
+            input[type='submit'] {
+                background-color: transparent;
+                border-width: 0;
+                padding: 0;
+                cursor: pointer;
+            }
+
+            input {
+                border-width: 0;
+            }
+
+            input::-moz-focus-inner {
+                border: 0;
+                padding: 0;
+                margin: 0;
+            }
+
+            ul,
+            ol,
+            dd {
+                margin: 0;
+                padding: 0;
+                list-style: none;
+            }
+
+            h1,
+            h2,
+            h3,
+            h4,
+            h5,
+            h6 {
+                margin: 0;
+                font-size: inherit;
+                font-weight: inherit;
+            }
+
+            p {
+                margin: 0;
+            }
+
+            cite {
+                font-style: normal;
+            }
+
+            fieldset {
+                border-width: 0;
+                padding: 0;
+                margin: 0;
+            }
+
+            iframe {
+                border-style: none;
+                border-width: 0;
+            }
+
+            form {
+                margin: 0;
+                padding: 0;
+            }
+
+            table {
+                border: 0;
+                border-spacing: 0px;
+                border-collapse: collapse;
+            }
+
+            table td {
+                padding: 0px;
+            }
+
+            input[type='number']::-webkit-inner-spin-button,
+            input[type='number']::-webkit-outer-spin-button {
+                -ms-appearance: none;
+                -moz-appearance: none;
+                -webkit-appearance: none;
+                -webkit-appearance: none;
+                -moz-appearance: none;
+                -ms-appearance: none;
+                appearance: none;
+                margin: 0;
+            }
+
+            figure {
+                margin: 0;
+            }
+
+            html {
+                height: 100%;
+                font-size: 1px;
+            }
+
+            body.zahav {
+                direction: ltr;
+                font-family: arial, sans-serif;
+                font-size: 16rem;
+                line-height: 1.3;
+            }
+
+            @media (max-width: 999px) {
+
+                body.zahav .no-mobile,
+                body.zahav .only-laptop,
+                body.zahav .only-desktop {
+                    display: none !important;
+                }
+            }
+
+            @media (min-width: 1000px) and (max-width: 1260px) {
+
+                body.zahav .only-mobile,
+                body.zahav .only-desktop {
+                    display: none !important;
+                }
+            }
+
+            @media (min-width: 1261px) {
+
+                body.zahav .only-laptop,
+                body.zahav .only-mobile,
+                body.zahav .no-desktop {
+                    display: none !important;
+                }
+            }
+
+            @-webkit-keyframes animation-1p27pre {
+                0% {
+                    top: -54px;
+                }
+
+                100% {
+                    top: 0;
+                }
+            }
+
+            @keyframes animation-1p27pre {
+                0% {
+                    top: -54px;
+                }
+
+                100% {
+                    top: 0;
+                }
+            }
+        </style>
+        <style data-emotion="css 0"></style>
+        <div class="css-0 vertical-1" style="--vertical-color:#1978bb;--light-color:#bddef6;--bg-color:#e4f2fb">
+            <script type="application/ld+json">
+        {
+            "@context": "http://schema.org/",
+            "@type": "NewsArticle",
+            "mainEntityOfPage": {
+                "@type": "WebPage",
+                "@id": "https://news.walla.co.il/break/3448092"
+            },
+            "headline": "פקיסטן: שמונה הרוגים בפיצוץ באוטובוס",
+            "image": {
+                "@type": "ImageObject",
+                "url": "https://img.wcdn.co.il/f_auto,q_auto,w_1200,t_54/0/n/u/l/null-46.jpg",
+                "height": 800,
+                "width": 1200
+            },
+            "author": {
+                "@type": "Person",
+                "name": "מערכת וואלה"
+            },
+            "datePublished": "2021-07-14 09:10:00",
+            "dateModified": "2021-07-14 09:15:37",
+            "publisher": {
+                "@type": "Organization",
+                "name": "Walla!",
+                "logo": {
+                    "@type": "ImageObject",
+                    "url": "https://www.walla.co.il/public/assets/logo/logo-black.svg",
+                    "width": 433
+                }
+            },
+            "description": "פקיסטן: שמונה הרוגים בפיצוץ באוטובוס - וואלה! חדשות"
+        }
+        </script>
+            <style data-emotion="css y02riy">
+                @media (max-width: 969px) {
+                    .css-y02riy {
+                        z-index: 10000;
+                        position: fixed;
+                        -webkit-align-items: center;
+                        -webkit-box-align: center;
+                        -ms-flex-align: center;
+                        align-items: center;
+                        top: 0;
+                        left: 0;
+                        right: 0;
+                        background: var(--vertical-color);
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        -webkit-user-select: none;
+                        -moz-user-select: none;
+                        -ms-user-select: none;
+                        user-select: none;
+                        margin-right: 0;
+                        -webkit-transition: 0.6s;
+                        transition: 0.6s;
+                        height: 54px;
+                    }
+
+                    .css-y02riy.homepage {
+                        background-color: #000000;
+                    }
+
+                    .css-y02riy .mobile-vertical-name {
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        color: #ffffff;
+                        margin-right: 10px;
+                        min-width: 170px;
+                        -webkit-align-items: center;
+                        -webkit-box-align: center;
+                        -ms-flex-align: center;
+                        align-items: center;
+                    }
+
+                    .css-y02riy .mobile-vertical-name .vertical-name {
+                        margin-right: 5px;
+                        font-size: 25rem;
+                        line-height: 54px;
+                        font-family: 'almoni-demi-bold', arial;
+                        white-space: nowrap;
+                        overflow: hidden;
+                        -webkit-flex: 1;
+                        -ms-flex: 1;
+                        flex: 1;
+                    }
+
+                    .css-y02riy .mobile-vertical-name .vertical-name.is-advertorial {
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        -webkit-flex-direction: column;
+                        -ms-flex-direction: column;
+                        flex-direction: column;
+                        line-height: 1;
+                    }
+
+                    .css-y02riy .mobile-vertical-name .vertical-name.is-advertorial .collaboration-with {
+                        font-size: 11rem;
+                        font-family: arial;
+                    }
+
+                    .css-y02riy .mobile-vertical-name .vertical-name.small-font {
+                        font-size: 20rem;
+                    }
+
+                    .css-y02riy .mobile-vertical-name .mobile-inner-header-image {
+                        height: 27px;
+                        margin-right: 5px;
+                    }
+
+                    .css-y02riy .mobile-vertical-name .logo {
+                        height: 24px;
+                        width: auto;
+                    }
+
+                    .css-y02riy .small-weather-icon {
+                        margin-right: auto;
+                    }
+
+                    .css-y02riy .small-weather-icon a {
+                        background-image: url('/public/assets/weather/weather-sprite-white.svg');
+                        width: 70px;
+                        height: 60px;
+                        background-repeat: no-repeat;
+                        display: inline-block;
+                        vertical-align: middle;
+                        -webkit-background-position: -14px -827px;
+                        background-position: -14px -827px;
+                        zoom: 0.5;
+                        margin-left: 25px;
+                    }
+
+                    .css-y02riy .back-button {
+                        padding: 0 1px 0 7px;
+                    }
+
+                    .css-y02riy .back-button .walla-icon-X:before {
+                        font-size: 30px;
+                        color: #ffffff;
+                        font-weight: bold;
+                    }
+
+                    .css-y02riy.open {
+                        margin-right: 250px;
+                    }
+                }
+            </style>
+            <header class="css-y02riy  no-mobile-app noprint only-mobile ">
+                <style data-emotion="css eje17f">
+                    .css-eje17f {
+                        display: inline-block;
+                        cursor: pointer;
+                        background-color: #000000;
+                        padding: 15px 9px;
+                        height: 100%;
+                    }
+
+                    .css-eje17f.transparent {
+                        background-color: transparent;
+                    }
+
+                    .css-eje17f .bar1,
+                    .css-eje17f .bar2,
+                    .css-eje17f .bar3 {
+                        width: 25px;
+                        height: 4px;
+                        background-color: #ffffff;
+                        margin: 3px 0;
+                        -webkit-transition: 1s;
+                        transition: 1s;
+                    }
+
+                    .css-eje17f.open .bar1 {
+                        -webkit-transform: rotate(-45deg) translate(-6px, 4px);
+                        -moz-transform: rotate(-45deg) translate(-6px, 4px);
+                        -ms-transform: rotate(-45deg) translate(-6px, 4px);
+                        transform: rotate(-45deg) translate(-6px, 4px);
+                    }
+
+                    .css-eje17f.open .bar2 {
+                        opacity: 0;
+                    }
+
+                    .css-eje17f.open .bar3 {
+                        -webkit-transform: rotate(45deg) translate(-6px, -4px);
+                        -moz-transform: rotate(45deg) translate(-6px, -4px);
+                        -ms-transform: rotate(45deg) translate(-6px, -4px);
+                        transform: rotate(45deg) translate(-6px, -4px);
+                    }
+                </style><button class="css-eje17f  no-desktop ">
+                    <div class="bar1"></div>
+                    <div class="bar2"></div>
+                    <div class="bar3"></div>
+                </button>
+                <div class="mobile-vertical-name"><a href="https://www.walla.co.il/" aria-label="וואלה!"
+                        title="וואלה!"><img src="/public/assets/logo/mobile.svg" alt="וואלה!" title="וואלה!" /></a><a
+                        href="https://news.walla.co.il" aria-label="חדשות" title="חדשות"
+                        class="vertical-name  ">חדשות</a></div>
+                <div class="small-weather-icon"><a href="https://weather.walla.co.il" aria-label="מזג אויר"
+                        title="מזג אויר"></a></div>
+                <div class="small-mail-bar">
+                    <style data-emotion="css bu25vf">
+                        .css-bu25vf {
+                            font-size: 12rem;
+                            width: 100px;
+                        }
+
+                        .css-bu25vf>a {
+                            display: -webkit-box;
+                            display: -webkit-flex;
+                            display: -ms-flexbox;
+                            display: flex;
+                            height: 100%;
+                        }
+
+                        .css-bu25vf>a>.wrap {
+                            position: relative;
+                            width: 32px;
+                            margin: -3px 0px auto 10px;
+                        }
+
+                        @media (max-width: 969px) {
+                            .css-bu25vf>a>.wrap {
+                                background: var(--black, #000000);
+                            }
+                        }
+
+                        .css-bu25vf>a>.wrap .walla-icon-envelop:before {
+                            color: #ffffff;
+                            font-size: 35rem;
+                        }
+
+                        .css-bu25vf>a>.wrap .dot {
+                            background-color: #cf041c;
+                            color: #ffffff;
+                            width: 20px;
+                            height: 20px;
+                            position: absolute;
+                            top: -2px;
+                            right: -10px;
+                            border-radius: 50%;
+                            display: -webkit-box;
+                            display: -webkit-flex;
+                            display: -ms-flexbox;
+                            display: flex;
+                            -webkit-box-pack: center;
+                            -ms-flex-pack: center;
+                            -webkit-justify-content: center;
+                            justify-content: center;
+                            -webkit-align-items: center;
+                            -webkit-box-align: center;
+                            -ms-flex-align: center;
+                            align-items: center;
+                        }
+
+                        .css-bu25vf>a .name-read {
+                            display: -webkit-box;
+                            display: -webkit-flex;
+                            display: -ms-flexbox;
+                            display: flex;
+                            -webkit-flex-direction: column;
+                            -ms-flex-direction: column;
+                            flex-direction: column;
+                            -webkit-box-pack: center;
+                            -ms-flex-pack: center;
+                            -webkit-justify-content: center;
+                            justify-content: center;
+                            overflow: hidden;
+                        }
+
+                        .css-bu25vf>a .name-read .name {
+                            color: #ffffff;
+                            white-space: nowrap;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                        }
+
+                        .css-bu25vf>a .name-read .read {
+                            color: #f2f2f2;
+                        }
+
+                        .css-bu25vf.small {
+                            width: auto;
+                            margin-right: 10px;
+                        }
+
+                        .css-bu25vf.small .name-read {
+                            display: none;
+                        }
+
+                        .css-bu25vf.small>a>.wrap {
+                            background-color: transparent;
+                        }
+                    </style>
+                    <div class="css-bu25vf small "><a href="https://mail.walla.co.il">
+                            <div class="wrap"><span class="walla-icon-envelop"></span></div>
+                            <div class="name-read">
+                                <div class="name">וואלה! דואר</div>
+                                <div class="read">קרא דואר</div>
+                            </div>
+                        </a></div>
+                </div>
+            </header>
+            <style data-emotion="css uf5ene">
+                @media (max-width: 969px) {
+                    .css-uf5ene {
+                        position: fixed;
+                        top: 54px;
+                        z-index: 1000;
+                        left: 0;
+                        right: 0;
+                        font-family: 'almoni-regular', arial;
+                        border-top: solid 1px #333333;
+                        background-color: #4c4c4c;
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        overflow: scroll;
+                        overflow-y: hidden;
+                        -webkit-align-items: center;
+                        -webkit-box-align: center;
+                        -ms-flex-align: center;
+                        align-items: center;
+                        color: #ffffff;
+                        height: 40px;
+                    }
+
+                    .css-uf5ene::-webkit-scrollbar {
+                        width: 0;
+                        height: 0;
+                    }
+
+                    .css-uf5ene.sheee {
+                        display: none;
+                    }
+
+                    .css-uf5ene li {
+                        border-left: 1px solid #999999;
+                        position: relative;
+                    }
+
+                    .css-uf5ene li a {
+                        padding: 10px 14px;
+                        white-space: nowrap;
+                        font-size: 17rem;
+                    }
+
+                    .css-uf5ene li:last-of-type {
+                        border: 0;
+                    }
+                }
+            </style>
+            <ul class="css-uf5ene  only-mobile noprint verticals-nav-items no-mobile-app">
+                <li><a href="https://www.walla.co.il">ראשי</a></li>
+                <li role="menuitem"><a href="https://news.walla.co.il/">חדשות</a></li>
+                <li role="menuitem"><a href="https://news.walla.co.il/breaking">מבזקים</a></li>
+                <li role="menuitem"><a href="https://sports.walla.co.il/">ספורט</a></li>
+                <li role="menuitem"><a href="https://news.walla.co.il/category/5108">ויראלי</a></li>
+                <li role="menuitem"><a href="https://e.walla.co.il/">תרבות</a></li>
+                <li role="menuitem"><a href="https://healthy.walla.co.il/">בריאות</a></li>
+                <li role="menuitem"><a href="https://food.walla.co.il/">אוכל</a></li>
+                <li role="menuitem"><a href="https://celebs.walla.co.il/">סלבס</a></li>
+                <li role="menuitem"><a href="https://travel.walla.co.il/">תיירות</a></li>
+                <li role="menuitem"><a href="https://tech.walla.co.il/">Tech</a></li>
+                <li role="menuitem"><a href="https://fashion.walla.co.il/">אופנה</a></li>
+                <li role="menuitem"><a href="https://www.sheee.co.il/">sheee</a></li>
+                <li role="menuitem"><a href="https://vod.walla.co.il/">vod</a></li>
+                <li role="menuitem"><a href="https://judaism.walla.co.il">יהדות</a></li>
+                <li role="menuitem"><a href="https://cars.walla.co.il/">רכב</a></li>
+                <li role="menuitem"><a href="https://fun.walla.co.il/">כיף</a></li>
+                <li role="menuitem"><a href="https://help.walla.co.il/">עזרה</a></li>
+                <li role="menuitem"><a href="https://www.walla.co.il/track">מעקב חבילות</a></li>
+                <li role="menuitem"><a href="https://home.walla.co.il/">בית ועיצוב</a></li>
+            </ul>
+            <style data-emotion="css 1mryvlz">
+                .css-1mryvlz {
+                    margin-bottom: 20px;
+                }
+
+                .css-1mryvlz .main-header-image-background {
+                    position: relative;
+                    top: 0;
+                    left: 0;
+                    right: 0;
+                    height: 146px;
+                    background-repeat: no-repeat;
+                    -webkit-background-position: top center;
+                    background-position: top center;
+                }
+
+                .css-1mryvlz .main-header-image-background .container {
+                    height: 146px;
+                    position: relative;
+                    max-width: 970px;
+                    margin: 0 auto;
+                    padding: 10px 10px;
+                }
+
+                .css-1mryvlz .main-header-image-background .container .logo-black {
+                    width: auto;
+                    height: 24px;
+                }
+
+                @media (max-width: 969px) {
+                    .css-1mryvlz .main-header-image-background {
+                        display: none;
+                    }
+                }
+
+                .css-1mryvlz.no-bottom-margin {
+                    margin-bottom: 0;
+                }
+
+                .css-1mryvlz nav.open+nav {
+                    visibility: hidden;
+                }
+
+                .css-1mryvlz .mobile-logo {
+                    display: none;
+                }
+
+                @media (max-width: 969px) {
+                    .css-1mryvlz {
+                        overflow-x: hidden;
+                        overflow-y: auto;
+                        background-color: #191919;
+                        position: fixed;
+                        top: 0;
+                        right: -250px;
+                        margin-bottom: 0;
+                        left: initial;
+                        bottom: 0;
+                        width: 250px;
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        -webkit-flex-direction: column;
+                        -ms-flex-direction: column;
+                        flex-direction: column;
+                        -webkit-transition: 0.6s;
+                        transition: 0.6s;
+                        z-index: 10000;
+                    }
+
+                    .css-1mryvlz nav {
+                        -webkit-order: 3;
+                        -ms-flex-order: 3;
+                        order: 3;
+                    }
+
+                    .css-1mryvlz nav+nav {
+                        -webkit-order: 2;
+                        -ms-flex-order: 2;
+                        order: 2;
+                    }
+
+                    .css-1mryvlz .mobile-logo {
+                        display: initial;
+                        -webkit-order: 1;
+                        -ms-flex-order: 1;
+                        order: 1;
+                        padding: 9px 0;
+                        padding-right: 10px;
+                        background: #000000;
+                    }
+
+                    .css-1mryvlz.open {
+                        right: 0;
+                    }
+
+                    .css-1mryvlz.open .mobile-logo {
+                        min-height: 54px;
+                        display: block;
+                        padding-top: 15px;
+                    }
+
+                    .css-1mryvlz.open .mobile-logo img {
+                        height: 24px;
+                        width: auto;
+                    }
+                }
+            </style>
+            <header class="no-mobile-app css-1mryvlz main-header  "><a href="https://www.walla.co.il"
+                    class="mobile-logo"><img src="/public/assets/logo/logo_new.svg" alt="וואלה!" title="וואלה!" /></a>
+                <style data-emotion="css 1lslle7">
+                    .css-1lslle7 {
+                        background-color: #1f1f1f;
+                        color: #ffffff;
+                        -webkit-user-select: none;
+                        -moz-user-select: none;
+                        -ms-user-select: none;
+                        user-select: none;
+                        z-index: 10000;
+                    }
+
+                    @media (min-width: 970px) {
+                        .css-1lslle7 {
+                            overflow: hidden;
+                        }
+                    }
+
+                    .css-1lslle7 .wrap {
+                        width: 970px;
+                        margin: 0 auto;
+                        display: grid;
+                        -webkit-box-pack: justify;
+                        -webkit-justify-content: space-between;
+                        justify-content: space-between;
+                        -webkit-align-items: center;
+                        -webkit-box-align: center;
+                        -ms-flex-align: center;
+                        align-items: center;
+                        grid-template-areas: 'logo search promotions''nav nav nav';
+                    }
+
+                    .css-1lslle7 .wrap .main-logo {
+                        grid-area: logo;
+                        padding: 14px 0;
+                    }
+
+                    .css-1lslle7 .wrap .main-logo img {
+                        width: 164px;
+                        height: 40px;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar {
+                        grid-area: nav;
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        position: relative;
+                        -webkit-flex: 1;
+                        -ms-flex: 1;
+                        flex: 1;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar:before {
+                        content: '';
+                        position: absolute;
+                        top: -1px;
+                        height: 1px;
+                        background: #333333;
+                        left: -50%;
+                        right: -50%;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li {
+                        -webkit-flex: 1;
+                        -ms-flex: 1;
+                        flex: 1;
+                        text-align: center;
+                        border: solid 1px #333333;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li.only-sticky {
+                        display: none;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a,
+                    .css-1lslle7 .wrap .main-menu-bar li button {
+                        position: relative;
+                        height: 38px;
+                        color: #ffffff;
+                        font-family: 'almoni-demi-bold', arial;
+                        font-size: 17rem;
+                        line-height: 38px;
+                        display: block;
+                        width: 100%;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a:after {
+                        content: '';
+                        opacity: 0;
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        width: 100%;
+                        height: 2px;
+                        background: #666666;
+                        -webkit-transition: opacity 0.3s, -webkit-transform 0.3s;
+                        transition: opacity 0.3s, transform 0.3s;
+                        -webkit-transform: translateY(5px);
+                        -moz-transform: translateY(5px);
+                        -ms-transform: translateY(5px);
+                        transform: translateY(5px);
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a:hover:after,
+                    .css-1lslle7 .wrap .main-menu-bar li a:focus:after {
+                        opacity: 1;
+                        -webkit-transform: translateY(0);
+                        -moz-transform: translateY(0);
+                        -ms-transform: translateY(0);
+                        transform: translateY(0);
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-0:after {
+                        background-color: undefined;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-1:after {
+                        background-color: #1978bb;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-2:after {
+                        background-color: #cf041c;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-3:after {
+                        background-color: #e8997f;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-4:after {
+                        background-color: #643985;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-5:after {
+                        background-color: #b3932d;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-6:after {
+                        background-color: #c72564;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-7:after {
+                        background-color: #a2b427;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-8:after {
+                        background-color: #009fe4;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-9:after {
+                        background-color: #f26522;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-10:after {
+                        background-color: #913b97;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-11:after {
+                        background-color: #35466c;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li a.color-12:after {
+                        background-color: #25b4b1;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li button:hover .arrow,
+                    .css-1lslle7 .wrap .main-menu-bar li button:focus .arrow {
+                        -webkit-animation: animation-18l7q8n 0.8s infinite;
+                        animation: animation-18l7q8n 0.8s infinite;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li .yad2 {
+                        padding: 6px 0;
+                    }
+
+                    .css-1lslle7 .wrap .main-menu-bar li .yad2 img {
+                        margin: auto;
+                        width: 40px;
+                    }
+
+                    .css-1lslle7 .wrap .more {
+                        display: none;
+                        position: fixed;
+                        top: -100px;
+                        opacity: 0.6;
+                        -webkit-transition: 1s;
+                        transition: 1s;
+                        background: #1f1f1f;
+                        left: 0;
+                        right: 0;
+                        box-shadow: inset 1px 1px 10px black, #000000;
+                        padding: 30px 0;
+                        border-bottom: 4px solid black, #000000;
+                        height: 392px;
+                    }
+
+                    .css-1lslle7 .wrap .more.active {
+                        display: initial;
+                        top: 38px;
+                        opacity: 1;
+                    }
+
+                    .css-1lslle7 .wrap .more a:hover,
+                    .css-1lslle7 .wrap .more a:focus {
+                        -webkit-text-decoration: underline;
+                        text-decoration: underline;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists {
+                        max-width: 970px;
+                        margin: 0 auto;
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        -webkit-box-pack: justify;
+                        -webkit-justify-content: space-between;
+                        justify-content: space-between;
+                        height: 100%;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li {
+                        padding: 0 10px;
+                        background-color: #000000;
+                        -webkit-flex: 1;
+                        -ms-flex: 1;
+                        flex: 1;
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-1lslle7 .wrap .more .more-lists>li {
+                            height: auto;
+                        }
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li+li {
+                        margin: 0 10px;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li .title {
+                        font-family: 'almoni-regular', arial;
+                        font-size: 14rem;
+                        line-height: 32px;
+                        border-bottom: solid 1px #333333;
+                        color: #d8d8d8;
+                        margin-bottom: 7px;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul {
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        -webkit-flex-direction: column;
+                        -ms-flex-direction: column;
+                        flex-direction: column;
+                        -webkit-box-flex-wrap: wrap;
+                        -webkit-flex-wrap: wrap;
+                        -ms-flex-wrap: wrap;
+                        flex-wrap: wrap;
+                        max-height: 90%;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li {
+                        line-height: 28px;
+                        font-family: 'almoni-regular', arial;
+                        font-size: 14rem;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li .link-red {
+                        color: red;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li .link-orange {
+                        color: #f26522;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li .link-orange:hover {
+                        color: #ffffff;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li .link-zap:after,
+                    .css-1lslle7 .wrap .more .more-lists>li ul li .link-shops:after {
+                        content: '';
+                        display: inline-block;
+                        width: 16px;
+                        height: 16px;
+                        margin-right: 3px;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li .link-zap:hover,
+                    .css-1lslle7 .wrap .more .more-lists>li ul li .link-shops:hover {
+                        color: #ffffff;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li button {
+                        color: white;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li.with-toogle {
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li.with-toogle span {
+                        margin-left: auto;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li .link-shops:after {
+                        background-image: url('/public/assets/icons/wallashops.png');
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li ul li .link-zap:after {
+                        background: url('/public/assets/icons/zap.png') no-repeat center center;
+                        -webkit-background-size: contain;
+                        background-size: contain;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-site {
+                        -webkit-flex: 2.5;
+                        -ms-flex: 2.5;
+                        flex: 2.5;
+                        height: 320px;
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-site {
+                            height: auto;
+                        }
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-site ul li {
+                        width: 50%;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.shopping {
+                        -webkit-flex: 1.5;
+                        -ms-flex: 1.5;
+                        flex: 1.5;
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-1lslle7 .wrap .more .more-lists>li.shopping {
+                            height: auto;
+                        }
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.monster {
+                        background: transparent;
+                        padding: 0;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla {
+                        background: transparent;
+                        padding: 0;
+                        -webkit-flex: 2;
+                        -ms-flex: 2;
+                        flex: 2;
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-walla {
+                            height: auto;
+                        }
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul {
+                        margin-top: -6px;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li {
+                        border-bottom: solid 1px #333333;
+                        line-height: 32px;
+                        width: 50%;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a {
+                        display: block;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a:before {
+                        content: '';
+                        display: inline-block;
+                        width: 2px;
+                        height: 9px;
+                        margin-left: 10px;
+                        background-color: #ffffff;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a:hover,
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a:focus {
+                        background-color: #000000;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-0:before {
+                        background-color: undefined;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-1:before {
+                        background-color: #1978bb;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-2:before {
+                        background-color: #cf041c;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-3:before {
+                        background-color: #e8997f;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-4:before {
+                        background-color: #643985;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-5:before {
+                        background-color: #b3932d;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-6:before {
+                        background-color: #c72564;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-7:before {
+                        background-color: #a2b427;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-8:before {
+                        background-color: #009fe4;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-9:before {
+                        background-color: #f26522;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-10:before {
+                        background-color: #913b97;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-11:before {
+                        background-color: #35466c;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-12:before {
+                        background-color: #25b4b1;
+                    }
+
+                    .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a.color-sheee:before {
+                        background-color: #ff0ac5;
+                    }
+
+                    .css-1lslle7 .wrap .search-box {
+                        grid-area: search;
+                    }
+
+                    .css-1lslle7 .wrap .search-box form {
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        height: 28px;
+                    }
+
+                    .css-1lslle7 .wrap .search-box input {
+                        width: 285px;
+                        padding: 0 10px;
+                        background: #ffffff url('/public/assets/icons/google.gif') no-repeat right center;
+                        -webkit-background-position: right 10px center;
+                        background-position: right 10px center;
+                        height: 100%;
+                    }
+
+                    .css-1lslle7 .wrap .search-box input:focus {
+                        background: #ffffff;
+                    }
+
+                    .css-1lslle7 .wrap .search-box button {
+                        padding: 0 15px;
+                        background-color: #e81d82;
+                        color: #ffffff;
+                        height: 100%;
+                        font-size: 18rem;
+                        font-weight: bold;
+                        text-align: center;
+                    }
+
+                    .css-1lslle7 .wrap .promotions {
+                        grid-area: promotions;
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        -webkit-align-items: center;
+                        -webkit-box-align: center;
+                        -ms-flex-align: center;
+                        align-items: center;
+                    }
+
+                    .css-1lslle7 .wrap .promotions>*+* {
+                        margin-right: 30px;
+                    }
+
+                    @media (min-width: 970px) {
+                        .css-1lslle7.sticky {
+                            border-bottom: solid 4px var(--vertical-color, #1978bb);
+                            position: fixed;
+                            top: 0;
+                            left: 0;
+                            right: 0;
+                            -webkit-transition: 0.4s;
+                            transition: 0.4s;
+                        }
+
+                        .css-1lslle7.sticky.with-animation {
+                            top: -54px;
+                            -webkit-animation: animation-lwohc9 0.4s forwards;
+                            animation: animation-lwohc9 0.4s forwards;
+                        }
+
+                        .css-1lslle7.sticky .wrap {
+                            display: -webkit-box;
+                            display: -webkit-flex;
+                            display: -ms-flexbox;
+                            display: flex;
+                        }
+
+                        .css-1lslle7.sticky .wrap .no-sticky {
+                            display: none;
+                        }
+
+                        .css-1lslle7.sticky .wrap .main-menu-bar {
+                            margin-right: 15px;
+                        }
+
+                        .css-1lslle7.sticky .wrap .main-menu-bar:before {
+                            content: initial;
+                        }
+
+                        .css-1lslle7.sticky .wrap .main-menu-bar li {
+                            border-right: 0;
+                            border-bottom: 0;
+                            border-top: 0;
+                        }
+
+                        .css-1lslle7.sticky .wrap .main-menu-bar li:last-of-type {
+                            border-left: 0;
+                        }
+
+                        .css-1lslle7.sticky .wrap .main-menu-bar li.only-sticky {
+                            display: initial;
+                        }
+
+                        .css-1lslle7.sticky .wrap .main-menu-bar li:nth-child(3) {
+                            -webkit-flex: 2;
+                            -ms-flex: 2;
+                            flex: 2;
+                        }
+
+                        .css-1lslle7.sticky .wrap .main-logo {
+                            padding: 0;
+                        }
+
+                        .css-1lslle7.sticky .wrap .main-logo img {
+                            width: 98px;
+                            height: 24px;
+                        }
+
+                        .css-1lslle7.with-image-header {
+                            top: -42px;
+                        }
+                    }
+
+                    .css-1lslle7 .arrow {
+                        width: 13px;
+                        height: 13px;
+                        position: relative;
+                        display: inline-block;
+                    }
+
+                    .css-1lslle7 .arrow:before,
+                    .css-1lslle7 .arrow:after {
+                        content: '';
+                        position: absolute;
+                        display: inline-block;
+                        width: 8px;
+                        height: 1px;
+                        top: 8px;
+                        left: 2px;
+                        background-color: #ffffff;
+                        -webkit-transition: 0.4s;
+                        transition: 0.4s;
+                    }
+
+                    .css-1lslle7 .arrow:before {
+                        -webkit-transform: rotate(135deg);
+                        -moz-transform: rotate(135deg);
+                        -ms-transform: rotate(135deg);
+                        transform: rotate(135deg);
+                    }
+
+                    .css-1lslle7 .arrow:after {
+                        -webkit-transform: rotate(225deg);
+                        -moz-transform: rotate(225deg);
+                        -ms-transform: rotate(225deg);
+                        transform: rotate(225deg);
+                        left: -3px;
+                    }
+
+                    .css-1lslle7 .arrow.active {
+                        -webkit-animation: none !important;
+                        animation: none !important;
+                    }
+
+                    .css-1lslle7 .arrow.active:before {
+                        -webkit-transform: rotate(225deg);
+                        -moz-transform: rotate(225deg);
+                        -ms-transform: rotate(225deg);
+                        transform: rotate(225deg);
+                    }
+
+                    .css-1lslle7 .arrow.active:after {
+                        -webkit-transform: rotate(135deg);
+                        -moz-transform: rotate(135deg);
+                        -ms-transform: rotate(135deg);
+                        transform: rotate(135deg);
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-1lslle7 .wrap {
+                            display: -webkit-box;
+                            display: -webkit-flex;
+                            display: -ms-flexbox;
+                            display: flex;
+                            -webkit-flex-direction: column;
+                            -ms-flex-direction: column;
+                            flex-direction: column;
+                            width: 100%;
+                            background-color: #333333;
+                        }
+
+                        .css-1lslle7 .wrap .main-logo {
+                            display: none;
+                        }
+
+                        .css-1lslle7 .wrap .main-menu-bar {
+                            -webkit-flex-direction: column;
+                            -ms-flex-direction: column;
+                            flex-direction: column;
+                            width: 100%;
+                        }
+
+                        .css-1lslle7 .wrap .main-menu-bar:before {
+                            content: initial;
+                        }
+
+                        .css-1lslle7 .wrap .main-menu-bar li {
+                            border: 0;
+                            text-align: right;
+                        }
+
+                        .css-1lslle7 .wrap .main-menu-bar li.no-sticky {
+                            display: none;
+                        }
+
+                        .css-1lslle7 .wrap .main-menu-bar li a {
+                            display: block;
+                            padding: 0 10px;
+                            border-bottom: solid 1px #4c4c4c;
+                            font-size: 19rem;
+                        }
+
+                        .css-1lslle7 .wrap .main-menu-bar li .yad2 img {
+                            margin: 0 10px 0 0;
+                        }
+
+                        .css-1lslle7 .wrap .more {
+                            display: block;
+                            position: static;
+                            width: 100%;
+                            opacity: 1;
+                            box-shadow: none;
+                            padding: 0;
+                            background: transparent;
+                            height: auto;
+                        }
+
+                        .css-1lslle7 .wrap .more .more-lists {
+                            -webkit-flex-direction: column;
+                            -ms-flex-direction: column;
+                            flex-direction: column;
+                        }
+
+                        .css-1lslle7 .wrap .more .more-lists>li {
+                            height: auto;
+                            background: transparent;
+                            margin: 0;
+                        }
+
+                        .css-1lslle7 .wrap .more .more-lists>li+li {
+                            margin: 0;
+                        }
+
+                        .css-1lslle7 .wrap .more .more-lists>li .title {
+                            color: #ffffff;
+                            background-color: #191919;
+                            padding: 0 10px;
+                        }
+
+                        .css-1lslle7 .wrap .more .more-lists>li.useful,
+                        .css-1lslle7 .wrap .more .more-lists>li.shopping,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-walla,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-site,
+                        .css-1lslle7 .wrap .more .more-lists>li {
+                            padding: 0;
+                            margin: 0;
+                        }
+
+                        .css-1lslle7 .wrap .more .more-lists>li.useful ul,
+                        .css-1lslle7 .wrap .more .more-lists>li.shopping ul,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-site ul,
+                        .css-1lslle7 .wrap .more .more-lists>li ul {
+                            padding: 0 10px;
+                            display: block;
+                        }
+
+                        .css-1lslle7 .wrap .more .more-lists>li.useful ul li,
+                        .css-1lslle7 .wrap .more .more-lists>li.shopping ul li,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-site ul li,
+                        .css-1lslle7 .wrap .more .more-lists>li ul li {
+                            width: 100%;
+                            border-bottom: solid 1px #4c4c4c;
+                        }
+
+                        .css-1lslle7 .wrap .more .more-lists>li.useful ul li a:before,
+                        .css-1lslle7 .wrap .more .more-lists>li.shopping ul li a:before,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li a:before,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-site ul li a:before,
+                        .css-1lslle7 .wrap .more .more-lists>li ul li a:before {
+                            content: none;
+                        }
+
+                        .css-1lslle7 .wrap .more .more-lists>li.useful ul li:last-of-type,
+                        .css-1lslle7 .wrap .more .more-lists>li.shopping ul li:last-of-type,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-walla ul li:last-of-type,
+                        .css-1lslle7 .wrap .more .more-lists>li.more-in-site ul li:last-of-type,
+                        .css-1lslle7 .wrap .more .more-lists>li ul li:last-of-type {
+                            border: 0;
+                        }
+
+                        .css-1lslle7 .wrap .promotions {
+                            background: #000000;
+                            width: 100%;
+                            padding: 10px 0;
+                        }
+                    }
+                </style>
+                <nav class="css-1lslle7 sticky" role="navigation">
+                    <div class="wrap"><a href="https://www.walla.co.il" class="main-logo"><img
+                                src="/public/assets/logo/logo_new.svg" alt="וואלה!" title="וואלה!" /></a>
+                        <div class="search-box no-sticky no-mobile">
+                            <form action="https://search.walla.co.il" method="GET"><input name="q" /><button
+                                    type="submit">חפש</button></form>
+                        </div>
+                        <ul role="menubar" class="main-menu-bar">
+                            <li role="menuitem" class=""><a href="https://news.walla.co.il" class="color-1">חדשות</a>
+                            </li>
+                            <li role="menuitem" class=""><a href="https://sports.walla.co.il" class="color-2">ספורט</a>
+                            </li>
+                            <li role="menuitem" class=""><a href="https://olympics.walla.co.il" class="color-2">טוקיו
+                                    2020</a></li>
+                            <li role="menuitem" class=""><a href="https://finance.walla.co.il" class="color-3">כסף</a>
+                            </li>
+                            <li role="menuitem" class=""><a href="https://e.walla.co.il/" class="color-4">תרבות</a></li>
+                            <li role="menuitem" class=""><a href="https://celebs.walla.co.il/" class="color-5">סלבס</a>
+                            </li>
+                            <li role="menuitem" class=""><a href="https://food.walla.co.il/" class="color-7">אוכל</a>
+                            </li>
+                            <li role="menuitem" class=""><a href="https://fashion.walla.co.il/"
+                                    class="color-6">אופנה</a></li>
+                            <li role="menuitem" class=""><a href="https://healthy.walla.co.il/"
+                                    class="color-8">בריאות</a></li>
+                            <li role="menuitem" class=" no-sticky"><a href="https://travel.walla.co.il/"
+                                    class="color-8">תיירות</a></li>
+                            <li role="menuitem" class=" no-sticky"><a href="https://tech.walla.co.il/"
+                                    class="color-9">טכנולוגיה</a></li>
+                            <li role="menuitem" class=" no-sticky"><a href="https://cars.walla.co.il/"
+                                    class="color-11">רכב</a></li>
+                            <li role="menuitem" class=""><a
+                                    href="https://www.wallashops.co.il/?utm_source=wallahp1&amp;amp;utm_medium=walla&amp;amp;utm_campaign=hpnemalakniut_1"
+                                    target="_blank" class="color-1">קניות</a></li>
+                            <li role="menuitem" class=" no-sticky"><a href="https://www.sheee.co.il/"
+                                    class="color-sheee">Sheee</a></li>
+                            <li role="menuitem" class="only-sticky"><a href="https://vod.walla.co.il/"
+                                    class="color-1">VOD</a></li>
+                            <li role="menuitem" class=" no-sticky"><a href="https://www.drushim.co.il"
+                                    target="_blank">דרושים</a></li>
+                            <li role="menuitem" class=""><a
+                                    href="https://www.yad2.co.il/?utm_source=Walla&amp;amp;utm_medium=Logo_main&amp;amp;site=Walla"
+                                    target="_blank" class="color-9 yad2 no-border"><img
+                                        src="/public/assets/icons/yad2.png" alt="יד 2" /></a></li>
+                            <li class="only-sticky"><button>עוד<span class="arrow "></span></button></li>
+                        </ul>
+                        <div class="more ">
+                            <ul class="more-lists">
+                                <li class="more-in-walla">
+                                    <div class="title">עוד באתר</div>
+                                    <ul role="menubar">
+                                        <li role="menuitem" class=""><a href="https://tech.walla.co.il/"
+                                                class="color-9">טכנולוגיה</a></li>
+                                        <li role="menuitem" class=""><a href="https://home.walla.co.il/"
+                                                class="color-6">בית</a></li>
+                                        <li role="menuitem" class=""><a href="https://cars.walla.co.il/"
+                                                class="color-11">רכב</a></li>
+                                        <li role="menuitem" class=""><a href="https://www.sheee.co.il/"
+                                                class="color-sheee">Sheee</a></li>
+                                        <li role="menuitem" class=""><a href="https://judaism.walla.co.il/"
+                                                class="color-8">יהדות</a></li>
+                                        <li role="menuitem" class=""><a
+                                                href="https://horoscope.walla.co.il/zodiacs">הורוסקופ</a></li>
+                                        <li role="menuitem" class=""><a
+                                                href="https://www.walla.co.il/podcast">פודקאסטים</a></li>
+                                        <li role="menuitem" class=""><a href="https://nadlan.walla.co.il/"
+                                                class="color-9">נדל&quot;ן</a></li>
+                                        <li role="menuitem" class=""><a href="https://tld.walla.co.il/"
+                                                class="color-8">טוב לדעת</a></li>
+                                        <li role="menuitem" class=""><a href="https://law.walla.co.il"
+                                                class="color-4">משפטי</a></li>
+                                        <li role="menuitem" class=""><a href="https://movies.walla.co.il/"
+                                                class="color-4">סרטים</a></li>
+                                        <li role="menuitem" class=""><a href="https://forums.walla.co.il">פורומים</a>
+                                        </li>
+                                        <li role="menuitem" class=""><a href="https://weather.walla.co.il/"
+                                                class="color-8">מזג אויר</a></li>
+                                        <li role="menuitem" class=""><a href="https://fun.walla.co.il/"
+                                                class="color-9">משחקים</a></li>
+                                        <li role="menuitem" class=""><a href="https://horoscope.walla.co.il/"
+                                                class="color-4">רוח</a></li>
+                                        <li role="menuitem" class=""><a href="https://b.walla.co.il/"
+                                                class="color-branja">ברנז&#x27;ה</a></li>
+                                        <li role="menuitem" class=""><a href="https://travel.walla.co.il/"
+                                                class="color-8">תיירות</a></li>
+                                    </ul>
+                                </li>
+                                <li class="useful">
+                                    <div class="title">שימושי</div>
+                                    <ul role="menubar">
+                                        <li role="menuitem" class=""><a href="https://calendar.walla.co.il/">לוח שנה</a>
+                                        </li>
+                                        <li role="menuitem" class=""><a href="https://tv-guide.walla.co.il/">לוח
+                                                שידורים</a></li>
+                                        <li role="menuitem" class=""><a href="https://mail.walla.co.il/">דואר</a></li>
+                                        <li role="menuitem" class=""><a href="https://www.walla.co.il/track">מעקב
+                                                משלוחים</a></li>
+                                        <li role="menuitem" class=""><a href="https://walla.co.il/shabbat-times">כניסת
+                                                שבת</a></li>
+                                        <li role="menuitem" class=""><a
+                                                href="https://www.b144.co.il/?sitecode=10&amp;subsitecode=1406&amp;site=walla&amp;utm_source=walla&amp;utm_medium=header">B144</a>
+                                        </li>
+                                        <li role="menuitem" class=""><a
+                                                href="https://www.migdal.co.il/campaign/car/walla-v1?utm_source=walla&amp;utm_medium=nivut_up&amp;utm_campaign=elementary_car_walla-2021_customer_sales_lead-online_v1"
+                                                target="_blank">וואלה! ביטוח</a></li>
+                                    </ul>
+                                </li>
+                                <li class="more-in-site">
+                                    <div class="title">עוד באתר</div>
+                                    <ul role="menubar">
+                                        <li role="menuitem" class=""><a href="https://theselected.walla.co.il"
+                                                class="color-8">הנבחרים</a></li>
+                                        <li role="menuitem" class=""><a href="https://mumlazim.walla.co.il/"
+                                                class="color-10">מומלצים</a></li>
+                                        <li role="menuitem" class=""><a href="https://b144.walla.co.il/"
+                                                target="_blank">עסקים קטנים</a></li>
+                                        <li role="menuitem" class=""><a href="https://yoram.walla.co.il/">לימודים</a>
+                                        </li>
+                                        <li role="menuitem" class=""><a href="https://career.walla.co.il/"
+                                                class="link-orange">חיפוש עבודה</a></li>
+                                        <li role="menuitem" class=""><a href="https://paisculture.walla.co.il/"
+                                                target="_blank">פיס בתרבות</a></li>
+                                        <li role="menuitem" class=""><a href="https://www.drushim.co.il/">דרושים</a>
+                                        </li>
+                                        <li role="menuitem" class=""><a href="https://turkish.walla.co.il/">טורקי מוציא
+                                                ממך יותר</a></li>
+                                        <li role="menuitem" class=""><a href="https://gemara.walla.co.il"
+                                                target="_blank">הדף היומי</a></li>
+                                        <li role="menuitem" class=""><a href="https://bemazal.walla.co.il/"
+                                                class="color-7">שיהיה במזל</a></li>
+                                        <li role="menuitem" class=""><a href="https://malti.walla.co.il/"
+                                                target="_blank">בא בטוב עם מאלטי</a></li>
+                                        <li role="menuitem" class=""><a href="https://starkist.walla.co.il/"
+                                                target="_blank">כל מה שטוב בטונה</a></li>
+                                        <li role="menuitem" class=""><a href="https://www.democratv.org/"
+                                                target="_blank">דמוקרטTV</a></li>
+                                    </ul>
+                                </li>
+                                <li class="shopping">
+                                    <div class="title">קניות</div>
+                                    <ul role="menubar">
+                                        <li role="menuitem" class=""><a
+                                                href="https://www.wallashops.co.il/%D7%93%D7%99%D7%9C-%D7%99%D7%95%D7%9E%D7%99?utm_source=WALLA&amp;utm_medium=text_linkHP&amp;utm_campaign=dilyomi"
+                                                target="_blank">דיל יומי</a></li>
+                                        <li role="menuitem" class=""><a
+                                                href="https://www.wallashops.co.il/?utm_source=WALLA&amp;utm_medium=text_linkHP&amp;utm_campaign=wallashops"
+                                                target="_blank" class="link-red link-shops">וואלה!שופס</a></li>
+                                        <li role="menuitem" class=""><a
+                                                href="https://www.wallashops.co.il/?utm_source=WALLA&amp;utm_medium=text_linkHP&amp;utm_campaign=mivtzeim"
+                                                target="_blank">מבצעים</a></li>
+                                        <li role="menuitem" class=""><a href="https://www.wallatours.co.il/zimmer/"
+                                                target="_blank">צימרים</a></li>
+                                        <li role="menuitem" class=""><a
+                                                href="https://www.wallaprint.co.il/?utm_source=WALLA&amp;utm_medium=HP&amp;utm_campaign=PRINTtext"
+                                                target="_blank">אלבומים</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <div class="title">צפייה ישירה</div>
+                                    <ul role="menubar">
+                                        <li role="menuitem" class=""><a href="https://vod.walla.co.il/movies">סרטים</a>
+                                        </li>
+                                        <li role="menuitem" class=""><a href="https://vod.walla.co.il/tvshows">סדרות</a>
+                                        </li>
+                                        <li role="menuitem" class=""><a href="https://viva.walla.co.il/">ויוה</a></li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <div class="title">הגדרות</div>
+                                    <ul role="menubar">
+                                        <li role="menuitem" class="with-toogle dark-mode-switch" style="display:none">
+                                            <span>מצב כהה</span>
+                                            <style data-emotion="css 11g38a3">
+                                                .css-11g38a3 {
+                                                    position: relative;
+                                                    display: inline-block;
+                                                }
+
+                                                .css-11g38a3 input.mobileToggle {
+                                                    opacity: 0;
+                                                    position: absolute;
+                                                }
+
+                                                .css-11g38a3 input.mobileToggle+label {
+                                                    position: relative;
+                                                    display: inline-block;
+                                                    -webkit-user-select: none;
+                                                    -moz-user-select: none;
+                                                    -ms-user-select: none;
+                                                    user-select: none;
+                                                    -webkit-transition: 0.4s ease;
+                                                    transition: 0.4s ease;
+                                                    width: 34px;
+                                                    height: 14px;
+                                                    background-color: #b2b1b3;
+                                                    border-radius: 50px;
+                                                }
+
+                                                .css-11g38a3 input.mobileToggle+label:after {
+                                                    content: '';
+                                                    position: absolute;
+                                                    display: block;
+                                                    box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.1), 0 4px 0px 0 hsla(0, 0%, 0%, 0.04), 0 4px 9px hsla(0, 0%, 0%, 0.13), 0 3px 3px hsla(0, 0%, 0%, 0.05);
+                                                    -webkit-transition: 0.35s cubic-bezier(0.54, 1.6, 0.5, 1);
+                                                    transition: 0.35s cubic-bezier(0.54, 1.6, 0.5, 1);
+                                                    background: whitesmoke;
+                                                    height: 20px;
+                                                    width: 20px;
+                                                    top: -3px;
+                                                    left: 1px;
+                                                    border-radius: 60px;
+                                                }
+
+                                                .css-11g38a3 input.mobileToggle:checked+label {
+                                                    background-color: #00aeef;
+                                                }
+
+                                                .css-11g38a3 input.mobileToggle:checked+label:after {
+                                                    left: 100%;
+                                                    -webkit-transform: translateX(-70%);
+                                                    -moz-transform: translateX(-70%);
+                                                    -ms-transform: translateX(-70%);
+                                                    transform: translateX(-70%);
+                                                }
+                                            </style>
+                                            <div class="css-11g38a3"><input type="checkbox" name="darkmode"
+                                                    class="mobileToggle" id="darkmode" /><label for="darkmode">
+                                                    <div class="screen-reader">מצב חשוך</div>
+                                                </label></div>
+                                        </li>
+                                        <li role="menuitem"><button>נגישות</button></li>
+                                    </ul>
+                                    <div class="title">פיקוד העורף</div>
+                                    <ul role="menubar">
+                                        <li role="menuitem" class="with-toogle"><span>הפעל</span>
+                                            <div class="css-11g38a3"><input type="checkbox" name="pikud"
+                                                    class="mobileToggle" id="pikud" checked="" /><label for="pikud">
+                                                    <div class="screen-reader">פיקוד העורף</div>
+                                                </label></div>
+                                        </li>
+                                        <li role="menuitem" class="with-toogle"><span>צליל</span>
+                                            <div class="css-11g38a3"><input type="checkbox" name="pikud-sound"
+                                                    class="mobileToggle" id="pikud-sound" checked="" /><label
+                                                    for="pikud-sound">
+                                                    <div class="screen-reader">צליל פיקוד העורף</div>
+                                                </label></div>
+                                        </li>
+                                    </ul>
+                                </li>
+                                <li class="only-mobile">
+                                    <div class="title">שונות</div>
+                                    <ul role="menubar">
+                                        <li role="menuitem" class=""><a href="https://help.walla.co.il"
+                                                class="only-mobile">עזרה</a></li>
+                                        <li role="menuitem" class=""><a href="https://help.walla.co.il/section/12344"
+                                                class="only-mobile">כתבו לנו</a></li>
+                                        <li role="menuitem" class=""><a
+                                                href="https://dcx.walla.co.il/walla/terms/terms.pdf"
+                                                class="only-mobile">תנאי שימוש</a></li>
+                                        <li role="menuitem" class=""><a
+                                                href="https://dcx.walla.co.il/walla/terms/PrivacyPolicy.pdf"
+                                                class="only-mobile">מדיניות פרטיות</a></li>
+                                        <li role="menuitem" class=""><a href="https://www.walla.co.il/about"
+                                                class="only-mobile">אודות</a></li>
+                                        <li role="menuitem" class=""><a href="https://apps.walla.co.il"
+                                                class="only-mobile">אפליקציות</a></li>
+                                        <li role="menuitem" class=""><a href="https://www.walla.co.il/writers"
+                                                class="only-mobile">כתבים</a></li>
+                                        <li role="menuitem" class=""><a href="https://www.walla.co.il/archive"
+                                                class="only-mobile">ארכיון</a></li>
+                                        <li role="menuitem" class=""><a href="https://www.walla.co.il/rss"
+                                                class="only-mobile">RSS</a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="promotions">
+                            <div class="vod no-sticky no-mobile"><a href="https://vod.walla.co.il"><img
+                                        src="/public/assets/icons/vod.png" alt="VOD" /></a></div>
+                            <div class="css-bu25vf  "><a href="https://mail.walla.co.il">
+                                    <div class="wrap"><span class="walla-icon-envelop"></span></div>
+                                    <div class="name-read">
+                                        <div class="name">וואלה! דואר</div>
+                                        <div class="read">קרא דואר</div>
+                                    </div>
+                                </a></div>
+                        </div>
+                    </div>
+                </nav>
+                <style data-emotion="css d70xps">
+                    .css-d70xps {
+                        background-color: var(--vertical-color, #1978bb);
+                        color: #ffffff;
+                        -webkit-user-select: none;
+                        -moz-user-select: none;
+                        -ms-user-select: none;
+                        user-select: none;
+                        margin-top: 42px;
+                    }
+
+                    .css-d70xps.header-image {
+                        margin-top: 0;
+                    }
+
+                    .css-d70xps.header-image .wrap .vertical-name {
+                        margin-top: 0;
+                    }
+
+                    .css-d70xps .wrap {
+                        width: 970px;
+                        margin: 0 auto;
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        margin-top: -4px;
+                        padding: 2px 0 0;
+                    }
+
+                    .css-d70xps .wrap>a {
+                        z-index: 1000;
+                        white-space: nowrap;
+                    }
+
+                    .css-d70xps .wrap .vertical-name {
+                        font-family: 'almoni-demi-bold', arial;
+                        font-size: 42rem;
+                        line-height: 40px;
+                        margin-left: 15px;
+                        margin-top: -2px;
+                    }
+
+                    .css-d70xps .wrap .vertical-name.small-font {
+                        font-size: 30rem;
+                    }
+
+                    .css-d70xps .wrap .collaboration-with {
+                        font-size: 12rem;
+                        line-height: 1.2;
+                        border: solid 3px rgba(255, 255, 255, 0.5);
+                        border-width: 3px 0;
+                        -webkit-align-self: center;
+                        -ms-flex-item-align: center;
+                        align-self: center;
+                        padding: 2px;
+                        margin-right: -10px;
+                        margin-left: 5px;
+                    }
+
+                    .css-d70xps .wrap .header-sponsership-image {
+                        margin-right: auto;
+                        margin-top: 2px;
+                    }
+
+                    .css-d70xps .wrap .icon-buttons {
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        margin-right: auto;
+                        -webkit-align-items: center;
+                        -webkit-box-align: center;
+                        -ms-flex-align: center;
+                        align-items: center;
+                        padding-bottom: 4px;
+                    }
+
+                    .css-d70xps .wrap .icon-buttons li {
+                        width: 25px;
+                        height: 25px;
+                        background-color: rgba(0, 0, 0, 0.23);
+                        border-radius: 50%;
+                        margin-right: 3px;
+                        -webkit-transition: 0.3s;
+                        transition: 0.3s;
+                        z-index: 1000;
+                    }
+
+                    .css-d70xps .wrap .icon-buttons li a:before {
+                        font-size: 16.5rem;
+                    }
+
+                    .css-d70xps .wrap .icon-buttons li:hover {
+                        background-color: #ffffff;
+                    }
+
+                    .css-d70xps .wrap .icon-buttons li:hover a:before {
+                        color: var(--vertical-color);
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-d70xps .wrap .icon-buttons {
+                            display: none;
+                        }
+                    }
+
+                    .css-d70xps .wrap .vertical-menu {
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0 {
+                        line-height: 39px;
+                        position: relative;
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0>a,
+                    .css-d70xps .wrap .vertical-menu .level-0 span {
+                        margin-top: 12px;
+                        padding: 3px 6px 11px 6px;
+                        line-height: 25px;
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0+.level-0:before {
+                        content: '';
+                        width: 0;
+                        height: 14px;
+                        border-right: solid 1px rgba(255, 255, 255, 0.3);
+                        display: inline-block;
+                        vertical-align: middle;
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0 .submenu {
+                        top: 39px;
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0 .subsubmenu {
+                        right: 100%;
+                        top: 0;
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0 .submenu,
+                    .css-d70xps .wrap .vertical-menu .level-0 .subsubmenu {
+                        position: absolute;
+                        z-index: 10000;
+                        background: red;
+                        min-width: 110px;
+                        background-color: var(--gray10, #f2f2f2);
+                        height: 0;
+                        overflow: hidden;
+                    }
+
+                    @media (max-width: 969px) {
+
+                        .css-d70xps .wrap .vertical-menu .level-0 .submenu.force-open,
+                        .css-d70xps .wrap .vertical-menu .level-0 .subsubmenu.force-open {
+                            height: auto;
+                            position: initial;
+                        }
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0 .submenu>li,
+                    .css-d70xps .wrap .vertical-menu .level-0 .subsubmenu>li {
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                        overflow: hidden;
+                        min-width: 110px;
+                        font-size: 15rem;
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0 .submenu>li a,
+                    .css-d70xps .wrap .vertical-menu .level-0 .subsubmenu>li a {
+                        border-top: solid 1px var(--gray7, #b2b2b2);
+                        display: block;
+                        padding: 0 7px 0 17px;
+                        height: 30px;
+                        line-height: 30px;
+                        color: var(--gray3, #4c4c4c);
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0 .submenu>li a:hover,
+                    .css-d70xps .wrap .vertical-menu .level-0 .subsubmenu>li a:hover,
+                    .css-d70xps .wrap .vertical-menu .level-0 .submenu>li a:focus,
+                    .css-d70xps .wrap .vertical-menu .level-0 .subsubmenu>li a:focus {
+                        color: #1978bb;
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0 .submenu>li.with-subsubmenu,
+                    .css-d70xps .wrap .vertical-menu .level-0 .subsubmenu>li.with-subsubmenu {
+                        position: relative;
+                        overflow: initial;
+                    }
+
+                    .css-d70xps .wrap .vertical-menu .level-0 .walla-icon-prev:before,
+                    .css-d70xps .wrap .vertical-menu .level-n .walla-icon-prev:before,
+                    .css-d70xps .wrap .vertical-menu .level-0 .walla-icon-next:before,
+                    .css-d70xps .wrap .vertical-menu .level-n .walla-icon-next:before {
+                        font-size: 15px;
+                        color: var(--gray4, #666666);
+                    }
+
+                    @media (min-width: 970px) {
+
+                        .css-d70xps .wrap .vertical-menu .level-0 .walla-icon-next,
+                        .css-d70xps .wrap .vertical-menu .level-n .walla-icon-next {
+                            position: absolute;
+                            top: 50%;
+                            left: 3px;
+                            -webkit-transform: translateY(-50%);
+                            -moz-transform: translateY(-50%);
+                            -ms-transform: translateY(-50%);
+                            transform: translateY(-50%);
+                        }
+
+                        .css-d70xps .wrap .vertical-menu .level-0 .walla-icon-prev,
+                        .css-d70xps .wrap .vertical-menu .level-n .walla-icon-prev {
+                            display: none;
+                        }
+                    }
+
+                    @media (max-width: 969px) {
+
+                        .css-d70xps .wrap .vertical-menu .level-0 .walla-icon-next,
+                        .css-d70xps .wrap .vertical-menu .level-n .walla-icon-next {
+                            display: none;
+                        }
+
+                        .css-d70xps .wrap .vertical-menu .level-0 .walla-icon-prev,
+                        .css-d70xps .wrap .vertical-menu .level-n .walla-icon-prev {
+                            position: absolute;
+                            left: 3px;
+                            top: 10px;
+                            -webkit-transform: rotate(90deg);
+                            -moz-transform: rotate(90deg);
+                            -ms-transform: rotate(90deg);
+                            transform: rotate(90deg);
+                            -webkit-transition: 0.4s;
+                            transition: 0.4s;
+                            outline: 0;
+                        }
+
+                        .css-d70xps .wrap .vertical-menu .level-0 .walla-icon-prev.open,
+                        .css-d70xps .wrap .vertical-menu .level-n .walla-icon-prev.open {
+                            -webkit-transform: rotate(-90deg);
+                            -moz-transform: rotate(-90deg);
+                            -ms-transform: rotate(-90deg);
+                            transform: rotate(-90deg);
+                        }
+                    }
+
+                    @media (min-width: 970px) {
+
+                        .css-d70xps .wrap .vertical-menu .level-0:hover>a,
+                        .css-d70xps .wrap .vertical-menu .level-n:hover>a,
+                        .css-d70xps .wrap .vertical-menu .level-0:focus>a,
+                        .css-d70xps .wrap .vertical-menu .level-n:focus>a,
+                        .css-d70xps .wrap .vertical-menu .level-0:hover span,
+                        .css-d70xps .wrap .vertical-menu .level-n:hover span,
+                        .css-d70xps .wrap .vertical-menu .level-0:focus span,
+                        .css-d70xps .wrap .vertical-menu .level-n:focus span {
+                            background-color: var(--white, #ffffff);
+                            color: var(--gray4, #666666);
+                        }
+
+                        .css-d70xps .wrap .vertical-menu .level-0:hover>.submenu,
+                        .css-d70xps .wrap .vertical-menu .level-n:hover>.submenu,
+                        .css-d70xps .wrap .vertical-menu .level-0:focus>.submenu,
+                        .css-d70xps .wrap .vertical-menu .level-n:focus>.submenu,
+                        .css-d70xps .wrap .vertical-menu .level-0:hover>.subsubmenu,
+                        .css-d70xps .wrap .vertical-menu .level-n:hover>.subsubmenu,
+                        .css-d70xps .wrap .vertical-menu .level-0:focus>.subsubmenu,
+                        .css-d70xps .wrap .vertical-menu .level-n:focus>.subsubmenu {
+                            height: auto;
+                            border: solid 1px var(--gray6, #999999);
+                            border-top: 0;
+                            overflow: initial;
+                        }
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-d70xps {
+                            margin-top: 0;
+                            margin-top: 0;
+                        }
+
+                        .css-d70xps .wrap {
+                            -webkit-flex-direction: column;
+                            -ms-flex-direction: column;
+                            flex-direction: column;
+                            width: 100%;
+                        }
+
+                        .css-d70xps .wrap .vertical-name {
+                            line-height: 46px;
+                            font-size: 25rem;
+                            padding: 2px 10px;
+                        }
+
+                        .css-d70xps .wrap .vertical-name.small-font {
+                            font-size: 23rem;
+                        }
+
+                        .css-d70xps .wrap .vertical-menu {
+                            -webkit-flex-direction: column;
+                            -ms-flex-direction: column;
+                            flex-direction: column;
+                            background-color: var(--gray10, #f2f2f2);
+                            color: var(--black, #000000);
+                        }
+
+                        .css-d70xps .wrap .vertical-menu li {
+                            margin: 0 9px;
+                            border-bottom: solid 1px var(--gray7, #b2b2b2);
+                        }
+                    }
+                </style>
+                <nav class="css-d70xps " role="navigation">
+                    <div class="wrap"><a href="https://news.walla.co.il">
+                            <div class="vertical-name ">חדשות</div>
+                        </a>
+                        <ul class="vertical-menu">
+                            <li class="level-0"><a href="/breaking">מבזקים</a></li>
+                            <li class="level-0"><a href="/category/12837">קורונה</a></li>
+                            <li class="level-0"><a href="/category/2689">צבא וביטחון</a></li>
+                            <li class="level-0"><a href="/category/1">חדשות בארץ</a><button
+                                    class="mobile-force-open walla-icon-prev "></button>
+                                <ul class="submenu ">
+                                    <li class="level-n "><a href="/category/4487" target="_self">אירועים בארץ</a></li>
+                                    <li class="level-n "><a href="/category/10" target="_self">חדשות פלילים ומשפט</a>
+                                    </li>
+                                    <li class="level-n "><a href="/category/94" target="_self">חינוך</a></li>
+                                    <li class="level-n "><a href="/category/18" target="_self">בריאות</a></li>
+                                    <li class="level-n "><a href="/category/90" target="_self">חברה ורווחה</a></li>
+                                </ul>
+                            </li>
+                            <li class="level-0"><a href="/category/2686">פוליטי-מדיני</a><button
+                                    class="mobile-force-open walla-icon-prev "></button>
+                                <ul class="submenu ">
+                                    <li class="level-n "><a href="/category/9" target="_self">פוליטיקה וממשל</a></li>
+                                    <li class="level-n "><a href="/category/2687" target="_self">יחסי חוץ</a></li>
+                                </ul>
+                            </li>
+                            <li class="level-0"><a href="/category/2">חדשות בעולם</a><button
+                                    class="mobile-force-open walla-icon-prev "></button>
+                                <ul class="submenu ">
+                                    <li class="level-n "><a href="/category/13" target="_self">המזרח התיכון</a></li>
+                                    <li class="level-n "><a href="/category/14" target="_self">אירופה</a></li>
+                                    <li class="level-n "><a href="/category/15" target="_self">אמריקה</a></li>
+                                    <li class="level-n "><a href="/category/16" target="_self">אסיה והפסיפיק</a></li>
+                                    <li class="level-n "><a href="/category/17" target="_self">אפריקה</a></li>
+                                </ul>
+                            </li>
+                            <li class="level-0"><a>עוד בחדשות</a><button
+                                    class="mobile-force-open walla-icon-prev "></button>
+                                <ul class="submenu ">
+                                    <li class="level-n "><a href="/category/12942" target="_self">חיסון לקורונה</a></li>
+                                    <li class="level-n "><a href="https://elections.walla.co.il/" target="_self">בחירות
+                                            2021</a></li>
+                                    <li class="level-n "><a href="https://usaelections.walla.co.il"
+                                            target="_blank">בחירות בארה&quot;ב</a></li>
+                                    <li class="level-n "><a href="/category/4996" target="_self">דעות ופרשנויות</a></li>
+                                    <li class="level-n "><a href="/category/5606" target="_self">מיוחד</a></li>
+                                    <li class="level-n with-subsubmenu"><a href="/category/5108" target="_self">אסור
+                                            לפספס</a>
+                                        <div class="walla-icon-next"></div><button
+                                            class="mobile-force-open walla-icon-prev "></button>
+                                        <ul class="subsubmenu ">
+                                            <li class="level-n "><a href="/category/12145" target="_self">חמישה
+                                                    דברים</a></li>
+                                        </ul>
+                                    </li>
+                                    <li class="level-n "><a href="https://news.walla.co.il/item/3333875"
+                                            target="_self">הנחיות פיקוד העורף</a></li>
+                                    <li class="level-n with-subsubmenu"><a href="/category/5700" target="_self">מדע
+                                            וסביבה</a>
+                                        <div class="walla-icon-next"></div><button
+                                            class="mobile-force-open walla-icon-prev "></button>
+                                        <ul class="subsubmenu ">
+                                            <li class="level-n "><a href="/category/4488" target="_self">טבע ואיכות
+                                                    הסביבה</a></li>
+                                            <li class="level-n "><a href="/category/4489" target="_self">מדע ומחקר</a>
+                                            </li>
+                                            <li class="level-n "><a href="/category/4490" target="_self">בעלי חיים</a>
+                                            </li>
+                                            <li class="level-n "><a href="/category/4491" target="_self">חלל</a></li>
+                                        </ul>
+                                    </li>
+                                    <li class="level-n with-subsubmenu"><a href="/category/3062" target="_self">ארכיון
+                                            מדורים</a>
+                                        <div class="walla-icon-next"></div><button
+                                            class="mobile-force-open walla-icon-prev "></button>
+                                        <ul class="subsubmenu ">
+                                            <li class="level-n "><a href="/category/4492" target="_self">מהדורה
+                                                    מקומית</a></li>
+                                            <li class="level-n "><a href="/category/117" target="_self">מסביב לעולם
+                                                    בדקה</a></li>
+                                            <li class="level-n "><a href="/category/12179" target="_self">בחירות
+                                                    בארה&quot;ב</a></li>
+                                            <li class="level-n "><a href="/category/3836" target="_self">בחירות 2015</a>
+                                            </li>
+                                            <li class="level-n "><a href="/category/2787" target="_self">סוגרים שנה</a>
+                                            </li>
+                                            <li class="level-n "><a href="/category/116" target="_self">המהדורה</a></li>
+                                            <li class="level-n "><a href="/category/3892" target="_self">שיחת חוץ</a>
+                                            </li>
+                                            <li class="level-n "><a href="/category/3895" target="_self">פניית פרסה</a>
+                                            </li>
+                                            <li class="level-n "><a>חדשות המדע</a></li>
+                                            <li class="level-n "><a href="/category/3891" target="_self">פוסט פוליטי</a>
+                                            </li>
+                                            <li class="level-n "><a href="/category/3894" target="_self">המוביל
+                                                    הדרומי</a></li>
+                                            <li class="level-n "><a href="/category/3896" target="_self">חשאי בחמישי</a>
+                                            </li>
+                                            <li class="level-n "><a href="/category/3897" target="_self">נוהל שכן</a>
+                                            </li>
+                                            <li class="level-n "><a href="/category/91" target="_self">עת חפירה</a></li>
+                                            <li class="level-n "><a href="/category/2780" target="_self">בחירות 2013</a>
+                                            </li>
+                                            <li class="level-n "><a href="/category/115" target="_self">בחירות
+                                                    בארה&quot;ב 2012</a></li>
+                                        </ul>
+                                    </li>
+                                    <li class="level-n "><a href="https://news.walla.co.il/item/3061281"
+                                            target="_self">חגים ומועדים</a></li>
+                                    <li class="level-n "><a href="/item/2773368" target="_self">המייל האדום</a></li>
+                                </ul>
+                            </li>
+                        </ul>
+                        <ul class="icon-buttons">
+                            <li><a href="https://play.google.com/store/apps/details?id=com.walla" target="_blank"
+                                    class="walla-icon-android" title="אפליקציית אנדרויד" rel="noreferrer"><span
+                                        class="screen-reader">אפליקציית אנדרויד</span></a></li>
+                            <li><a href="https://itunes.apple.com/il/app/walla!-!ww-lh/id336751384?mt=8" target="_blank"
+                                    class="walla-icon-apple" title="אפליקציית אייפון" rel="noreferrer"><span
+                                        class="screen-reader">אפליקציית אייפון</span></a></li>
+                            <li><a href="https://twitter.com/wallanews" target="_blank" class="walla-icon-twitter"
+                                    title="טוויטר" rel="noreferrer"><span class="screen-reader">טוויטר</span></a></li>
+                            <li><a href="https://www.facebook.com/wallanews" target="_blank" class="walla-icon-facebook"
+                                    title="פייסבוק" rel="noreferrer"><span class="screen-reader">פייסבוק</span></a></li>
+                        </ul>
+                    </div>
+                </nav>
+            </header>
+            <div data-interstitial="true" class="no-desktop"></div>
+            <style data-emotion="css 111x2nu">
+                .css-111x2nu {
+                    position: fixed;
+                    top: 50%;
+                    left: -200%;
+                    -webkit-transform: translateY(-50%);
+                    -moz-transform: translateY(-50%);
+                    -ms-transform: translateY(-50%);
+                    transform: translateY(-50%);
+                    opacity: 0;
+                    -webkit-transition: opacity 0.5s;
+                    transition: opacity 0.5s;
+                    transition-delay: 0.5s;
+                }
+
+                .css-111x2nu li {
+                    margin-bottom: 10px;
+                }
+
+                .css-111x2nu li:last-of-type {
+                    margin-bottom: 0;
+                }
+
+                .css-111x2nu li picture {
+                    padding-top: 0 !important;
+                }
+
+                .css-111x2nu li picture source,
+                .css-111x2nu li picture img {
+                    position: relative;
+                }
+            </style>
+            <section class="shdera css-111x2nu no-mobile">
+                <ul>
+                    <li><a href="https://b144.walla.co.il/" target="_blank">
+                            <style data-emotion="css 1iqw88f">
+                                .css-1iqw88f {
+                                    width: 100%;
+                                    overflow: hidden;
+                                }
+
+                                .css-1iqw88f .live,
+                                .css-1iqw88f .gallery,
+                                .css-1iqw88f .podcast,
+                                .css-1iqw88f .opinion {
+                                    background-image: url('/public/assets/icons/walla-sprite.svg');
+                                    background-repeat: no-repeat;
+                                    display: inline-block;
+                                    vertical-align: middle;
+                                    position: absolute;
+                                    top: 0px;
+                                    left: 0px;
+                                    z-index: 1;
+                                }
+
+                                .css-1iqw88f .gallery,
+                                .css-1iqw88f .podcast,
+                                .css-1iqw88f .opinion {
+                                    width: 26px;
+                                    height: 26px;
+                                }
+
+                                .css-1iqw88f .live {
+                                    -webkit-background-position: -133px -172px;
+                                    background-position: -133px -172px;
+                                    width: 30px;
+                                    height: 45px;
+                                }
+
+                                .css-1iqw88f .gallery {
+                                    -webkit-background-position: -3px -175px;
+                                    background-position: -3px -175px;
+                                }
+
+                                .css-1iqw88f .podcast {
+                                    -webkit-background-position: -35px -174px;
+                                    background-position: -35px -174px;
+                                }
+
+                                .css-1iqw88f .opinion {
+                                    -webkit-background-position: -70px -175px;
+                                    background-position: -70px -175px;
+                                }
+
+                                .css-1iqw88f .play-indicator:before {
+                                    width: 26px;
+                                    height: 26px;
+                                    -webkit-background-position: -102px -175px;
+                                    background-position: -102px -175px;
+                                    margin: 0;
+                                }
+
+                                .css-1iqw88f .parental-control {
+                                    width: 32px;
+                                    height: 32px;
+                                    font-size: 18rem;
+                                    padding: 5px 2px 5px 5px;
+                                    top: 5px;
+                                    right: 5px;
+                                    z-index: 1;
+                                    border-radius: 50%;
+                                    background-color: #FF0000;
+                                    color: var(--white, #ffffff);
+                                    text-align: center;
+                                    font-family: 'almoni-demi-bold', arial;
+                                    display: inline-block;
+                                    vertical-align: middle;
+                                    position: absolute;
+                                }
+
+                                .css-1iqw88f .parental-control:after {
+                                    content: '+18';
+                                }
+
+                                .css-1iqw88f .main-media .gallery,
+                                .css-1iqw88f .main-media .podcast,
+                                .css-1iqw88f .main-media .opinion {
+                                    width: 64px;
+                                    height: 65px;
+                                }
+
+                                .css-1iqw88f .main-media .live {
+                                    -webkit-background-position: 0 -335px;
+                                    background-position: 0 -335px;
+                                    width: 65px;
+                                    height: 90px;
+                                }
+
+                                .css-1iqw88f .main-media .gallery {
+                                    -webkit-background-position: 0 -270px;
+                                    background-position: 0 -270px;
+                                }
+
+                                .css-1iqw88f .main-media .podcast {
+                                    -webkit-background-position: 0 -205px;
+                                    background-position: 0 -205px;
+                                }
+
+                                .css-1iqw88f .main-media .opinion {
+                                    -webkit-background-position: -65px -205px;
+                                    background-position: -65px -205px;
+                                }
+
+                                .css-1iqw88f .main-media .play-indicator:before {
+                                    width: 45px;
+                                    height: 45px;
+                                    -webkit-background-position: -75px -280px;
+                                    background-position: -75px -280px;
+                                    margin: 5px;
+                                }
+
+                                .css-1iqw88f .main-media .parental-control {
+                                    width: 40px;
+                                    height: 40px;
+                                    font-size: 23rem;
+                                    padding: 5px 4px 5px 6px;
+                                    top: 7px;
+                                    right: 10px;
+                                    z-index: 1;
+                                    border-radius: 50%;
+                                    background-color: #FF0000;
+                                    color: var(--white, #ffffff);
+                                    text-align: center;
+                                    font-family: 'almoni-demi-bold', arial;
+                                    display: inline-block;
+                                    vertical-align: middle;
+                                    position: absolute;
+                                }
+
+                                .css-1iqw88f .main-media .parental-control:after {
+                                    content: '+18';
+                                }
+
+                                @media (max-width: 969px) {
+
+                                    .css-1iqw88f .main-media .gallery,
+                                    .css-1iqw88f .main-media .podcast,
+                                    .css-1iqw88f .main-media .opinion {
+                                        width: 26px;
+                                        height: 26px;
+                                    }
+
+                                    .css-1iqw88f .main-media .live {
+                                        -webkit-background-position: -133px -172px;
+                                        background-position: -133px -172px;
+                                        width: 30px;
+                                        height: 45px;
+                                    }
+
+                                    .css-1iqw88f .main-media .gallery {
+                                        -webkit-background-position: -3px -175px;
+                                        background-position: -3px -175px;
+                                    }
+
+                                    .css-1iqw88f .main-media .podcast {
+                                        -webkit-background-position: -35px -174px;
+                                        background-position: -35px -174px;
+                                    }
+
+                                    .css-1iqw88f .main-media .opinion {
+                                        -webkit-background-position: -70px -175px;
+                                        background-position: -70px -175px;
+                                    }
+
+                                    .css-1iqw88f .main-media .play-indicator:before {
+                                        width: 26px;
+                                        height: 26px;
+                                        -webkit-background-position: -102px -175px;
+                                        background-position: -102px -175px;
+                                        margin: 0;
+                                    }
+
+                                    .css-1iqw88f .main-media .parental-control {
+                                        width: 32px;
+                                        height: 32px;
+                                        font-size: 18rem;
+                                        padding: 5px 2px 5px 5px;
+                                        top: 5px;
+                                        right: 5px;
+                                        z-index: 1;
+                                        border-radius: 50%;
+                                        background-color: #FF0000;
+                                        color: var(--white, #ffffff);
+                                        text-align: center;
+                                        font-family: 'almoni-demi-bold', arial;
+                                        display: inline-block;
+                                        vertical-align: middle;
+                                        position: absolute;
+                                    }
+
+                                    .css-1iqw88f .main-media .parental-control:after {
+                                        content: '+18';
+                                    }
+                                }
+
+                                .css-1iqw88f picture {
+                                    position: relative;
+                                    overflow: hidden;
+                                    display: block;
+                                    -webkit-user-select: none;
+                                    -moz-user-select: none;
+                                    -ms-user-select: none;
+                                    user-select: none;
+                                }
+
+                                .css-1iqw88f picture:not(.no-background) {
+                                    background-color: var(--gray9, #e5e5e5);
+                                }
+
+                                .css-1iqw88f picture .lazyload-placeholder {
+                                    position: absolute;
+                                    top: 0;
+                                    width: 100%;
+                                    height: 100%;
+                                }
+
+                                .css-1iqw88f picture img,
+                                .css-1iqw88f picture source {
+                                    position: absolute;
+                                    top: 0;
+                                    width: 100%;
+                                    -webkit-transition: -webkit-transform 0.4s;
+                                    transition: transform 0.4s;
+                                }
+
+                                .css-1iqw88f picture .vertical-name {
+                                    bottom: 0;
+                                    right: 0;
+                                    z-index: 1;
+                                    position: absolute;
+                                    padding: 0 5px;
+                                    font-family: 'almoni-demi-bold', 'arial';
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    font-size: 16rem;
+                                    height: 1.2em;
+                                    line-height: 1.2em;
+                                    color: white;
+                                }
+
+                                @media (min-width: 970px) {
+                                    .css-1iqw88f picture.desktop-16-9 {
+                                        padding-top: 56.25%;
+                                    }
+
+                                    .css-1iqw88f picture.desktop-1-1 {
+                                        padding-top: 100%;
+                                    }
+
+                                    .css-1iqw88f picture.desktop-4-3 {
+                                        padding-top: 75%;
+                                    }
+
+                                    .css-1iqw88f picture.desktop-3-4 {
+                                        padding-top: 133%;
+                                    }
+
+                                    .css-1iqw88f picture.desktop-12-15 {
+                                        padding-top: 125%;
+                                    }
+
+                                    .css-1iqw88f picture.desktop-9-16 {
+                                        padding-top: 177%;
+                                    }
+
+                                    .css-1iqw88f picture.desktop-original img {
+                                        position: initial;
+                                    }
+                                }
+
+                                @media (max-width: 969px) {
+                                    .css-1iqw88f picture.mobile-16-9 {
+                                        padding-top: 56.25%;
+                                    }
+
+                                    .css-1iqw88f picture.mobile-1-1 {
+                                        padding-top: 100%;
+                                    }
+
+                                    .css-1iqw88f picture.mobile-4-3 {
+                                        padding-top: 75%;
+                                    }
+
+                                    .css-1iqw88f picture.mobile-3-4 {
+                                        padding-top: 133%;
+                                    }
+
+                                    .css-1iqw88f picture.mobile-12-15 {
+                                        padding-top: 125%;
+                                    }
+
+                                    .css-1iqw88f picture.mobile-9-16 {
+                                        padding-top: 177%;
+                                    }
+
+                                    .css-1iqw88f picture.mobile-original img {
+                                        position: initial;
+                                    }
+                                }
+
+                                .css-1iqw88f picture.round * {
+                                    border-radius: 50%;
+                                }
+
+                                .css-1iqw88f picture.zoom-on-hover:hover img,
+                                .css-1iqw88f picture.zoom-on-hover:focus img {
+                                    -webkit-transform: scale(1.05);
+                                    -moz-transform: scale(1.05);
+                                    -ms-transform: scale(1.05);
+                                    transform: scale(1.05);
+                                }
+                            </style>
+                            <figure class="css-1iqw88f false">
+                                <picture class="ratio-desktop ratio-mobile" style="padding-top:80%">
+                                    <div class="lazyload-wrapper ">
+                                        <div class="lazyload-placeholder"></div>
+                                    </div>
+                                </picture>
+                            </figure>
+                        </a></li>
+                    <li><a href="https://www.alm.co.il/televisions-audio/tv-s.html" target="_blank">
+                            <figure class="css-1iqw88f false">
+                                <picture class="ratio-desktop ratio-mobile" style="padding-top:80%">
+                                    <div class="lazyload-wrapper ">
+                                        <div class="lazyload-placeholder"></div>
+                                    </div>
+                                </picture>
+                            </figure>
+                        </a></li>
+                </ul>
+            </section>
+            <style data-emotion="css 11x5rb1">
+                .css-11x5rb1 {
+                    width: 970px;
+                    margin: 0 auto;
+                    padding: 20px 0;
+                    -webkit-transition: background-color 0.7s;
+                    transition: background-color 0.7s;
+                }
+
+                @media (min-width: 970px) {
+                    .css-11x5rb1:not(.transparent) {
+                        background-color: var(--white, #ffffff);
+                    }
+                }
+
+                @media (max-width: 969px) {
+                    .css-11x5rb1 {
+                        width: 100%;
+                        padding: 0 10px;
+                        margin: 10px auto;
+                        overflow: hidden;
+                    }
+                }
+
+                .css-11x5rb1+.css-11x5rb1 {
+                    padding-top: 0;
+                }
+            </style>
+            <section class="walla-core-container css-11x5rb1 undefined ">
+                <style data-emotion="css 16v2dvx">
+                    .css-16v2dvx {
+                        border-top: double 6px var(--gray9, #e5e5e5);
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                    }
+
+                    .css-16v2dvx.no-border {
+                        border: 0;
+                    }
+
+                    .css-16v2dvx header {
+                        color: var(--vertical-color);
+                        padding: 5px 5px;
+                        margin-left: 2px;
+                        height: 20px;
+                        line-height: 20px;
+                        font-size: 14rem;
+                        font-family: arial;
+                        font-weight: bold;
+                        min-width: 104px;
+                    }
+
+                    .css-16v2dvx header:after {
+                        content: '>';
+                        margin-right: 4px;
+                    }
+
+                    .css-16v2dvx ul {
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        overflow: auto;
+                        -webkit-box-flex-wrap: nowrap;
+                        -webkit-flex-wrap: nowrap;
+                        -ms-flex-wrap: nowrap;
+                        flex-wrap: nowrap;
+                        width: 100%;
+                    }
+
+                    .css-16v2dvx ul::-webkit-scrollbar {
+                        width: 0;
+                        height: 0;
+                    }
+
+                    .css-16v2dvx ul li {
+                        padding: 5px 12px;
+                        font-size: 14rem;
+                        line-height: 20px;
+                        font-weight: normal;
+                        position: relative;
+                        white-space: nowrap;
+                    }
+
+                    .css-16v2dvx ul li a {
+                        color: var(--black, #000000);
+                        -webkit-transition: 0.3s;
+                        transition: 0.3s;
+                    }
+
+                    .css-16v2dvx ul li a:hover,
+                    .css-16v2dvx ul li a:focus {
+                        color: var(--vertical-color);
+                    }
+
+                    .css-16v2dvx ul li+li:before {
+                        content: '•';
+                        position: absolute;
+                        top: 5px;
+                        right: -1px;
+                    }
+                </style>
+                <section class="css-16v2dvx no-mobile-app ">
+                    <header>נושאים חמים</header>
+                    <ul>
+                        <li><a href="https://news.walla.co.il/item/3446034">חוק האזרחות</a></li>
+                        <li><a href="https://news.walla.co.il/item/3441958">עוטף עזה</a></li>
+                        <li><a href="https://news.walla.co.il/item/3433664">בנט</a></li>
+                        <li><a href="https://news.walla.co.il/item/3433686">נתניהו</a></li>
+                        <li><a href="https://news.walla.co.il/item/3441829">מסיכות</a></li>
+                        <li><a href="https://news.walla.co.il/item/3433677">יאיר לפיד</a></li>
+                        <li><a href="https://news.walla.co.il/item/3440383">קצין</a></li>
+                        <li><a href="https://news.walla.co.il/item/3434630">חמאס</a></li>
+                    </ul>
+                </section>
+            </section>
+            <style data-emotion="css 50mq0i">
+                .css-50mq0i .break {
+                    margin: 15px 0;
+                }
+
+                .css-50mq0i .paging {
+                    display: -webkit-box;
+                    display: -webkit-flex;
+                    display: -ms-flexbox;
+                    display: flex;
+                    -webkit-box-pack: justify;
+                    -webkit-justify-content: space-between;
+                    justify-content: space-between;
+                    margin-bottom: 30px;
+                }
+
+                .css-50mq0i .paging a {
+                    margin: 0 7px;
+                }
+
+                .css-50mq0i .paging-prev {
+                    margin-right: auto;
+                }
+
+                .css-50mq0i .paging-next,
+                .css-50mq0i .paging-prev {
+                    color: var(--white, #ffffff);
+                    min-width: 145px;
+                    background-color: var(--vertical-color);
+                    font-size: 16rem;
+                    line-height: 1.5;
+                    padding: 0 10px;
+                    border-radius: 5px;
+                    display: -webkit-box;
+                    display: -webkit-flex;
+                    display: -ms-flexbox;
+                    display: flex;
+                    -webkit-box-pack: justify;
+                    -webkit-justify-content: space-between;
+                    justify-content: space-between;
+                    -webkit-align-items: center;
+                    -webkit-box-align: center;
+                    -ms-flex-align: center;
+                    align-items: center;
+                    outline: 0;
+                    -webkit-transition: 0.4s;
+                    transition: 0.4s;
+                    height: 30px;
+                }
+
+                .css-50mq0i .paging-next .icon,
+                .css-50mq0i .paging-prev .icon {
+                    width: 20px;
+                    height: 100%;
+                    cursor: pointer;
+                    position: relative;
+                }
+
+                .css-50mq0i .paging-next .icon .arrow-next,
+                .css-50mq0i .paging-prev .icon .arrow-next,
+                .css-50mq0i .paging-next .icon .arrow-prev,
+                .css-50mq0i .paging-prev .icon .arrow-prev {
+                    width: 90%;
+                    height: 2px;
+                    background-color: var(--white, #ffffff);
+                    position: absolute;
+                    top: 50%;
+                    -webkit-transform: translateY(-50%);
+                    -moz-transform: translateY(-50%);
+                    -ms-transform: translateY(-50%);
+                    transform: translateY(-50%);
+                }
+
+                .css-50mq0i .paging-next .icon .arrow-next:after,
+                .css-50mq0i .paging-prev .icon .arrow-next:after,
+                .css-50mq0i .paging-next .icon .arrow-prev:after,
+                .css-50mq0i .paging-prev .icon .arrow-prev:after,
+                .css-50mq0i .paging-next .icon .arrow-next:before,
+                .css-50mq0i .paging-prev .icon .arrow-next:before,
+                .css-50mq0i .paging-next .icon .arrow-prev:before,
+                .css-50mq0i .paging-prev .icon .arrow-prev:before {
+                    content: '';
+                    position: absolute;
+                    width: 60%;
+                    height: 2px;
+                    right: -3px;
+                    background-color: var(--white, #ffffff);
+                }
+
+                .css-50mq0i .paging-next .icon .arrow-next:after,
+                .css-50mq0i .paging-prev .icon .arrow-next:after {
+                    top: -4px;
+                    -webkit-transform: rotate(45deg);
+                    -moz-transform: rotate(45deg);
+                    -ms-transform: rotate(45deg);
+                    transform: rotate(45deg);
+                }
+
+                .css-50mq0i .paging-next .icon .arrow-next:before,
+                .css-50mq0i .paging-prev .icon .arrow-next:before {
+                    top: 3px;
+                    -webkit-transform: rotate(-45deg);
+                    -moz-transform: rotate(-45deg);
+                    -ms-transform: rotate(-45deg);
+                    transform: rotate(-45deg);
+                }
+
+                .css-50mq0i .paging-next .icon .arrow-prev:after,
+                .css-50mq0i .paging-prev .icon .arrow-prev:after {
+                    top: -4px;
+                    -webkit-transform: rotate(140deg);
+                    -moz-transform: rotate(140deg);
+                    -ms-transform: rotate(140deg);
+                    transform: rotate(140deg);
+                    right: 8px;
+                }
+
+                .css-50mq0i .paging-next .icon .arrow-prev:before,
+                .css-50mq0i .paging-prev .icon .arrow-prev:before {
+                    top: 3px;
+                    right: 8px;
+                    -webkit-transform: rotate(-140deg);
+                    -moz-transform: rotate(-140deg);
+                    -ms-transform: rotate(-140deg);
+                    transform: rotate(-140deg);
+                }
+            </style>
+            <section class="walla-core-container css-11x5rb1 css-50mq0i ">
+                <style data-emotion="css 12flape">
+                    .css-12flape {
+                        display: -webkit-box;
+                        display: -webkit-flex;
+                        display: -ms-flexbox;
+                        display: flex;
+                        margin-top: 20px;
+                        position: relative;
+                    }
+
+                    .css-12flape.with-top-border {
+                        border-top: double 6px var(--gray9, #e5e5e5);
+                        margin-top: 25px;
+                        padding-top: 10px;
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-12flape {
+                            -webkit-flex-direction: column;
+                            -ms-flex-direction: column;
+                            flex-direction: column;
+                            margin-top: 10px;
+                            overflow: hidden;
+                        }
+                    }
+
+                    .css-12flape>main {
+                        width: 635px;
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-12flape>main {
+                            width: 100%;
+                            margin-bottom: 10px;
+                        }
+                    }
+
+                    .css-12flape>main .main-wrap {
+                        width: 635px;
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-12flape>main .main-wrap {
+                            width: 100%;
+                        }
+                    }
+
+                    .css-12flape>main .main-wrap.fixed-bottom {
+                        position: fixed;
+                        bottom: 0;
+                    }
+
+                    .css-12flape>main .main-wrap.absolute-bottom {
+                        position: absolute;
+                        bottom: 0;
+                    }
+
+                    .css-12flape>main .main-wrap>* {
+                        max-width: 100%;
+                    }
+
+                    .css-12flape>aside {
+                        width: 300px;
+                        margin-right: auto;
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-12flape>aside {
+                            width: 100%;
+                            margin: 0;
+                        }
+                    }
+
+                    .css-12flape>aside .aside-wrap {
+                        width: 300px;
+                    }
+
+                    @media (max-width: 969px) {
+                        .css-12flape>aside .aside-wrap {
+                            width: 100%;
+                        }
+                    }
+                </style>
+                <section class="css-12flape  ">
+                    <main>
+                        <section>
+                            <style data-emotion="css 1ws3k16">
+                                .css-1ws3k16 {
+                                    font-family: 'almoni-demi-bold', arial;
+                                    -webkit-user-select: none;
+                                    -moz-user-select: none;
+                                    -ms-user-select: none;
+                                    user-select: none;
+                                    border-bottom: solid 1px var(--gray8, #d8d8d8);
+                                    font-size: 18rem;
+                                    margin-bottom: 10px;
+                                    position: relative;
+                                }
+
+                                .css-1ws3k16 ul {
+                                    display: -webkit-box;
+                                    display: -webkit-flex;
+                                    display: -ms-flexbox;
+                                    display: flex;
+                                    -webkit-box-flex-wrap: wrap;
+                                    -webkit-flex-wrap: wrap;
+                                    -ms-flex-wrap: wrap;
+                                    flex-wrap: wrap;
+                                }
+
+                                .css-1ws3k16 ul li {
+                                    color: var(--gray5, #7f7f7f);
+                                    white-space: nowrap;
+                                }
+
+                                .css-1ws3k16 ul li:not(:last-of-type):after {
+                                    content: '//';
+                                    color: var(--gray5, #7f7f7f);
+                                    padding: 0 5px;
+                                }
+
+                                .css-1ws3k16 ul li:last-of-type {
+                                    color: var(--black, #000000);
+                                }
+
+                                .css-1ws3k16 ul li a:hover,
+                                .css-1ws3k16 ul li a:focus {
+                                    color: var(--vertical-color);
+                                }
+
+                                .css-1ws3k16.cover-story {
+                                    border: 0;
+                                    font-size: 22rem;
+                                    font-family: 'spoiler-regular';
+                                }
+
+                                .css-1ws3k16.cover-story ul li:not(:last-of-type) {
+                                    color: var(--gray3, #4c4c4c);
+                                }
+
+                                .css-1ws3k16.sheee {
+                                    border: 0;
+                                }
+
+                                .css-1ws3k16.sheee ul {
+                                    -webkit-box-pack: center;
+                                    -ms-flex-pack: center;
+                                    -webkit-justify-content: center;
+                                    justify-content: center;
+                                }
+
+                                .css-1ws3k16.sheee ul li:not(:last-of-type):after {
+                                    content: '/';
+                                    color: var(--black, #000000);
+                                }
+                            </style>
+                            <nav class="css-1ws3k16 breadcrumb no-mobile-app noprint">
+                                <script type="application/ld+json">{ 
+    "@context": "https://schema.org/", 
+    "@type": "BreadcrumbList", 
+    "itemListElement": [
+        {"@type": "ListItem", "position": "1",  "name": "חדשות", "item": "https://news.walla.co.il/"},{"@type": "ListItem", "position": "2",  "name": "מבזקי חדשות", "item": "https://news.walla.co.il/breaking"}
+    ]
+}</script>
+                                <ul>
+                                    <li><a href="/" aria-label="חדשות" title="חדשות">חדשות</a></li>
+                                    <li><a href="/breaking" aria-label="מבזקי חדשות" title="מבזקי חדשות">מבזקי חדשות</a>
+                                    </li>
+                                </ul>
+                            </nav>
+                            <style data-emotion="css 1e7r3ag">
+                                .css-1e7r3ag {
+                                    background-color: var(--white, #ffffff);
+                                    display: -webkit-box;
+                                    display: -webkit-flex;
+                                    display: -ms-flexbox;
+                                    display: flex;
+                                    padding: 35px 0 5px;
+                                    white-space: nowrap;
+                                }
+
+                                .css-1e7r3ag .date-part-1,
+                                .css-1e7r3ag .date-part-2 {
+                                    color: #cf041c;
+                                    font-family: 'almoni-demi-bold', arial;
+                                    font-size: 24rem;
+                                    margin-bottom: 20px;
+                                    margin-left: 6px;
+                                }
+
+                                @media (max-width: 969px) {
+
+                                    .css-1e7r3ag .date-part-1,
+                                    .css-1e7r3ag .date-part-2 {
+                                        font-size: 20rem;
+                                    }
+                                }
+
+                                .css-1e7r3ag .date-part-1:after {
+                                    content: ' / ';
+                                    color: var(--black, #000000);
+                                }
+                            </style>
+                            <div class="css-1e7r3ag">
+                                <div class="date-part-1">יום רביעי
+                                    <!-- -->
+                                    <!-- -->14.07.2021
+                                </div>
+                                <div class="date-part-2">ה אב התשפ&quot;א</div>
+                            </div>
+                            <div class="break">
+                                <style data-emotion="css oxkh4s">
+                                    .css-oxkh4s {
+                                        display: -webkit-box;
+                                        display: -webkit-flex;
+                                        display: -ms-flexbox;
+                                        display: flex;
+                                    }
+
+                                    .css-oxkh4s.in-item {
+                                        -webkit-flex-direction: column;
+                                        -ms-flex-direction: column;
+                                        flex-direction: column;
+                                    }
+
+                                    @media (max-width: 969px) {
+                                        .css-oxkh4s {
+                                            -webkit-flex-direction: column;
+                                            -ms-flex-direction: column;
+                                            flex-direction: column;
+                                        }
+                                    }
+
+                                    .css-oxkh4s .right-side .time {
+                                        display: -webkit-box;
+                                        display: -webkit-flex;
+                                        display: -ms-flexbox;
+                                        display: flex;
+                                        -webkit-align-items: center;
+                                        -webkit-box-align: center;
+                                        -ms-flex-align: center;
+                                        align-items: center;
+                                        font-family: 'almoni-demi-bold', arial;
+                                        font-size: 18rem;
+                                        line-height: 30px;
+                                        color: #cf041c;
+                                        margin: 0 8px;
+                                    }
+
+                                    .css-oxkh4s .right-side .time:after {
+                                        content: '';
+                                        margin-right: 6px;
+                                        width: 0;
+                                        height: 0;
+                                        border-top: 5px solid transparent;
+                                        border-bottom: 5px solid transparent;
+                                        border-right: 8px solid var(--gray5, #7f7f7f);
+                                        display: inline-block;
+                                    }
+
+                                    .css-oxkh4s .right-side.in-item .time {
+                                        margin: 0;
+                                        padding-bottom: 6px;
+                                    }
+
+                                    @media (min-width: 970px) {
+                                        .css-oxkh4s .right-side.in-item .time {
+                                            font-size: 24rem;
+                                        }
+                                    }
+
+                                    .css-oxkh4s .right-side.in-item .time:after {
+                                        content: initial;
+                                    }
+
+                                    @media (max-width: 969px) {
+                                        .css-oxkh4s .right-side .time {
+                                            margin: 0;
+                                            padding-bottom: 6px;
+                                        }
+
+                                        .css-oxkh4s .right-side .time:after {
+                                            content: initial;
+                                        }
+                                    }
+
+                                    .css-oxkh4s .left-side {
+                                        margin-right: 28px;
+                                        -webkit-flex: 1;
+                                        -ms-flex: 1;
+                                        flex: 1;
+                                    }
+
+                                    .css-oxkh4s .left-side.in-item {
+                                        margin-bottom: 6px;
+                                    }
+
+                                    .css-oxkh4s .left-side .body {
+                                        border-bottom: 1px var(--gray8, #d8d8d8) solid;
+                                    }
+
+                                    .css-oxkh4s .left-side .body .title {
+                                        font-family: 'almoni-demi-bold', arial;
+                                        font-size: 24rem;
+                                    }
+
+                                    @media (max-width: 969px) {
+                                        .css-oxkh4s .left-side .body .title {
+                                            font-size: 22rem;
+                                        }
+                                    }
+
+                                    .css-oxkh4s .left-side .body .author {
+                                        margin-bottom: 6px;
+                                        font-size: 14rem;
+                                        font-family: arial;
+                                        color: var(--gray5, #7f7f7f);
+                                    }
+
+                                    .css-oxkh4s .left-side .body .author a {
+                                        color: var(--gray5, #7f7f7f);
+                                    }
+
+                                    @media (max-width: 969px) {
+                                        .css-oxkh4s .left-side .body .author {
+                                            font-size: 14rem;
+                                        }
+                                    }
+
+                                    .css-oxkh4s .left-side .body .content {
+                                        margin-bottom: 20px;
+                                    }
+
+                                    .css-oxkh4s .left-side .body .content section div p {
+                                        font-size: 16rem;
+                                    }
+
+                                    .css-oxkh4s .left-side .body .content section+section {
+                                        margin-top: 15px;
+                                    }
+
+                                    .css-oxkh4s .left-side .body .tags-list {
+                                        margin-bottom: 20px;
+                                    }
+
+                                    .css-oxkh4s .left-side .body .share-panel {
+                                        display: -webkit-box;
+                                        display: -webkit-flex;
+                                        display: -ms-flexbox;
+                                        display: flex;
+                                        -webkit-box-pack: justify;
+                                        -webkit-justify-content: space-between;
+                                        justify-content: space-between;
+                                        margin-bottom: 30px;
+                                    }
+
+                                    .css-oxkh4s .left-side .body .share-panel .social {
+                                        display: -webkit-box;
+                                        display: -webkit-flex;
+                                        display: -ms-flexbox;
+                                        display: flex;
+                                    }
+
+                                    .css-oxkh4s .left-side .body>a {
+                                        -webkit-transition: 0.4s;
+                                        transition: 0.4s;
+                                    }
+
+                                    .css-oxkh4s .left-side .body>a:hover,
+                                    .css-oxkh4s .left-side .body>a:focus {
+                                        color: #cf041c;
+                                    }
+
+                                    .css-oxkh4s .left-side.in-item {
+                                        margin-right: 0;
+                                    }
+
+                                    @media (max-width: 969px) {
+                                        .css-oxkh4s .left-side {
+                                            margin-right: 0;
+                                        }
+                                    }
+                                </style>
+                                <section class="css-oxkh4s in-item">
+                                    <div class="in-item right-side">
+                                        <div class="time">09:10</div>
+                                    </div>
+                                    <div class="in-item left-side">
+                                        <div class="body">
+                                            <h1 class="title">פקיסטן: שמונה הרוגים בפיצוץ באוטובוס</h1>
+                                            <div class="author">
+                                                <style data-emotion="css 1om44rh">
+                                                    .css-1om44rh.center {
+                                                        display: -webkit-box;
+                                                        display: -webkit-flex;
+                                                        display: -ms-flexbox;
+                                                        display: flex;
+                                                        -webkit-box-pack: center;
+                                                        -ms-flex-pack: center;
+                                                        -webkit-justify-content: center;
+                                                        justify-content: center;
+                                                    }
+                                                </style>
+                                                <div class="css-1om44rh author ">רויטרס</div>
+                                            </div>
+                                            <div class="content">
+                                                <style data-emotion="css onxvt4">
+                                                    .css-onxvt4 {
+                                                        font-size: 17rem;
+                                                        font-family: arial;
+                                                    }
+
+                                                    .css-onxvt4 a {
+                                                        color: var(--link-blue, #0067bd);
+                                                    }
+
+                                                    .css-onxvt4.cover-story {
+                                                        font-family: 'spoiler-regular';
+                                                        font-size: 22rem;
+                                                        line-height: 26rem;
+                                                    }
+
+                                                    .css-onxvt4.cover-story div p {
+                                                        text-align: justify;
+                                                    }
+
+                                                    .css-onxvt4 aside {
+                                                        float: right;
+                                                        width: 165px;
+                                                        margin-left: 10px;
+                                                        margin-bottom: 10px;
+                                                    }
+
+                                                    .css-onxvt4 .sheee {
+                                                        max-width: 635px;
+                                                        margin: 0 auto;
+                                                    }
+                                                </style>
+                                                <section class="css-onxvt4  ">
+                                                    <div class="">
+                                                        <p>שמונה בני אדם נהרגו הבוקר (רביעי) בפיצוץ אוטובוס בצפון
+                                                            פקיסטן. בין ההרוגים, שישה מהנדסים תושבי סין. טרם ידוע מקור
+                                                            הפיצוץ.</p>
+                                                    </div>
+                                                </section>
+                                            </div>
+                                            <style data-emotion="css 1innaux">
+                                                .css-1innaux {
+                                                    display: -webkit-box;
+                                                    display: -webkit-flex;
+                                                    display: -ms-flexbox;
+                                                    display: flex;
+                                                    font-size: 12rem;
+                                                }
+
+                                                .css-1innaux label {
+                                                    font-weight: bold;
+                                                    margin-left: 7px;
+                                                    display: -webkit-box;
+                                                    display: -webkit-flex;
+                                                    display: -ms-flexbox;
+                                                    display: flex;
+                                                    -webkit-align-items: center;
+                                                    -webkit-box-align: center;
+                                                    -ms-flex-align: center;
+                                                    align-items: center;
+                                                }
+
+                                                .css-1innaux label span {
+                                                    margin-left: 3px;
+                                                }
+
+                                                .css-1innaux label:after {
+                                                    content: ':';
+                                                }
+
+                                                .css-1innaux ul {
+                                                    display: -webkit-box;
+                                                    display: -webkit-flex;
+                                                    display: -ms-flexbox;
+                                                    display: flex;
+                                                }
+
+                                                .css-1innaux ul li {
+                                                    margin-left: 3px;
+                                                }
+
+                                                .css-1innaux ul li:after {
+                                                    content: ',';
+                                                }
+
+                                                .css-1innaux ul li:last-of-type {
+                                                    margin: 0;
+                                                }
+
+                                                .css-1innaux ul li:last-of-type:after {
+                                                    content: initial;
+                                                }
+
+                                                .css-1innaux.sheee {
+                                                    max-width: 635px;
+                                                    margin: 0 auto;
+                                                }
+
+                                                .css-1innaux.sheee label:before {
+                                                    content: '';
+                                                    width: 30px;
+                                                    height: 12px;
+                                                    border: solid 0 var(--vertical-color);
+                                                    border-width: 0 12px;
+                                                    margin-left: 20px;
+                                                }
+
+                                                @media (max-width: 969px) {
+                                                    .css-1innaux {
+                                                        -webkit-flex-direction: column;
+                                                        -ms-flex-direction: column;
+                                                        flex-direction: column;
+                                                    }
+
+                                                    .css-1innaux ul {
+                                                        -webkit-box-flex-wrap: wrap;
+                                                        -webkit-flex-wrap: wrap;
+                                                        -ms-flex-wrap: wrap;
+                                                        flex-wrap: wrap;
+                                                    }
+                                                }
+                                            </style>
+                                            <section class="css-1innaux  tags-list no-mobile-app"><label><span
+                                                        class="walla-icon-tags"></span> תגיות</label>
+                                                <ul>
+                                                    <li>
+                                                        <style data-emotion="css t6swnh">
+                                                            .css-t6swnh {
+                                                                white-space: nowrap;
+                                                            }
+
+                                                            .css-t6swnh:hover,
+                                                            .css-t6swnh:focus {
+                                                                -webkit-text-decoration: underline;
+                                                                text-decoration: underline;
+                                                            }
+                                                        </style><a
+                                                            href="https://tags.walla.co.il/%D7%A4%D7%A7%D7%99%D7%A1%D7%98%D7%9F"
+                                                            class="css-t6swnh">פקיסטן</a>
+                                                    </li>
+                                                </ul>
+                                            </section>
+                                            <div class="share-panel">
+                                                <style data-emotion="css 1utisc7">
+                                                    .css-1utisc7 {
+                                                        display: -webkit-box;
+                                                        display: -webkit-flex;
+                                                        display: -ms-flexbox;
+                                                        display: flex;
+                                                        padding-top: 25px;
+                                                        margin-bottom: 10px;
+                                                    }
+
+                                                    .css-1utisc7.no-margin {
+                                                        padding-top: 0;
+                                                        margin-bottom: 0;
+                                                    }
+
+                                                    .css-1utisc7.center {
+                                                        -webkit-box-pack: center;
+                                                        -ms-flex-pack: center;
+                                                        -webkit-justify-content: center;
+                                                        justify-content: center;
+                                                        margin: 20px;
+                                                    }
+                                                </style>
+                                                <ul class="share-panel noprint css-1utisc7 no-margin ">
+                                                    <li>
+                                                        <style data-emotion="css 1qqupgc">
+                                                            .css-1qqupgc {
+                                                                width: 36px;
+                                                                height: 36px;
+                                                                background-color: red;
+                                                                -webkit-background-position: 50%;
+                                                                background-position: 50%;
+                                                                background-repeat: no-repeat;
+                                                                display: block;
+                                                                border-radius: 50%;
+                                                                margin-left: 10px;
+                                                                color: #ffffff;
+                                                                outline: 0;
+                                                                -webkit-transition: 0.3s;
+                                                                transition: 0.3s;
+                                                                position: relative;
+                                                                overflow: hidden;
+                                                            }
+
+                                                            @media (max-width: 969px) {
+                                                                .css-1qqupgc {
+                                                                    width: 32px;
+                                                                    height: 32px;
+                                                                }
+                                                            }
+
+                                                            .css-1qqupgc.share-fb {
+                                                                background-color: #3b5998;
+                                                            }
+
+                                                            .css-1qqupgc.share-fb:hover,
+                                                            .css-1qqupgc.share-fb:focus {
+                                                                background-color: #233865;
+                                                            }
+
+                                                            .css-1qqupgc.share-whatsapp {
+                                                                background-color: #39b54a;
+                                                            }
+
+                                                            .css-1qqupgc.share-whatsapp:hover,
+                                                            .css-1qqupgc.share-whatsapp:focus {
+                                                                background-color: #236f2e;
+                                                            }
+
+                                                            .css-1qqupgc.share-twitter {
+                                                                background-color: #009fe4;
+                                                            }
+
+                                                            .css-1qqupgc.share-twitter:hover,
+                                                            .css-1qqupgc.share-twitter:focus {
+                                                                background-color: #01628c;
+                                                            }
+
+                                                            .css-1qqupgc.share-email,
+                                                            .css-1qqupgc.share-general {
+                                                                background-color: var(--gray4, #666666);
+                                                            }
+
+                                                            .css-1qqupgc.share-email:hover,
+                                                            .css-1qqupgc.share-general:hover,
+                                                            .css-1qqupgc.share-email:focus,
+                                                            .css-1qqupgc.share-general:focus {
+                                                                background-color: var(--gray2, #333333);
+                                                            }
+
+                                                            .css-1qqupgc.share-email.icon-share-ios,
+                                                            .css-1qqupgc.share-general.icon-share-ios {
+                                                                background-image: url('/public/assets/item/mobile-app-header/share.svg');
+                                                                background-repeat: no-repeat;
+                                                                -webkit-background-size: 50%;
+                                                                background-size: 50%;
+                                                            }
+
+                                                            .css-1qqupgc.zahav-share-ok {
+                                                                background-color: #ee8208;
+                                                                background-image: url('/public/zahav/assets/sharePanel/ok.png');
+                                                                -webkit-background-size: 90%;
+                                                                background-size: 90%;
+                                                            }
+
+                                                            .css-1qqupgc.zahav-share-vk {
+                                                                background-color: #4872a3;
+                                                                background-image: url('/public/zahav/assets/sharePanel/wk.png');
+                                                                -webkit-background-size: 90%;
+                                                                background-size: 90%;
+                                                            }
+
+                                                            .css-1qqupgc.zahav-share-talkbacks {
+                                                                background-color: #387f38;
+                                                                background-image: url('/public/zahav/assets/sharePanel/comm.svg');
+                                                                -webkit-background-size: 90%;
+                                                                background-size: 90%;
+                                                            }
+
+                                                            .css-1qqupgc.white {
+                                                                background-color: var(--white, #ffffff);
+                                                                color: var(--vertical-color, var(--black, #000000));
+                                                            }
+
+                                                            .css-1qqupgc.gray {
+                                                                background-color: var(--gray8, #d8d8d8);
+                                                                color: #ffffff;
+                                                            }
+
+                                                            .css-1qqupgc.transparent {
+                                                                background-color: var(--vertical-color);
+                                                                color: #ffffff;
+                                                            }
+
+                                                            .css-1qqupgc.transparent:hover,
+                                                            .css-1qqupgc.transparent:focus {
+                                                                background-color: var(--vertical-color);
+                                                            }
+
+                                                            .css-1qqupgc:hover,
+                                                            .css-1qqupgc:focus {
+                                                                color: #ffffff;
+                                                            }
+
+                                                            .css-1qqupgc.squre {
+                                                                border-radius: 0;
+                                                            }
+
+                                                            .css-1qqupgc.small {
+                                                                width: 26px;
+                                                                height: 26px;
+                                                                margin-left: 5px;
+                                                            }
+
+                                                            .css-1qqupgc.medium {
+                                                                width: 32px;
+                                                                height: 32px;
+                                                                margin-left: 7px;
+                                                            }
+
+                                                            .css-1qqupgc.sheee {
+                                                                background-color: #ff0ac5;
+                                                            }
+
+                                                            .css-1qqupgc.sheee:hover,
+                                                            .css-1qqupgc.sheee:focus {
+                                                                background-color: #c50297;
+                                                            }
+                                                        </style><a rel="nofollow" aria-label="שתף ב פייסבוק"
+                                                            href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnews.walla.co.il%2Fbreak%2F3448092%3Futm_campaign%3Dsocialbutton%26utm_content%3Dfacebook%26utm_medium%3Dsharebutton%26utm_source%3Dfacebook%26utm_term%3Dsocial&amp;quote=פקיסטן: שמונה הרוגים בפיצוץ באוטובוס"
+                                                            class="css-1qqupgc share-fb walla-icon-facebook"
+                                                            target="_blank"><span class="screen-reader">שתף ב
+                                                                <!-- -->
+                                                                <!-- -->פייסבוק
+                                                            </span></a>
+                                                    </li>
+                                                    <li><a rel="nofollow" aria-label="שתף ב וואצאפ"
+                                                            href="https://api.whatsapp.com/send?text=פקיסטן: שמונה הרוגים בפיצוץ באוטובוס https%3A%2F%2Fnews.walla.co.il%2Fbreak%2F3448092%3Futm_campaign%3Dsocialbutton%26utm_content%3Dwhatsapp%26utm_medium%3Dsharebutton%26utm_source%3Dwhatsapp%26utm_term%3Dsocial"
+                                                            class="css-1qqupgc share-whatsapp walla-icon-whatsapp"
+                                                            target="_blank"><span class="screen-reader">שתף ב
+                                                                <!-- -->
+                                                                <!-- -->וואצאפ
+                                                            </span></a></li>
+                                                    <li class="only-mobile-app"><a rel="nofollow"
+                                                            aria-label="שתף ב general" href=""
+                                                            class="css-1qqupgc share-general walla-icon-share-android"
+                                                            target="_blank"><span class="screen-reader">שתף ב
+                                                                <!-- -->
+                                                                <!-- -->general
+                                                            </span></a></li>
+                                                    <li class="only-mobile no-mobile-app"><a rel="nofollow"
+                                                            aria-label="שתף ב general" href=""
+                                                            class="css-1qqupgc share-general walla-icon-share-android"
+                                                            target="_blank"><span class="screen-reader">שתף ב
+                                                                <!-- -->
+                                                                <!-- -->general
+                                                            </span></a></li>
+                                                    <li class="no-mobile-app"><a rel="nofollow"
+                                                            aria-label="שתף ב טוויטר"
+                                                            href="http://twitter.com/share?&amp;url=https%3A%2F%2Fnews.walla.co.il%2Fbreak%2F3448092%3Futm_campaign%3Dsocialbutton%26utm_content%3Dtwitter%26utm_medium%3Dsharebutton%26utm_source%3Dtwitter%26utm_term%3Dsocial&amp;text=פקיסטן: שמונה הרוגים בפיצוץ באוטובוס"
+                                                            class="css-1qqupgc share-twitter walla-icon-twitter"
+                                                            target="_blank"><span class="screen-reader">שתף ב
+                                                                <!-- -->
+                                                                <!-- -->טוויטר
+                                                            </span></a></li>
+                                                    <li class="no-mobile-app"><a rel="nofollow"
+                                                            aria-label="שתף ב אימאייל"
+                                                            href="mailto:?subject=פקיסטן: שמונה הרוגים בפיצוץ באוטובוס&amp;body=%0D%0A :%0D%0Ahttps%3A%2F%2Fnews.walla.co.il%2Fbreak%2F3448092%3Futm_campaign%3Dsocialbutton%26utm_content%3D__s%26utm_medium%3Dsharebutton%26utm_source%3D__s%26utm_term%3Dsocial"
+                                                            class="css-1qqupgc share-email walla-icon-envelop"
+                                                            target="_blank"><span class="screen-reader">שתף ב
+                                                                <!-- -->
+                                                                <!-- -->אימאייל
+                                                            </span></a></li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </section>
+                            </div>
+                            <div class="paging">
+                                <div class="paging-next">
+                                    <div class="icon">
+                                        <div class="arrow-next"></div>
+                                    </div><a href="/break/3448089">
+                                        <h3>המבזק הקודם</h3>
+                                    </a>
+                                </div>
+                                <div class="paging-prev"><a href="/break/3448095">
+                                        <h3>המבזק הבא</h3>
+                                    </a>
+                                    <div class="icon">
+                                        <div class="arrow-prev"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+                    </main>
+                    <aside>
+                        <style data-emotion="css vqwqhw">
+                            .css-vqwqhw a h2 {
+                                font-family: 'almoni-ultra-bold', arial;
+                                font-style: normal;
+                                font-weight: normal;
+                                color: var(--vertical-color);
+                                font-size: 20rem;
+                                line-height: 1;
+                                margin: 14px 0px;
+                            }
+
+                            .css-vqwqhw li {
+                                margin-bottom: 20px;
+                            }
+
+                            .css-vqwqhw li .lazyload-placeholder {
+                                padding-top: 56.25%;
+                            }
+
+                            .css-vqwqhw li:after {
+                                content: '';
+                                height: 1px;
+                                background: var(--gray8, #d8d8d8);
+                                display: block;
+                                margin: 10px 0px;
+                            }
+                        </style>
+                        <ul class="css-vqwqhw "><a href="https://news.walla.co.il">
+                                <h2>עוד ב
+                                    <!-- -->חדשות
+                                </h2>
+                            </a>
+                            <li><a href="https://news.walla.co.il/item/3448232">
+                                    <style data-emotion="css emywkl">
+                                        .css-emywkl {
+                                            overflow: hidden;
+                                            width: 100%;
+                                        }
+
+                                        .css-emywkl h3 {
+                                            margin-top: 7px;
+                                            font-family: 'almoni-demi-bold', arial;
+                                            font-size: 17rem;
+                                            line-height: 1;
+                                        }
+
+                                        .css-emywkl:hover h3,
+                                        .css-emywkl:hover h3 {
+                                            color: var(--link-blue, #0067bd);
+                                        }
+
+                                        .css-emywkl footer {
+                                            margin-top: 7px;
+                                            color: var(--gray4, #666666);
+                                            font-size: 12rem;
+                                            display: -webkit-box;
+                                            display: -webkit-flex;
+                                            display: -ms-flexbox;
+                                            display: flex;
+                                            -webkit-box-flex-wrap: wrap;
+                                            -webkit-flex-wrap: wrap;
+                                            -ms-flex-wrap: wrap;
+                                            flex-wrap: wrap;
+                                        }
+
+                                        .css-emywkl footer .pub-date:after {
+                                            content: '|';
+                                            margin: 0 5px;
+                                        }
+
+                                        .css-emywkl.without-image h3 {
+                                            margin-top: 0;
+                                            font-family: arial;
+                                            font-size: 14rem;
+                                            font-weight: bold;
+                                        }
+
+                                        .css-emywkl.with-background .content {
+                                            background: var(--eventv1-bg-color, var(--gray9, #e5e5e5));
+                                            padding: 10px 15px;
+                                        }
+
+                                        .css-emywkl.with-background .content h3 {
+                                            font-size: 22rem;
+                                            margin-top: 0;
+                                        }
+
+                                        .css-emywkl.full-line-roof .event-roof {
+                                            display: block;
+                                        }
+
+                                        @media (min-width: 970px) {
+                                            .css-emywkl.desktop-roof-on-image .content {
+                                                position: relative;
+                                            }
+
+                                            .css-emywkl.desktop-roof-on-image .content .event-roof {
+                                                position: absolute;
+                                                top: -30px;
+                                                right: 0;
+                                            }
+
+                                            .css-emywkl.desktop-roof-on-image.with-background .content .event-roof {
+                                                top: -23px;
+                                            }
+
+                                            .css-emywkl.desktop-big-title .content h3 {
+                                                font-size: 28rem;
+                                                letter-spacing: -1px;
+                                                margin-bottom: 0;
+                                            }
+
+                                            .css-emywkl.desktop-title-on-image .content {
+                                                position: relative;
+                                            }
+
+                                            .css-emywkl.desktop-title-on-image .content .event-roof {
+                                                position: absolute;
+                                                top: -77px;
+                                            }
+
+                                            .css-emywkl.desktop-title-on-image .content h3 {
+                                                padding: 0 15px;
+                                                line-height: 1.5;
+                                                white-space: nowrap;
+                                                overflow: hidden;
+                                                color: #ffffff;
+                                                background-color: rgba(0, 0, 0, 0.65);
+                                                font-size: 33rem;
+                                                position: absolute;
+                                                bottom: 106%;
+                                                right: 0;
+                                                left: 0;
+                                            }
+
+                                            .css-emywkl.desktop-title-on-image .content p {
+                                                margin-top: 5px;
+                                            }
+
+                                            .css-emywkl.desktop-full-height {
+                                                height: 100%;
+                                            }
+
+                                            .css-emywkl.desktop-full-height .content {
+                                                height: 100%;
+                                            }
+                                        }
+
+                                        @media (max-width: 969px) {
+                                            .css-emywkl {
+                                                display: -webkit-box;
+                                                display: -webkit-flex;
+                                                display: -ms-flexbox;
+                                                display: flex;
+                                            }
+
+                                            .css-emywkl h3 {
+                                                margin-top: 0;
+                                                font-size: 20rem;
+                                            }
+
+                                            .css-emywkl:not(.mobile-with-subtitle) p {
+                                                display: none;
+                                            }
+
+                                            .css-emywkl figure,
+                                            .css-emywkl .lazyload-placeholder {
+                                                width: 165px;
+                                                margin-left: 12px;
+                                                max-width: 165px;
+                                                min-width: 165px;
+                                            }
+
+                                            .css-emywkl.mobile-vertical {
+                                                -webkit-flex-direction: column;
+                                                -ms-flex-direction: column;
+                                                flex-direction: column;
+                                            }
+
+                                            .css-emywkl.mobile-vertical figure,
+                                            .css-emywkl.mobile-vertical .lazyload-placeholder {
+                                                width: 100%;
+                                                max-width: 100%;
+                                                margin-left: 0;
+                                                margin-bottom: 12px;
+                                                min-width: 100%;
+                                            }
+
+                                            .css-emywkl.mobile-first-two-high:nth-of-type(1),
+                                            .css-emywkl.mobile-first-two-high:nth-of-type(2) {
+                                                -webkit-flex-direction: column;
+                                                -ms-flex-direction: column;
+                                                flex-direction: column;
+                                            }
+
+                                            .css-emywkl.mobile-roof-on-image .content {
+                                                position: relative;
+                                                margin-top: -22px;
+                                                background: var(--gray9, #e5e5e5);
+                                                padding: 7px;
+                                            }
+
+                                            .css-emywkl:not(.mobile-with-footer) footer {
+                                                display: none;
+                                            }
+
+                                            .css-emywkl.with-background figure {
+                                                margin-left: 0;
+                                            }
+
+                                            .css-emywkl.with-background .content h3 {
+                                                font-size: 18rem;
+                                            }
+                                        }
+
+                                        .css-emywkl.small-title .content h3 {
+                                            font-size: 19rem;
+                                            line-height: 40px;
+                                        }
+
+                                        @media (max-width: 969px) {
+                                            .css-emywkl.small-title .content h3 {
+                                                font-size: 19rem;
+                                                line-height: 23px;
+                                            }
+                                        }
+
+                                        .css-emywkl.white-text .content h3,
+                                        .css-emywkl.white-text .content p,
+                                        .css-emywkl.white-text .content footer {
+                                            color: #ffffff;
+                                        }
+
+                                        .css-emywkl.white-text .content p {
+                                            margin-top: 7px;
+                                        }
+                                    </style>
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>רה"מ בנט: "יש לקיים שגרת חיים וכלכלה, יותר שקיפות ופחות סגרים"</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://news.walla.co.il/item/3448209">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>15 שנה ללבנון השנייה: חיזבאללה אוגר 150 אלף טילים, ושומר עליהם בסביבה
+                                                אזרחית</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://news.walla.co.il/item/3448236">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>ח"כ שנדבק בקורונה לא יוכל להצביע, הקואליציה תמשוך שני חוקים</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://news.walla.co.il/item/3448144">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>שביתת העובדים בבתי החולים תתרחב? "התרגלו שאנחנו עבדים"</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://news.walla.co.il/item/3448173">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>"החיוך של שירה": הוריה של נערה שמתה מסרטן הנציחו אותה בדרך מיוחדת</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://news.walla.co.il/item/3448205">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>בוש נגד הנסיגה מאפגניסטן: "הנערות והנשים יסבלו מאוד"</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                        </ul>
+                        <style data-emotion="css 1cmsqyb">
+                            .css-1cmsqyb h2 {
+                                font-family: 'almoni-ultra-bold', arial;
+                                font-style: normal;
+                                font-weight: normal;
+                                color: var(--black, #000000);
+                                font-size: 20rem;
+                                line-height: 1;
+                                margin: 14px 0px;
+                            }
+
+                            .css-1cmsqyb li {
+                                margin-bottom: 20px;
+                            }
+
+                            .css-1cmsqyb li .lazyload-placeholder {
+                                padding-top: 56.25%;
+                            }
+
+                            .css-1cmsqyb li:after {
+                                content: '';
+                                height: 1px;
+                                background: var(--gray8, #d8d8d8);
+                                display: block;
+                                margin: 10px 0px;
+                            }
+                        </style>
+                        <ul class="css-1cmsqyb">
+                            <h2><a href="https://www.walla.co.il">עוד בוואלה!</a></h2>
+                            <li><a href="https://celebs.walla.co.il/item/3448248">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f long-image">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>שומרים על הגחלת: יעל בר זוהר וגיא זו-ארץ מאוהבים</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://sports.walla.co.il/item/3448096">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>"רונאלדו אידיוט וחולה, מוריניו לא נורמלי": הקלטות חדשות נחשפו</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://tech.walla.co.il/item/3448204">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f square1_1-image">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>בלי חוטים: אפל הכריזה על מטען נייד לאייפון</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://food.walla.co.il/item/3447985">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9 no-background">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>סיסיליה עירבבה לי כרגע קוקטייל מושלם. סיסיליה היא רובוט</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://cars.walla.co.il/item/3448079">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>אופל אסטרה החדשה: יש לנו את הפרטים ואת מועד ההגעה</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://career.walla.co.il/item/3441674">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9 no-background">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>שמונה טיפים שיעזרו לכם למצוא עבודה מושלמת אחרי הצבא</h3>
+                                            <style data-emotion="css 179ag37">
+                                                .css-179ag37 {
+                                                    display: inline-block;
+                                                    color: var(--gray5, #7f7f7f);
+                                                    font-size: 11rem;
+                                                    line-height: 1;
+                                                }
+
+                                                .css-179ag37.marketing-content-hp-taste {
+                                                    font-size: 14rem;
+                                                    font-style: italic;
+                                                    margin-top: 8px;
+                                                    font-family: arial;
+                                                }
+                                            </style><span class="css-179ag37 ">בשיתוף ManpowerGroup</span>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li></li>
+                            <li><a href="https://celebs.walla.co.il/item/3448254">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>מתרחבות: אלה לי הכניסה שתי שותפות חדשות לדירה</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://fashion.walla.co.il/item/3447940">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f long-image">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>הדוגמניות צעדו על המסלול כשרק סרט הדבקה מכסה את גופן</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://e.walla.co.il/item/3447135">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>ציפי רומנו: "נכנסתי לבית האח הגדול כדי לעשות תיקון"</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://www.sheee.co.il/item/3447704">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f square1_1-image">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>לא חתונמי: התוכנית המדהימה שבה מוצאים אהבת אמת</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://www.sheee.co.il/item/3447875">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>אתה פחדן: מילותיה של הקרבן לאנס רגע לפני גזר הדין</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://career.walla.co.il/item/3442292">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>להיות יועצי גיוס: כרטיס הכניסה שלכם לתחום משאבי האנוש</h3><span
+                                                class="css-179ag37 ">בשיתוף ManpowerGroup</span>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li></li>
+                            <li><a href="https://www.sheee.co.il/item/3440783">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9 no-background">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>חיפשנו שמפו זול ומעולה לשיער בעייתי, ואשכרה מצאנו</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://tech.walla.co.il/item/3448147">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>קיבלתם SMS מחברת החשמל? היזהרו, זו עלולה להיות הונאה</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://travel.walla.co.il/item/3448010">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>נחשפה החומה שהגנה על ירושלים מהחורבן הבבלי לפני 2600 שנה</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://healthy.walla.co.il/item/3447926">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f false">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>לא אוכלים בשר בגלל ט' באב? זה מה שקורה לגוף שלכם</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://celebs.walla.co.il/item/3448052">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f long-image">
+                                                <picture class="desktop-16-9 mobile-16-9 no-background">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>הרשת גועשת: האם קורטני קרדשאן התחתנה?</h3>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li><a href="https://food.walla.co.il/item/3447228">
+                                    <article class="css-emywkl ">
+                                        <div class="image-wrapper">
+                                            <figure class="css-1iqw88f long-image">
+                                                <picture class="desktop-16-9 mobile-16-9">
+                                                    <div class="lazyload-wrapper ">
+                                                        <div class="lazyload-placeholder"></div>
+                                                    </div>
+                                                </picture>
+                                            </figure>
+                                        </div>
+                                        <div class="content">
+                                            <h3>פאפי צ'ולו מציגים: מתכון לפיצה ואהבה</h3><span
+                                                class="css-179ag37 ">בשיתוף ZAP REST</span>
+                                        </div>
+                                    </article>
+                                </a></li>
+                            <li></li>
+                        </ul>
+                    </aside>
+                </section>
+            </section>
+            <style data-emotion="css i30fw1">
+                .css-i30fw1 {
+                    background-color: #191919;
+                    margin-top: 33px;
+                    -webkit-user-select: none;
+                    -moz-user-select: none;
+                    -ms-user-select: none;
+                    user-select: none;
+                    position: relative;
+                    --gray1: #f2f2f2;
+                    --gray2: #7f7f7f;
+                }
+
+                .css-i30fw1 .slot {
+                    height: 0;
+                }
+
+                .css-i30fw1.sheee {
+                    background-color: #ff0ac5;
+                    --gray1: #ffffff;
+                    --gray2: #ffffff;
+                }
+
+                @media (min-width: 970px) {
+                    .css-i30fw1.fixed {
+                        position: fixed;
+                        bottom: -100%;
+                        left: 0;
+                        right: 0;
+                        -webkit-animation: animation-ltupjm 0.5s forwards;
+                        animation: animation-ltupjm 0.5s forwards;
+                        z-index: 3;
+                    }
+                }
+
+                .css-i30fw1.no-margin {
+                    margin-top: 0;
+                }
+
+                .css-i30fw1 .wrap {
+                    width: 970px;
+                    margin: 0 auto;
+                    display: -webkit-box;
+                    display: -webkit-flex;
+                    display: -ms-flexbox;
+                    display: flex;
+                    padding: 10px 0;
+                }
+
+                .css-i30fw1 .wrap ul {
+                    -webkit-flex: 1;
+                    -ms-flex: 1;
+                    flex: 1;
+                    display: -webkit-box;
+                    display: -webkit-flex;
+                    display: -ms-flexbox;
+                    display: flex;
+                }
+
+                .css-i30fw1 .wrap ul li a,
+                .css-i30fw1 .wrap ul li button {
+                    font-size: 12rem;
+                    color: var(--gray1);
+                    padding: 0 7px;
+                }
+
+                .css-i30fw1 .wrap ul li+li {
+                    border-right: solid 1px var(--gray2);
+                }
+
+                .css-i30fw1 .wrap .copyrights {
+                    padding-top: 2px;
+                    color: var(--gray2);
+                    font-size: 11rem;
+                }
+
+                @media (max-width: 969px) {
+                    .css-i30fw1 .wrap {
+                        width: 100%;
+                        -webkit-flex-direction: column;
+                        -ms-flex-direction: column;
+                        flex-direction: column;
+                    }
+
+                    .css-i30fw1 .wrap ul {
+                        -webkit-box-flex-wrap: wrap;
+                        -webkit-flex-wrap: wrap;
+                        -ms-flex-wrap: wrap;
+                        flex-wrap: wrap;
+                    }
+
+                    .css-i30fw1 .wrap ul li {
+                        width: 45%;
+                        font-size: 14rem;
+                        border-bottom: 1px solid var(--gray2);
+                        padding: 5px 0;
+                        margin: 0 5px 5px 5px;
+                    }
+
+                    .css-i30fw1 .wrap ul li+li {
+                        border: 0;
+                        border-bottom: 1px solid var(--gray2);
+                    }
+
+                    .css-i30fw1 .wrap .copyrights {
+                        text-align: center;
+                        margin: 8px 0;
+                    }
+                }
+            </style>
+            <footer id="main-footer" class="css-i30fw1 no-mobile-app noprint   ">
+                <div class="wrap">
+                    <ul role="menubar">
+                        <li role="menuitem"><a href="https://help.walla.co.il/">עזרה</a></li>
+                        <li role="menuitem"><a href="https://help.walla.co.il/section/12344">כתבו לנו</a></li>
+                        <li role="menuitem"><a href="https://dcx.walla.co.il/walla/terms/terms.pdf">תנאי שימוש</a></li>
+                        <li role="menuitem"><a href="https://dcx.walla.co.il/walla/terms/PrivacyPolicy.pdf">מדיניות
+                                פרטיות</a></li>
+                        <li role="menuitem"><a href="https://www.walla.co.il/about">אודות</a></li>
+                        <li role="menuitem"><a href="https://apps.walla.co.il/">אפליקציות</a></li>
+                        <li role="menuitem"><a href="https://www.walla.co.il/writers">כתבים</a></li>
+                        <li role="menuitem"><a href="https://www.hamal.co.il/">חמ״ל</a></li>
+                        <li role="menuitem"><a href="https://www.walla.co.il/archive">ארכיון</a></li>
+                        <li role="menuitem"><a href="https://www.walla.co.il/rss" class="icon rss">RSS</a></li>
+                        <li role="menuitem" class="no-mobile"><button aria-label="נגישות" title="נגישות">נגישות</button>
+                        </li>
+                    </ul>
+                    <div class="copyrights">Copyright © 2021 Walla! Communications LTD. All rights reserved</div>
+                </div>
+            </footer><span style="display:none">walla_ssr_page_has_been_loaded_successfully</span>
+        </div>
+        <style data-emotion="css 1mxcanp">
+            .css-1mxcanp {
+                position: fixed;
+                bottom: 20px;
+                right: 20px;
+                background: var(--gray6, #999999);
+                padding: 10px;
+                border-radius: 9px;
+                -webkit-transition: 0.5s;
+                transition: 0.5s;
+                outline: 0;
+                opacity: 1;
+                -webkit-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+                color: #ffffff;
+                font-size: 30px;
+                z-index: 1000000;
+            }
+
+            @media (max-width: 969px) {
+                .css-1mxcanp {
+                    display: none;
+                }
+            }
+
+            .css-1mxcanp:before {
+                font-size: 30px;
+            }
+
+            .css-1mxcanp.hidden {
+                bottom: -80px;
+                opacity: 0;
+            }
+        </style><button title="גלול למעלה" class="css-1mxcanp hidden walla-icon-arrow-up" tabindex="-1"></button>
+    </div>
+    <script src="https://cf.dxmcdn.com/dta/wallawb.js" async></script>
+    <script data-react-helmet="true" async="true"
+        src="https://www.googleoptimize.com/optimize.js?id=GTM-MKKBK36"></script>
+    <script>window.loadDataState = "KQdgQsBMkEoPYFcAuBTAzlSwDMBBUE0aSAhkghtDvtAMoIDGD6lWkAwpgCZkmbUFMANxQAnJAEsGJADb88g6KPQIZSeTUhpGzNKyidoPUhsWQJXDQEYDmAHYkAtilNUAIiGABOTx+/ZgP1wvQM8vAFZQ4FxNWyMJNAAHGRIATwB9B2dXLD8fKK8AoJC8yKDYjkwULJcqBWg7FAB3fUroEgZJEWs4yAY4GThRHKhsKx8ADgAjKf42rRQ4dMkkGVqsetywsu2CgAYCzjyAFgBCKAO83zCiz2CCneiKwwWlrnQGEbzLu/wgiYuBWOBWu/ii91K4JoP28wLyWzBkLyhhhESBBQAouCAXkIHkAGwFEKQVE2PIlO4U6I4sKo9gAOkBeSxeTJYUJQVBXipXjcTN2QQRhQKeIFd1RxNRXNu0R5jxiF0gwJJ4KpuCF8uhBTZ3h5LLC+thjJVeRl3IeFquRIKfJNYTVPLVNN1Nv53h1aPJBTNqMidu8jy8HuduFBuGDbvVhzdXlF3hR6O+1v+lruQp5ttJ+2x4L9vu14I10bybmNMNwcLF8eTYWd5s56La5Y5YQ9BybIILKZOcVRca8RzC/cHsN73sLqaeMflRdNcxeaEW6QA1ihUk0hlx9Jt59w4I4SBI7DlGi16U1ZCl6f16RI5FR5olRBIhhIkKkNGwXlx94e7Ol3kcOARgfF4nxQIQJGadInxfZ93w0dsXhQAAPBgZAoCRujqCov0wAALJAkESbdw16OwpGXKYSGGHCbHmIDlHSRxPhwpDuASEgpjWZZZCojpl1I9j4jQLieMg94lhILdENAPkQHkxTegAKlUgBJVBHHSbBjmOCY9i8NgNnwcBMGIMgKByegmBYXcjF4UxTOgN8UEcRzCEgZRtDUHJtBsvQ7MgYw+BwswLByHS9IMozegg6okGWVJEhQdJwroqxhMgFY1i+O5K2iLk1QjPIADEBH9CEDUnXBUWVWqcyRMJ01df0g3BfL6zuFsA1zGM20nLw60DD15XovCiAQKZsvWcqYvmczyDQVLLDo3oDyPZiUC4CQQuMuxVHvBcUH6Ox3lEDJnG23bqH2mRDswJ99zgSQ4H/S6do0W77ugfCUGksRNquz6DrWradvSfoRFovaQfmX7/tEZY3xy0KH3GyBHoksR3MwNLjKsSA/ReDouhmvB6JeGpcupAaeRDEMxtiqnUc8lBkDEVpiZklnlHZ0ROcwYj0hIZB8Nk+YAHMlxFpAxdW+YSESRJhdFnp5iQIQVdltWXiaFApi1uX8d6bakhSDJmeM/huyrTrvHp8FGYYsHrrwTK7CWI93hQ8XKaWAAzAZBiaX3MAQUR7yttG5N6TGLABxcTp4c7gbu3oGGUMgUuMMnNBJSArAAWj2EBC6sOqDOoAnqHCJ2XgQRIc4ArOcnzouS7LiuQnJyI8GwTxQMwZQgKEWRm9QHI9invZi5nqeLnnt2DiXwKEAolD0mHuBR5kcfc8yxJJpkKQyBff8c9bvYC+L0vy4X7vw2Xmr23RteJA3w/uJPl7z5buj8UgAA442Bp69DfhvBuTcL7/0AUqbA8CB5gRovFMeJ0kCiAGKHaAB5RCrkkHYCWENXqoDsOoNivRSAyH4gwZc6R/YdH1nAOAy4sFZT4tRGhrDRB/2MplI8jR+aJGejrewntTqoVYfQ5gUwmG0OPquVhpsxIpWPnYZcbCJZCV6FDSQ0hI5V16ObRAZDeG9FEFwdI4d9E7kHtAJo8EAaW1moFbQBt7EuURk4vAX104oDutNamFZwSFUdgUOsZV6jlj1NVeqrV8q4CGgUZqJY+rtRrNEbqno7h5i7LSAaiTWTVTrlUAhSNVi5zmOjVC6FMLYSjnNF4xiAZWJAujRcbwPjPkSD/VpvQEjpBSMQSxjceEGPmIMhKkCs6WMXKILxmguAYNEPSAAXk4CQ0MTYOVCk5SAxipjcKPIXAJLM0kNi9EEYqYQIlamKJiGJjZ6o2x6vCdJvJUlBA6mqTJ8ocmFKTI1e2A0RqhKoApChJBNGmHCBAXZeNqDciJvYJwFT3B5WCeksieRwmrwjr0hWnQsK5xsOC8ItoXg6JPjIAA8lMAAVjjZyK1jbzHmdbMI0pVTVWeBxM2aRMgoupvkOcdzAUKlsZAaogqWangFu0QldSxkvH6IMTZNixiTBmC4pcJz6kDUDHSIE5xWqctFVWcVbSlzvDQKxPVALfg5jiZ2EVlJuUxg6kKM0gYEyAq8B1Q0CSRQFEyZKXJLozU03tfGMs9z/nsgxRcsImZqqeqDWKiUMZTWurFdCJUkY1Szgda1D00TmRAhjS68NttAwhJSa1B0mK6wZg+bbHkPoLStWGmEhNdwIwVSFD6oc0YnVRrtoGsVySk0tu8OWEMfzbY6ijL6kcvIK3ouXW8ptPbRwdiCJk/qu6OVhvHWEZUg7vDDjTWEFdZ6YwyiXea255rC1ggle0lca4NzmNIpUk2v4jwnmaGgc8l4SDXjgLefRj5nyvgQjhdGP51rn1csBU5ErwKQWgrBWDH5yHzGqRhNARL8UvEIsRUiFN7CUWomqsiDEhgpRYoozi3EUqUOoYJZjolWPpCxlJbmpjwXzGkB7CiejGWQBaSzMjJFyplUgCVWVIG7pgZvHeKAJUDl/RYQpyK+lDKBVNskNIEn4V4AlfQ2WAMzM1QhVC+WC5SCLWWiIn6f0zqAw+izF+vR4Yeak3qiVbK0XeENG1Ak27zQmvHBGrJU4334SGAlYLQowsem6qGa00XK2VReUWqpBDj5oHwgK7IMqgP+0GUbWKaFCPEbQ20yaurnESukttH+Y9ms2IQ50iQ3Sz4ke4EtGzmUtwDLSMY1hNEGD4Xq6Y4TJBRNUpyDJjA9R5OKaA8pq8an7wlWkKgCWQxcMlWjkJilYhdGyFM8ypVyKyt2qPTluUUJApSoe7NWVgUVVDBAhqkA0xZgSqUTx9jHDON4eQrV2pqKYrnd5cZjIFgf0wrCrd8z6MUuxtbMGyLoarTPbdWCvkZKY5wxIEtVRq4LFxVIaRehMhFy9ETj/FHsKPLvmSqwrruFmdNeRrD77xD4qBNLea2JWYggZtaqiM0yapeJjuHWIsI6cdirDACEkAAKBqav7QTnJAASmnUExNGTqrzpnfk4FRSTcZY6oGeT5Z4m1t7d20qa73RvKd4r0czy4sGbN+8w9spMU8jqtjv34oYtu6D/Lh1YqeQlsjMnj3MYHZ1ozZWuLUZWoBq5PKTXTz13673Rb40VSULoJIIlLnkPMCMQqbs6a6QJaQsCS+4Uxb9XZmREai4AA5DEAB1WggUqdbXSLThKNnMCRXxPiCYxJX54uk0RWT62NPwzUPhVI23VMQfUwplybldO6QX0vwKPP2VW4J0rrLqIs9VV9fJ89J68vm7jzGEc7+vD5nKJGH8Oapkv/g6pEqEjliGE+lHlWh/oHuanWFupnr7sKjcFyj2BVEVGcgge7nkl/tlqXoQV7vgYaj2LiI2i4vzuUkKh1P2E6B2o/q9vWgNC+r/kXgAOLUrurOpoF3Ih4PreDx4wECG/50EtTF4XoP64FwGp5TokiFwxhChCGoHVhxpwGv6KHiHSECHB6ohhZmhfJaG+pKExgBpChF6RYrqF5vKaie4B4NqtQmF56vYK4YF6E2E8GIhFpRKR4qGxiPLFhDqZ4KGq7RDxKIFvLKGLrxJP6CGBTvSuwmQeSz7QDYAkj4heD4g+bzANyDDSR7yXzXwdxWD0R7BWABB9y9y4BjCrwjKoAFEsxtw3xlylHlHUDYBVE1ESrX4hZ/5h4BFloAGjoBrlg8rYIuwwQYJYyIyz5wro4JJIoNDSr1K0D4TICoCiC0BIBwCcLA4JCI6law6rHrFiBbE7E6bowayGyuZZTKwyzVbky9BSxSSqwOaYB6wGz3E9Dw7OQHhSwSYJG14pQ2bHCEjzD+x3gpQpZpF7AZFZGFygn0h0qJASyBRNAWDaw4THCgJwwoASASyESfgL6eA/HmB2C/TwSeYkDsBMLmJHhZw/pnbkqYAZxgwmLOLkFDF647rO667RAgqDFEEWpbImA7IeQ4J4JHgSyFxoLxTHKoTsk7hqG5ZjpAEf7VGAHgigHEGnpX4C6Fxt6omnL+7yghpGHXp8l9E5qaliogFE7oz7KHJ2DHIC6BIej3pQHcFB6BisEREkEoFZqh5uHoGx4l7ql+l4FEG6GeF2yxmyFxGtQ3pXqwGBrE5rQ0SSmlKymkI5DFLQAEYw4RTn6L7L4xykrMnORLSN43GfzHwHZnx7zpC/RA6PY8m9446hEKgRpBLhAvDZjoZHzfwNk8AZDNlCovbIH+7xk6GlmPiDn1mvRIwfabCVzkzZFgTzmnyLlNyByiAHhERbS5nHD0glz0htyBTcKnT7g3ZFlRS1wuJOYUAuZvHQBTL1HQL1JNHFEVxPx7DAhux+joxIZlIoytlWn349i9k35tTgGCkFRvJi6wHRnZ4TnR7+mCjmm35Cl1iog+6cm8H66JkhneAa6OrlgIi4A/KWnNoy6R6/5qhhixHB5VIiCkJAnPn4wZS9DuIbGHGDbQDMD+KunGmRmRq6lQW9E2CwXP53Cu5IVhY0Wy4eGuFRlCE6HKGxG/64Uxj9hmj44WmxakUpj9rghUX+6KXEUDhakdroxoKTHbzxwzHzFo7WCEy9AkxzZ3ZLHLmxAmmbp8l0YFbLGzS8wbFyqQDSSMmsx8zhVCxfH17QDPHXEvkRVKzJUsovBXHxUZXvH6zpVeVBT7Hmx8UiViVwF0wBV5mQAJGsIeypTiI+wJWQB1WBx3RwAhxNUBYtZYCknAU1U4Q+LzTHSvRnQXQuypzfQYwYJAQ/xUkTVMyEI9ENIETuYAxLWBSUriYpVGLICsKsntbzXzSTTpA8WOLBXeKwwblfwLm/wTyNFXzty3wBD5wVG4DhCEgrwSrgIwSbmzUflVwAIAIGQgBZFgLrzDJQKjLkyA0FxXzHCLHVUZkoD4KELZmKm2bzDmKWKr6BboyJDIKkKoLEIYLWIY0vD9KVYU4PFk24xLTonvCsIFlEaKrdZ9KU4U6TJ1HEoimJFmCOl/gunUGlXgVlV+rAASVChSXQFeD54IW+EWUoUPLoVpiYUi1jo4UFB4VBEEUuhEWGUBUWEYVl5ipIFyGMFwX0Xbq2b4E9UVmQATIQ3TIUBiApbHxDDFbrKiBi0SqnX8zQoQCk4LZLZbVWy7JdWbCrZyYaZKYXgqbgaQYaZaYkA6YlR6Z7D3l7F8q4ah3JHzEWZkAUkcXUCZSkD2Y5VECPnDbzGUZuYIxzXeaBR+bNI43dXkTnW+UyU6neAZYhIEFeFBmPouKJbiAlVgVpa47nKEVSgx4D3qljGSqFYJAlYpayqU3FZvbQ7M2C5vpUGgWt0KxcDtZnydbCW40my9b9avT8VBRV2KLs2pCTZNXTazYs000CWLavTLZr7kZR0KYx2gbx1H77ZZxHYpwKZMnaKXZf0524zV1t0+XQWBkqmahvYr1AZC6qp/bjAA5aqZ3KK8RULg5aL4ab2eWs2klGbFXI7+0uXwaY7t3QXj0RaT263T2E7Wlpmk6knrVRq/7AgS0FjSWhZ45vIKWq16VK2qWRhOHm3YXtneBa2SGK163ZpPYQX34mXG04HK1YXCPmVW1MW2iNZTSn373KrC45nC2zqmVE4SHhbqMpnQGZZB6IXe0SEiF1ilE66xYroNpG53rKVoVSMqgCNG2yWYqGGTmiVeBOPxKTqqFSMCMh7+HKOkG6lqGDRvIDyyPxY+F36i3WFROz1WW0XMMON+EK3RMBqm3wUqVIXKG0GBFwGGPTpq30GjpO4hF9gFBOPuGXJkW+EdRerHqG2qPVjOHdl1jPV2MF69Td5wXChm7W26kVRKUVThFy2XJ2FhbyiBnIVRkoPGU5My0DPZ5dpHO+EBo8g/7S2aUa2lQ6VSHYooHWMPMTNBMwFWUAGYFZO2MG4Wl92xlWHYGsP/Of5yM6PqUxivNdR/NkHcmW3fPnqZHyPiqS6d2ZP+4R59763PKpk5NosvMUG8MtOhEnO+pcg92RGtOLpqlRZ2OXpJjzOiXv6UVwvpMIs1MxAV4UJJT7xk5IISxSkSYYY3ksxp2X5vqV1F2PE5Fc0NGfkPXNF3wkirk1RVF7DPVAV/ggWw5gnljkXUWq1iN+U+PUurNgtst+XMskWWXTNNNi1aNTjfN5PlNqgdTYsIvxOpksXxTsU2YlGZS+2j1mMsl+JqCmObD6vWVhOi2VN6MQvmrXPmsGuWsZaJI2sqEqn2s4scvgvOveHEWIthluPHreua62XEL2XTEytJGwOfi6TuUKrc2soMO9FmGWlxiEu+oGoOtnCZoz3INMFBUIN2KgZfatYCazTD6gYD5AZuDoAXEUJ3GvHl2QBJXZUFWKwruYlrtZWrsFUfH5WyvfhFX8pY4W0UV1hdvS2Bi9u5uwjGpsM61DvfNAXjVNV1VewSKfsBxBztWsLh2869U6v9UwxpxDVJxiBjVAwDWXUPTTXPQNlgc3Twf5mlLrUSpN2IyYfoybXXbbUTa7VNX7VviHULjHXBvzKDVXV1lbm3Ww5fm3xdzF28Lrlhzg21lDnblQ3hgw3HCEwqg5Hg1vnZy8dWD8eQAgCavpm4LI1SlEKkIi5NVY1Ae/qPgE2UKKfoKYJNUU1VasL9L038skM1Jb3X39IO2ic3HBQSb81HJLXRt1MeMpvy2WnyjJuQuGtOu/6W72O2uxY5sGV5tWsJ6FuTMRMDFesUFpnjIc2O31HO1zJttBRLKrKe1okOJ+2hSo67K+1ivGQkgTCIKYD+wXtjNfO2xiMSoyDlefM/4VuQPiDQMCBzE3F1d+H3qoXxYIZnsWwpcxldf2lMwpcTvoweWv0119ADC/Zob/aA7apLA8PVryOVePsDvsOD1vpWofBCqjGnN5udeWUoNkupobqdooHVPJkoteiZt+PlN0jbNho3fhM6M55nfa3qnS7Pv92vveF5o/Oxs57S3xnksYvHkBPekDRyX7MpmOhGtFP+f2Ez1q1+fnO1hW19recAvdN95kt3MpqucZMwvRBo9lsDQrqliRgO4OsVVLNci3oVT7r9nItciLp1iM+4/BdKPc/e3Iv3qsG3tgsB5avM5LirjribhRWGb/rHjlZnix07aH5QZgQwbwTZ3UAIay8AQobX0YZQRNCTFwRvga9uw1ZmdkO85wzr4UbkTUY0Q3GN7MS2rF0mwsY8Rg4CTEOnvcbiTxz8ZaK9UfswNMoRTpEgDYCNdyt5EWL/WbBMctH3zF2eDmbsevnytx95xKvFGlFqslya9p9ZSRsd3FPAsLP6X1eOrvtXTVuOW1u0PGRZH0OjtXurfo8KORhhhXIFOGZ9chtKkPc25vPlhd/aEZuXGaybtm/qw7vU1TcbsHsnu5WfGL9kSkkSB/FN7ikTGc7AnzGgm9AQk8TQnh+R8In4hInJRGnoz027sA3zy4n4mEl0SwmEjgrv9KSB3Kof1iYEch+SYt0I6NvX+ptgV4ANdsidTOCnQlazkfeiOArpr3RiWZC6I2OzLb3mjSsA2vmVaojBQ4rlG6OA7GqTXU6UwBuCzdLCI0BZDcOGbSYesljIEYsKBLDeloN2O7DsFqRWZeqNwqwGcJUTNS3iQLMi71t643Q+m+GPq7xcO59G1F0h6QNYTYt9JqmNh2ro1Moz9S3plBEyf0Q6s0SOpvj/pbZFeB+BOgpgOwoBQGJ2CBvMHw7EC2uKVDrkg267Cl8MaDFoBg1m6BZ5uuDXrr7zYzsIvejNUhq/V/QUM++1DHLuznrZ0N4GgucgRPVe5T1WBsWE7rbXFpKR1YxfTAE5w+Yuc3uJrcph51p6YVlm0QCiumwYLPcwwbab/L7lC4FtcmRbLlh6xNzltKCJjIWmfWEwWN0aN+FUvdzbLOdW+b3fsIum+4SdTCxLJNkUKKYlCRC5QyEGS18Z9sLg3jcptOXTDG5M2VQ8cCo2EIZY1S3bMZsWzCJMER+1UM0oj0XQ8h+w8ofbo4TeRJkbWM5bEJ7h0Jv5DCZLbYXOGSYxFLWNTWHo61hZLM6WfnHZpFiC6z1jhpuFZsc05QXcH2atUiqd0tbS0bhMZE7gyzeQClCKyLeJBcLC49R3m6pOEamzFSLpsAdhDqA00J7KkM2aTT5lcx6YbcEhKZT0kSJVIZ5T0PLdWHy1kiklGgVeBAZsDTpogpWFkRQWu1E4KtZoCfFVlPAfhuU+4VVYCst2EIhgzKTUcqKSJZGLMzaz3eYc+nZYnCuScBWZi62u7ItqurrHvk61LZmtfUGlTFAcPzB8DWKCUXfrW0DbcUsu/fK3sqnDaqjARZVOoQHijjajamOtAEUwIKHC8MRILLsrbDNHhdPuJTPpokIi62koupfAaI6OBExtdgEqOynHA8yzFc6DbRnhFWbbtcGBCbUoZ21OE95R0N6J9kkIq4pCRuLfIwWN3cpTtNgM7FTHOxaALs0AS7GfsezowvAF+d/Jfu0DSpT8JxgsSfqvym5Ht5xU3ShuexrFg86x/uG9tOAGj0i/ULY/JrqOKbtjnYsHebH7Hqrexaqf7Nqh1SvFhxABwHO2n1WD6ocIOR0KDudHrrgdJqj0Gashw/EXUvxJSRapkOji4k66Ug6wVAx0Ezj7aRHVQenGUAHU4OYEiaG4h9HUc0OGMX6sOV46YBZRLHDHMXUL7fUuON1aUdDVgTAIQAQneuCJwz7id+O2AQoFNwlLycsy3QrhBYjU5QSkEygQmrvDQQk1DOS0NetTT4R0144gQi3sEMEm01xsQyazilVs5ilMA9nZ0oGI2a2ifSWo/MRGP7pRj4hNolWhw15ImiA8SYhofhXGZpjQWGY4AlmJVJl89Ro6NUM6JsoCtMAVneVklxSyLIhg6XRwBsky4eI2cZgfLppND7wYyiFYsrluPZ4YoaudXX/KD1F5wTmuCEutnFLXYODB2Tg+ehuP64t9WxZ49gS4O4FuDWsVYlKj9loxzAvBLZMXkt0gmd572vPftlQLYFvs2pOvG1HtxcIaMZmRUo0UGPgImTvU+4+FrWNEJmSWBGTfoVpUOBPcMmVLN7jOBR5oi6mS0tRr92KmKhPWkIwXq01cZhYIerUCRj2xjLxsx08PfRpcNpgo8XR2pJHiGFH7PNNGOPC0V6WibtNDRb3fqHizJ7KlO8lPV4TTwRF08hSDPMcLaIPSs8RmjYZFoyxTGPD+esYhsROgGhZSjoSwCXl+l7F+i9wSGQDGALjoQD0MavE3p+D/TAVAIqGToarwggG8jeOGeSXVkUnLUfowA+wfb1oycSGMzvLjPg0940JvevKfBnxmFgkyDgQfS8a1zLHit064QQaMqFfjJA4A+RTPsRKvhzwJgZcaZnfDwDw0a4UfeuCxLuqKt5CewI2W0RJCmyKwVRcIJbMFgdSUZDYCqJ4zeT4yG8ExYsdZmcp2DjI4QY4MSFIHlTieKPJPBNP9Q2MN05fFqD4IOIdcQZkYuOZZMu6JzbYK6fIQmQn7jipucVZcU8Wlhlz5gq4suev034Akd+fLWtgf3BKQlfRc+NWRrPP6X9zBaJDEnPyyKZRfoT/dGlYHCDvUyySkcsunB/4tcFAYdF8QRGAH6DQBwGIwYAz2xJ1oBukfTIBTd5Z0hR6oJAQXWDnc5IU6AxzOKM9HYC66eAzQIX2w5EDr6HXJhvGmYEV8juyQqqQuDoFtz22+oygT91PF/ceuHAper/Oao8CqaG9BSSIL5ztC96rNA+kfVegn0OhobIwBfTkEsyhstbUbPfUfpPj2gogGbBoOnnB0/+ugpeTQA2z/0qZyvDTGYIsEaYrBF2HKRQrnkqyCpW4xwcN2qkt9uxXQzBnN2wYLc8GoOfwZLK5mFl5BoQrOstCimhzEBMQoVC/O7oAKKpwC4UlPO4aey5prLDUd4DDFGTnGkYqImZN87YzzRnyEaaaImmXoiR+0yEQUiBEwjLK7khMscy8lGTRRxjWCeYyU6WNWyswx6XkjJb6FMUEuTFJkjDDZNah6olgp30tLtg7G3XXQqsNFrrCiQmww8XpIOlxloWOMkLh6H7BWjVuKUuaQCJ/yd4IR2408WOm1KHCnF5wo0W5JzHSNVaK0+5tejsLd8TF/JZkdECYp7jAemop6TGKsWHcmKtkrvHY0cnq0Xp2c5UnS2RboskKpRVbld07LxLjChk0JjkL2ZmKym5kncVtyskEibJdi4dHMor65YLFtok6a0odEFK8xe0yIBLW5GZVeR5CD/hPN+XzBVIykDEO1iGDpBoAkAUshwrMiV0rIOgWyMDm2T/82SHg5WUPBUA+QWYfkXQOFQ0mIq3RCi7fqQCvnzBUBcXB+sR0IVaBEshvYNqRxQnzA4A9KY6O6MbkkrkIbo/1vMVGx998a04t+oVTkW79WEVE+jjRL5XfUpRmfTKJRIIk8cbZrvYTu/E3goYd4oqzKDYNYTHxX6B8TTkTVITiSmqXElGtp2U4UqEiNJTcPSVQCkQfE2iyeekJeAAqAAsq5AQDaRwVEmBaJZBZjWQsVhmBFSivGL7QJMXkVQD0Imj+RsV/qyFakXdURCG+VceGjpGUXC0eFNAprldhkBqR5iaRSOaV2PmiAs1U2eqWux5XU1BB0AbDOr0A4Ly+ZP9ZebQqV4mD5MBWCWJwIHw1TwqRGTSIrCmzEKX6JnRpMlDl5rsVB19QShhBSBCzeg3ERbEu2n4LhXoUUrhsyUUXkxjg0nTXFHNiGMDzFMPIxumqpSFqcIOaw/vmqPUUqJuLbJBLyvLVTVjecGSUTWsgB6DqF0dQweAPoUKZN5wrPgYvWKztqW+YUoQGsmXAb8XEJ+HtU/T7WW8pucAIdTcVHXyDhM4bVQA7xSozq1ErCNAIupobLrbAq68MImoRrpToi1UCIhKhsHnr2isal4MgLEBUb51mAS9TWQLp69aZD6zXmAifUvqNMGmJIEllXkfqm1qDVtUvQA2w5+N4gTtRBsSC9qSFWq3oHBuqAIbkJY6lDZOpuIYa51fK7DXYCXX2r41PcKwBMDBJbqhUgYQGbozW5RY8O8E2QAxuqI0a81VmAtZyqbakwWNN6pSRWvY2m8NSORbjVQt40GDKZjaoBowuOwaZa49skTW2oG5voZNcm/tawiU3DqCqiG7BQJXU1oa12WmrDThrjV4bKgBG8uOEH7jJqglBw32WmuykZqHNJ68Emerc0EoPNKVUtWxvvV+aKxAk59UFoUwaYUA++decFpbVxaW+M0eaIlqg3yaB1Wk+DYRzJVhreZfQbLVOvmB5amqum/Tb5JK3w0BOFWjkpyzeQNL56lG7NU5ugB0bXNRa1rSWtY1IbVenWjQAjR608b+tCmbfLLD3xrzqZza0Bf+pS6fbd84G7tbJum3JamqqWlTYtrU13RUNa2l4BtopVbbcNBm3beHPdhbj3p9i2zWwszXnbc1l2prTdpg2xx7tmWu9ZzJwimbnxxA2tRvlfUKZA4cALgENt+2xaxNKXZnbdkm2g6ktpC+lfNpHWqaHtYbOHRpvQ0pBMNm2grVbFRxFbOA6OyPgdoH79KERi6Kqmdo0ANbaNxOp+sWoKrtbRdPmp7ThBK6vlAtdaxnftj8T6xBNdC4Tb+tE0A6W+glO3SDtciQaL10GhTYLuU0LaCF6ClbeLpy0FUkd8qhdXptR07bOFCa6Ts9TM2lUExSFSzcDw2p2b8d2ui7ZACu0Oa1BBuxCUbop2Vq6ZOETdbTpWx9aNs1eEQDIDZ2fq/tLg53fhHE05Aa9fiD3QeDB3e6ZtKWoXelpF0U7x18OzTVLu02ZQUdhWtHbHrXXhyE992WHAABVjo1WWrYeoJ2nqXNee9zaTo05ebltJejjXgEJ0AC6dvWq3cFpKioAZs9ex3aNs50t9r9q+hcFNp70Q6KVUOgPeSqD3D6JduWsfflqj1T6Y9UQ/GHtqm4dcGlvwjArjrq0b7GtW+5rcTAL0LiK15OoPYfr81cUAtZ+t7RtnoTFYz4t+oBhzpd2w4CDs2K+glr53g6Bdg6/3cLph3G7g9E60PYhPD2MaiAsugQPLun2gGE1g0THS32KwoBRD6evHfVuz256kDTGlA1NyL0YHfN1gKbq9qr0aYmgGh+kCIdEPDb3t9+sg75F+hiHqDnu7vVux91Xq5tDBgfUwaH2rbWEHBnTdwYUC8GQD+UgQxMAgMpchALO8Q3Aaz0n7pDJOybmTv32BRMDrlLjbgbUMKYfDrOn7Q3tIMt7vDvhkw13puLqCQjfutLYhIy0/77DTVRwxPucP4BXD8OXbUvnN3NUtx4eFHueNYX+Hj1UhvXRerkOhGy13mynVWrojz6Ld0Ri/e9pKh0oEAPABII4GIMq9wJY22HMMdGNoBT8bSV/RHqY0WG+91h3I4PvyMh7aMmUIo8zhKPi0A6fB9w7Psbatto55TEYX4fX0BHN9FJbfS1t33XqOjB+pQ3RG62W6Gdl+6QPzAmMjb/tyR13TRGk00G39dBqwzkdQNITbDWx1gwjswB7H5oBxsoyupn2EaJgICFXSXxSZCl/Z0ALXU0cCMtHlj8qW7YbvQOILHtVO/GC9s+NrZrd/sNeH8b0MAnW9LMRk2lt52mH+dvu+g5Cam55HKTYuuE6PtnWAHtt5RtE+XAxNeGLjJytRVi2uN6JJDRJxA8EcsNoGwjNM03fjBp19HK9AxjbL9BkCJBmTje5CH+sBOw5jTZhrk+kdoO8mIT0OwPUKay3bHRT0u5HciaONuHzA1dPSOEGb7br5pFFNngMqR6ectusBm44SbuP0aZDpJp4w9ApOkyTd1JquFUdUOGn1DmhhI02ury7F9DVptvdwkLPM4ljiEzIxqb2T96NjMJ10ywZH2FGADMuoA3Lp9OSn+Da6jE0GaFTTkheQPb5Dbgo0Z6VTcZ67frrJOF6Uzt6iI3RHL36nv6XxwY4lmcBmmkjbJ+pKuYm0v7QTJJiKqsch21moTgp1M42b/1h6WzXptszwY7Mk47Vfyh1apCBVvgQVIAEALvOjVaBoV3q2FQFHhWilEVwKpqbshDXor6kmKuFQhijV5TJUeKmhrsmcCEqsBxKhM9CZdM6aqVJ1H0bSpS2MrOgHK3Mm9nZUejWVCOYqgoc4P8qDigqpqsKr+q8cpVnHGVQx0A7g0t4KqyVQetymZRNVs2tA8JK05iTdOpqpGkarRoaqjw2mxedma/XlxjyeZkgxKjNW0ltoDgK1RJkJjrrjgo83pIrK8ztnDNeccOSAB0u7zo+Os2PkRLBVlEjZZRMuEXi4p4Bw51AbErUUhpyr4+Bs4uEXEgCOWpaio8MHiaL5oLVdSPKlq1C7bxIQRB3Yph6UbDV9wYQcpygfIyhCHgzItZPfiwCquNYB5FzcXKcytVbIwIYXK1fiXG8qS6s/VhFOLn7cU8qa43yQJTQlkcWYUweS4FA36Qot+AcmvqRf356mc9rclLFpdMujyu5yJa/txT7nWAH+pGPEgSXRr6QmrZJCkm+CpLmq6S6l9AHpfvO+mkLNeFC+TTQunmJ9WFmlS1bpWNJ8LzK5KPX2gBVVp8hFpQdypTNcqBVXyilfRcImeWxVzEjy/xckzMXrqIqriwqo3gcWx4YNho7PL5V8WhVOq0ScTREv7nDVCnCS01SpwGnlzG2DQ00HpCyBxjv21AGsEghEZF1hcEWNtFQxX6hAhcYDIREcCTHxiV0Ta2pYZISYxgAnCYG7N2ugwlZLhyIScc0Bc2/LvNr6trN1nWXoA2fbAD5YuC6WzZH1GqFVQlXS2vyctsograqIH83YVVJamlcLjLXepfBey3LfPLKXA5UxOvqWK7OPx0rw0k0dlbxZlXM6acrHTYudsOMVS1XIufOKqvjjMotVm4tXN5Uko7auFqxg6yxASour/xWKdVQbl3WQSg1o/lCRS6i2ebRsxEpNd7lcAw7c1lasPI0DLX1+5JMQOtZUsWrtr0vThp/wfM/L/lqkZ1Y4FdWMwvznqqKj6qgs8165QahO2BaW2QX/z0FwCwGoLgIWpT4wDolid6FdLimeV/E6ObgYIH7jaF5jW1pnOdG5zFKnrf8ab3TGcg3CQg53q93mHe9KVT/RStPO3rf9bBvlYicj0SnUTdtgmLCQdvC1VFL3YybGX3Vr7lTK93XWqcnNJnNTLx7e28cfVn7IB2mH9UWc3OfZIF69NI2fcrOHmP9x5gU5sYbN32dj06q8/ucn2GWFdRl8uIZF7NJ7bJdyj5t7WjMAObiQRkB1keeO5k/L5W7U+mfMxRGQIwDQ7JFoUwEwMTA8eByl36AYIHAp9sw2g4vtrsr7NhjC7fYKP/6xTrZ5+/hqntBgFz1RuUyGIPTvTQedYaZeaeEDL2GHxJqixvbu377AEkrPGpA/aLcO0MvD8wfw9OwlkNzKXROOHFL2LG9z0j9/QVTkd1mFHnR3Bw4YIdUWiHt5tIb6YDbGbRRiesCqmtOXPcSeb1JU/ZsAfOa176pzzS8aqo73XLjjwLM46YUCOPHLfBINwg70oOpHUJqs2sf5OGJsHZ5sJ82ZUfXn8Vr98YLCVnu9ECeuM4GaiznQZPM9KVRh5xSXwI1LH5J/fdvOEexx7HeALR3vdMEgNXH8zip7DmnxEYKIaAap8za0AVn6n6DwJ5g+af1nWnSj/c4/bMjemYnnZ4WyUT/zEbuF40xZSWyWEwzVagYRkdYu+l0PMnZj4B5M4SeyGpzUJyi5oGwN2OdTCKYpy1lKeuOYXrJlLikEfHlm/HJzmR2c/WMnmWnij90+089OEP7nJDkrT04rGFSlm7007aY/GfmPww8T6Z20b30vHaHizuF2uQRc2IkXYDEqBy4PsP7tnXARgPR0kcZHTniEoJ/i8ueEuRTxL8ffsZvOC2HnL9p5+MHGB9PJaCPaJvUZMcSGsnROkF1XGZc77mHyZ/fcZvCNLOmXPLioHy5OzWundh96TH9B3wSuUqDTy+8ed4sEvQn1zqi7c64MqvSjd59R907/y9HtHGVsM4qfhHjLExCV7i0C4ZcmvyYZrx4xa7Ac5A+iHD7o/jBXzQO1nfD/l3m5EfCGdiO0KXVwD1gyB6EygT12u29eyPznpKkJ8tracUrg3WgMl/XdifV14nVLmsdCLgJfOMe5IBQgsxuk0PF7kAAk2uwmf7mZn056x4vjBKwvOH6TnAzw4i38ubHG71Fy3yETHxJA70CiE2/PsBPpXbbl4DfYDdEvu3ETpw6G8OOkOensp4M6O4DzjugU9PLMQHjCx/OAWgLsZ4u8ZclEl8FYld5C63uxrN3BbmuPa7mCOuNMc76oM3oQebAT34ghgKJFOhHYoYdgZwIEsxfcmvXUrqEzK79dyuH3Crp9x09JevuUTEbjV3/godgUeQX09MXkt+SjOHNU3Jdxm6g/mvqzUL4iYvgWfQYuXbLHd0473eWDJPWznILuQWt2BlAKQVnJe/8egOazeLmjx2++yBuH7z74o8x/Dfkup7S+Qa9S5fZHSnhEMlOSm7A8FUhPfKmD/Ibg+vGZPg11Z6h/AbKeWYX6GQDzt3Pkfm3lH2Dbe78n+vO3xn3Y6Z+VddO2PJRbVznKOW/5YleiultcIGjGOl7hr4Fzk/SjWfRPeT3MsFcKdrrkPD4fzyVEdkVvYcYUw+msD+jEBtP2L691R+i/QB73cXx9zc8S9InzPar1j36eUNBgP7YFAZ+amaEjnCvab4r6C8Gsef2jR5G1zJ90tyeSnCnjTCq0a85A2YGCOvL4/C9XvdPMrrB7R/6/0fBvjHyJ324HcTfK45xjK45KhHwz5vjR8D+m6Zeles3YnuD1t4Q8+OAaNXtgHV+B9HvYcFAa6HadQedeLvPX9C9/pwfxf8H93l92o+K0aOYtr3x26GSQonSA88SeJNOUibhMvvMZn70t9Nf/fkDELzz1a8PfSet3VgTM0+oYXrP+X4wl18K5yAU4DLZH+0xF5xc3u8XV3wz4WPR/rahvT96PY8/G/pQ/8VRyA/GK5affQPAn8cwJ/icrfWXLDlmOz429s+VnnPkty4559SeLTmHlLiQH9jPhpAHXqbi29xdNP23qPq5wN6Ddy+7nI3vDZZ9fu1xHZiTw7QFyFLYiO+uwvpTnmcWDLk3/91NzT/jO5PN7Vr8Fftvzeg+8AHP4t5D4z/LaMPrr+pAADUOgDAI8LUD2C7kLgYjlBc7/cqRfFNyPvr0Z+99Qme3UT1V4H6ee1xAEaXjJnJWoe5MLbWvo1znsZf57Gfa35g1V9TL1w6TIA23YSkXXrm+fBhlmMv60/5wHqDfhWE3+yPOnPf8rps8o5JcPf/fxxpXzSb/Kq/kpd09zoUq7qZWOe4tPsoUip/0PFvKfph4D61Mg+j9e4G29KFWSxKhYfLfzPh7dMLUOci/fnxZhwAtYBX8bzeHzqcXfSj0yhLvC5yl9bKGX0R1n3Kbi78w3Ubxx9X7COUDMB/F9jOkE3Y0W9s1Qd6Xs8x/Irx/9WjafzZccgCORRYs/QAOwMF/PP128FMDgJZ8bfYv1mg4NI8AGxanSVzF9uvCXywDj/Oj1P9LzTHzM9sfRXSlMSQZXXx9P7QJnD9X0RgO/8JzFgN09xPaAHepenLgKwMVDc3zq8zAoQKmM4AiC2SgK/ChRQCpArrwwCW/WLzb9bvH32UCkvBX3Vdr/KuDSIJgLRzV9+mE2hqF/nQn1HdAqZz219V7ZgOXcDfS1xeNotd2TTNEPcmGjc/PfgJKh0gwL3qQfwD2CQAwpEe2F8EfNAOkCPA2QI98ltbwMUDfA8/yx9J7V+w6JQgigN0DalfoTtFIxcpWCZ9A5P0MDggvyy0dVvNgKN8C4c2QsDPwKVWsC8ggmFK1Cg2aAhIRAWWClIQTM7x09s3PT0hMDPeQJu9Ggkzz8DhvNRx78ggtdQiAbPLcWgM8lezzOUUyaZRqU4mMjXBBgrBd1c9J/MrzT8XjPAzfVQtYwSAYT8DTHgR4EYrnMsqTLIMI1wfP4JC0oAwEL2xgQ3TFBDwQ5YM2AGMf2D39iYA/z5Mj/eoOl92/Kbk79HvRXzidKjToNqUBeWaUJ8IzZ7k1l4g8fzc8p/YwLg9wgaTkL45/Lb14Dd3bnxOw2Qh/gO8WYVIBohmELEJWNpAqL1qC73LwIJCfA44OaCVA1oJS9XnQq2q0VaagLaZruOMT0UPQUHg9B6QxPxc9EJNz0g98gAH3K8WYbeQyCujbP3VAPjPgN5CNMK0LRDNAaoEghxHEj3ZJXAijwlDm/fTzkD8QnAPb8EvE4Pl9gDUkMHcgwYd0KtwlDCg1CwsGJSr4GQpgOGDhPM0IZ8WQuZz0g53OfzcpgA3lzyDt5dD0tMsPTQBtQoIOwGYBFsRZHQA/oPtTFCiFX0MP9MbGUKDC5QkMIVD/A8MMCC4nIMGjd05YXiWFAWEJULlkwgwN19yQ80J+D2AiOQ5DbXfv3zCHXQsNnCXQ5FHIBM4U6EWwurRnAbCDzJsNxCWw67waCLzJoKVdTggILG9ew6uC0CknB1j7JDQhIKAdafNMKqNxgw33qRdINqBmD4MXPx5DS3E7E/DHrEsM8d8aZgF3DXfcXz2CAw2HXbCMfTsPPDuw4gLUDX7EkCixQ/MKxJ4cTJCkdwJhM5l1dRwh8MZCvgqcKscXjEBAAQTfKEN59uQ+T0dDdMWEkL9gIlvld9vQ0X3cC/Q932lCjw2UKOCOws8LDDDLErWwBF8MIK3FLpOo0tJifWWl9QC5ZwRhsv/IYIE9UIk/TfDUgmcIMxvw4yDOMaInbzoiSoT8MYjbfFvkGA9EIwWw0D2ViPO8dg6j2gjmDLtzu94IgSOidzggNmEiTNCkIDRdQrESiCLJPOVVp3SSLAND5IpP0+DfvN+zQjwXTMPydjfTSNctaTB0P/C9vGKMFD6kEULXh87X6GC9QvMyGOcqgrr0lCoIuoJgjeIuCP4i/fVQNIc3I6MIysPQIfzj9GlJHkwj+Gd/w7JBg0KOfDwwZSO+DSI1h3Z8cw212bkdIxFwWCC4EAGLCjImH1EgIA7g0sjtg6sxsiiouyNwCETX3xDcKooSIMhRIwq1qjJhOekVAyiCEINdvvdqKSDyYLqJIjZnMiIxM7AzINtD11cHy59Eo3TGujVw/MjugmVSAKdlDoogFyjG/fcKdNDw7AN8Rgw0qPFMLwkgKecQEPH3QiS+LFFtghhYJmtEShQV2CijQqExNDzojMJ2CTA6AABxrfBDhk89IB6It8ynU7DxjXovoEGBtAZQCdkgonKKxc8opH39DFouwxBjZfUMPKjwY5CMhip4fsJuDBmCSPjc2o40Ig9MYyKOxigfXnwACutE/VyC9IkohuiF6CaJyADwfCGkhw4OHzC8RfKyPmjfXWyNZjYI9mMcjOYxCIhiLgoK01Y+YnRxHCs2aWiodvo+d3pdFI6ujFjEzCWP31I+DSOljntOYISjLfE7E9jDIkQM2AFSCuyGA9EQ5y7UtgxH2si9YlmNhMSoo2LKi1ormNIclQbSIX1AkW4JT0n/WIIZgE/VGMfDsnU6M6iDIFSJSCc3cVimdKI20IzohogsL0jPYh2NgCN/epGQBw4Tky1jKgv6PyiOIjVVbDgYw2LwCOYlONNjuY82MEdgECkOSc9osJUHZltD4JFiwo12MrFWA98MUMZPcgMXDb1FuOLMMVCv2qBmAARS7jUAnuKZjCoriKBjkNNmOHjjY0eOIcr/ANj8sF8ToO/dRobtHWYKefylu5hY9GNFiy47qMuiIoJfAKdbXMrWJi6vT2KAjlYlmBw8M1IRHa9JAn0N7jmw6+wHjr4oeJWiR43t0v8nvOiD8tM/GGOgoE5X1FB5cRQdjj9ug/jyIjl4gBIujV3K6JRiCYrdxctt42rzyDPYumPQ4YEiC2MQKSSsJohnwbGCQS2I8+P7juItsMTjb45OJwT1o9QN0grY2N0spvuSoTc5YsOd0Xi/42hIii3Yv/0YTFYufzHkIEjhP+8Uo3QSppDwKYBQA1YsoNmxwInEIBi0EiRMHipErBLvjZE1OJK104jjzD9kYwMA6g38XLzeZf4wT3/idE1eKijgEs0O9icIceTYSIfExOiTofE8DgA1YxnDVjfoTuPpjo4xmNjjmYy+IODjw++z4iwYseLTjdIT9w7wn/LNgp9RaLhMdiFvZ2Nco6ErGL0Tc3UBM3jfw2iKeiBXaBODjXQ2WHt8NkTWOyTtYuaJuIFogpMDCXEk8PlCZEwgLfcXIl2L9Rqovswf9TWf7jKJ3gp2JOjUw0uPCTVIyuM/IAcOcM3izfP2NJipOY2zMSQ4xANZwnZYKyjixkmON1j8kmL2cSME1xOgBiQ3BIjDXKYBBP0Bwk8VT1tQ7khf90QPZS9wd/a8JCSdfF2JaTxYtpKN8ofVnyhD1ZYxPliUU4QIcDZoBAI+iZok+LcCxEwGMKSeI2ZJKTVHC8KWTrASPnFsiE3oi5B4mAEV+caRTOSc9CIlMIeNWki0OL1bXGKPrjNAWEJXkzTJENTpYSQRz6ScUiOgGALANIE2Dnk3JMBtMA+OLR8b4txPmSSQnsJdjdIFUIysSEqMmTZ8eQWLkJYUxIL2TmQ92JeMa47gPOSeHUVKk4I+NyIpi0JdaEjjfo/f2qC+4r/WmTPk8lNBjKUspKEiCYRRJUV/5N+XDNqBKMzHCmk3/x5SZRbzzZ9ZY+YL0jOjXeNLD7AJB2f1RkhHzUEHE6AEmT3kq+P9E1U75NWiPExCLw0flUkgBUXzbYlEBqUUQHYBeQ7SEsRxECEkaALEITn/5O7GFQjU/VMey/MdnJUMTtkLcfxSJIAPTAnTltfpERxhE+pCqp+kasiN9OrJaD4wiLWO3ZpVJLmnXT0YU62ZxzrHC0us8LOlCZVnredOIs/Wfq1Yc53UqRgggfNh3xiRIGi0+tZoDKAKcWLUVX1kiiZjgVtlbe6PMxgrcVWtlYcCTlgQQaPSEAzgbOjgYtfrTAFAyAEEADfsKJdi2VUobRi2c8d0wxHBMBLFBCRs9VFGyos0bHiQCUrrbgBgs+aZAAOQBaVUT4Y3/RhhNxUQUZnVJ6CMln6CkKE7X+lwyIfiFI/OAtHrEFhd7z1Dc471his9pUllWU/EpJAnBdhbcV0dOMmP0KZxcZN1JJ/JJuECkUuNZBv10AY0z1JQrWGNf9IUk5ieFGM3ZRai4eHyJ/sbYtSh5AEYuyTuCieW2HRkeeBJh3RkWI6QuZuyIf2hlkxdUg6gqHJxg9BbM3+zozOjVxEDEPQTyO8iJleU1VJJGKzXuk8RN5DYAJMkzNKYfM2TOitOMoMSyt4kWGVni7GTvDYyGo/xK/j7JRpVaVqA44UytUsuxjNAbmfsgkzHPOtGRYupeaSYysIlgUMzak2LODJYscMUkzos2pTDBak2jJGVWRItjek6KJ4LopfQSkWu4blLkGRYkyE8V/dMmH6QckICUZVGkumVbluZvFUEU8JYgqzOeUhSObwJZcs2K2s0PUP2UeYHmd5SyzFMmQkxQqiQEEhSY/IczxZJs3hmlpXbOxkyk8ZW7LZSxs7LPxFn/awmYJfUexXpEdCMEW+FVlb+z54Ts5/zfw6WbrOJ8ueFMmaEkmUD3AUNFBgMWcHKM6APl04wBMQln5P4WTJisg8T7ZjxPJUjTZ4kdlhwuxdBknYoqfsRSBBxNAGHFRxTKmqsUqYOy9c5xSuUyoKrOqyrkGrYXPysypDKw7ZdxapLvZVuZsQjS+pfLH5shfKiy/YGqO8ToR/2DFyotVnVISrksuZL0gAYpf/hswNA6NySkYw3aK/Dd0jrn7AOofLwaSM1VK2nj3nKNPmBb02z0OleFC0w7VAoQ5Om4hFTwREVvBAaUDEFcpsX7wTbNsS/kzIHbiGko7J23ay/Mj3PyyUCD7jHdqQhkX4zX5Hj2f9OlRXPWkwUzaURjWUkyV2lZ3ZXM/kXWAHiRiqA+HIuly0SHgOZoeBzPMylmf4UOVW0V6QqFSE7Qm48gUdbNTE/pI1K7yK84LMzY0nMGWi4k5JNChlSsqMg19UZSMGZ4mWZGVpFV8yKwdYnMxHOulLFdLO2lfUR5PF5P0KXmvpEMP8Apl4Q3QxiTCuBmR1YmZNjTZksMW10yh+BHmUbp+ZAqUFlHeEWSYwXrXwQIYOMKWREgZZf3jllA+N8RAlYLcdJAQJgAuHxAHY3IkstP0my3kIMoQuAnsnZZW2tc+4OdzVtYMjApngsCnArKI8CgEAILdMhBWxNZI32R3yKlZ3MBJkrevgI0m+V+PnsA8D0EUY+lOGL/cYxN22Kp0pLgvb4vAXgqHzMWQQr9tV+AO0atJYCuTDt6rFfiULa5bq3rk+rFlQGtD+Yawzt7ZJAvCAJrFEjzteVJUELs3MYu3/gtbKtKv8zc8exswIgLR2tyMrOsHvC73dKUjNCRUDzdybwsPw/k48/qS9y++H3KAV8cvhVhxj4xFJuJGpLBk1RWpIanak9M6CijzomJXNjzKpQIoJlBpF3gwjPbVPLxz45KTLwi8ed6X1TRafsDNI7uRoWLzcI0vJEZEeY/MjEq8+P1u5AFenLT184B5T4yPnQvMuYW8g/Kh4KWDvIelbc+6Uj9YydtAEzuMgQuMl+CtbOx4Ns+yVHyKlGb3VImUnvN0ZWWWfK7odCGaRLBF8+fKQoV8jAjfx180JU3yjtE4sByXMjrMxlW8mLNBS1igHO25CZc/O/RL82XhvzmTe/M40vc7XmfzZ/ZQEwxDeOfw/yghWBWt4f6AWRoQaMf/KYhACilRBwPeCRQhxES93hShZZSKj5EYCgWzgLnKMFQYlR5dyIlsY+dApltxgYuEgAy4SUDVYpOciXctpkPWRssKSq+GpKk+czBT5n4GgpcKrlNxX7ywyVljoC/c3qyStrbEsRDk0TN2S2iv3JlPGKIRZPVqVbhAuKlzccwc2e5AweUrpZYcmh3qT92JQrHF5CycUUKxc3WAlzVCu2jjserFm3Bgr0rElTtdClvik4C4N2XxAjCqayrkZrY9XMLn1Ba2f5dTEIBsKY4L/hFLqSVS0tUdrBOxhJiufPhkUcS9XKICCNOfCK5pOR9MkxJbKy2IKZbb9M7gFbTkvwK7XCWwBtCiR6hzKnZPMqoKCyy4l0VB+U23S9O6R5VcVnOTLO+djMj+PhzIsoPFpZ2lF5SUzPJfyP2zlE+TKod6o2JEtFqiuHKSUuUOeItpPC/fISlzpJfNYZR/NXJrxWC222FtI+HxNV0QxWcsDBlCDsrCASpYIpHdQc6zT3LaitXUPLyrYuWXYbyhQpeJ9S00pUK6rUkkjswKFdBXRC+S0o0KbSrQo0BBo0rgdLYcKMpTKjCnuR9pPSmk33yfSywuMhQg4EDLs1rBKCrstrDm1jKYnIOm0F2FWCyzMcbf4NvzftUVMnS0iXvn3kE7J+KEdxzXBTQEbiTuyJV5rG+VgLMAe+UIEDc1+JsyAqJxmHK4sphKIAf5dKW4r00ZUu4TOBXHL4FwS6+jCzPZSdmQUHASQWkqesGQT6wsFXxKzyOspUshZUlEMG6yNihHLCxFGNWgDQnGAdEjBUQb1meDIsR7JzxRyrLILkgFZLJQIxCEfLNAu2FRKB5yE26QnyyRWwGBTNsr7ieYdRKyo0qVmN/CCz7pJShkiicN/ECzLsjUrzynJELi1KAc4oqPy6ylzJDFHiirPe9U9Cyq3yg8E7R6VUWYq0+F08jooKzjUxYrBSi86POBwJRfc2UEWnaNwgioTLQV/5+jPCrhCzTEaMorYuVGJ8L6UoUBniOixnJvz3BJqQfAWpUivFkUSsAslQJK9CqCK5FcIUEjJS8ICm8/CizT7yFhQ3PHibMaLUBS3nTbgZy8Ewtx6qBqyylszyswSt7KVmHarTjQgypKT0OKvFi4rXgoSpgMTqquHBVwklLG0kLgf2FENbsW1X2tkaQ6zHT8SidO3lUIldJghzYOdNfSYatvHeiwGc9I3TmIBjEwziVVdP95Ma8mk3TOaJkpwLd0lpzOt2qbCw8QIYI9Mh0brM9IRrXRS9L/KjfAUL3kDiHGJscb0vvlot50rWwHIQbGDMY5s+H9K+iq4CsonTV4f60ZLpbeDKk5yieBHFrFVb61lUQMmGkQzVWeWohtUM3eGhsjo2Gzgzx8bDIxhEbbTn1VRLOTnEteJJQXIzdkbSUFpaCuDMtxblSJQREV0UYTy95MoUpcZ0QIRgqZFpDORuLHhY5gMkjmUeWSVFct4PTwHhc1hayVctrO7LeeWo2ekIgqqrpCkc7+0y8nRfgBUz4uKUXUzmIoRLugJYTZAyEkih6wdqPaxst54XagcuH5ahcupziewb2ph4ziqzQ/KAPd6Vb4vo0OujyggGpX+FVsisgaVUlTZQWLrNBOo8kEWLyM7K268xUMcM6nengUaokFjHRpszsntw3a9kTCr5s1Wicqm82OSyzMIzvAMqwsTgEMzu8uOo8VpCAPBrR80K5WxIu68JkMyY7aOqWL35RdCZTtSuzM+Y9Hfoh2VrWQ8WqrUi8+pmUE9HEjScuQeqJB4dA1dDtwIUszOWK9XOijPrGCgvP85ZhLL0O4wsTkQzyERY+pjJxI1jNW4HlGRnWT885/0PEA6oosjEZpT+NaKhOaHM7wjK/aPMDn6jFmtFYyOyuUId6oln9xD66nknzkWCLK1D16/+p2E5lV2shZlcH+vLzIqpOuczxCpHIajUQA0S6D35KuteVNaUZ1VK6cmOrkiEOQnPhqvzC3IzjdE6sRtzY2BaUGyUilupjy2inRvnp3sJnPHYWc0QTZzZ2edkXYr8PnLXYBc5tyFzHyxcTvKnywJpVLyc8xuvZ5c6nIREepWxtrzVci8XjL3YMRFvFf2HXIfFq1Ytzuq7EY3OHS7CwxrzpD+cIIxYWM+3Pv8hijJkDBrQ9VXIrx/EIvaL9XJ9OELDquz2FL0OAPLqk14lkhm5xqtgEmqXi3VnM1Im7qVpyugupvjyiARPJyLsTfbg8zDuIaseLJpNSuobSixBuu5Ki3euckW6kvOf8y8+phzydCFyp4r35OZtOF68otkbznuZvJOA7CGdzgJr6t7h6DU9MYoWVIxL7IXRB8vyvmLBw64vgbPmVYve5hiv2q2Kc81BqayF8vhsOLYyY4pCq181JwRk8lNjLnK/pJYruKBi3yOwagZW2FPzXiyXneLmDK/IAx5eAis/Ufirhz+LGZXXkBLX8kEvfzzebmQhLSMH/IKoxMfiHhNsEAAsmb3raasIYAhIAogLJIKAuxKVyg+TgzTLSPhe8tZUksJraY5ohjKKCmuCfh7owsslrMy6Vo7hZW8YWcsFW1MsDFrlS7PGK43W2GtCWCsUpPlqm0xplyKcsrIHNbYHJWNRU5RprMa0WixtSrfUW1uvLDSwWC8aCqHxsPYzSl8otK65BO0BJbSrSPtLj+FLnZ9gEfTDdKTCufhxJ5rWCuoBEMhCobs9reJtDLq7NCv/4oykIL5t024dPgKiuXNpJK0CqVsFrSyqeArKiYpUQZL3ydW3La5RGLTNkKyroirKS6iiheCg8dxSpy+yhZmCqEquRruaUne5SiAwAAJNaYhQZRt6C9hJev7bYsy2xr41yiUrttrgwq2GYt8pnlgboKNwpCatxddqO1N2yCjgad26AD1KTSz1uCbEqY0pDs/W74gDb1CoNqTs9+f8rDb07Fvhza/LMCvdLdYSCqrg4abAUTa8ARfBTa+kcu0pIUK9mw0t0K4MvfpyFWwQ8hcK+k0v0G1BEI0wiKqGvFaWa82GJz3HM1Oor1YM+VorMBcfwflb5ZioIE66Nit8Lty5urzd9Hb+N48NGhLCSwtG/NkajgWgx3REmOos3AUvHRD1M46WySuEFr6NrHEEUFeSvbbDMTBQkCwKKHIDJSqk7g8rPuBUsj8e2w7huar6khovqllLjsR5EsmOQ1COoTjpPEcI+QgvLUGjLHWK4Wtjuajt26ztiDQW2eMCSw0MdqDRkmWXMuNqkozoY6ug0zrfwkY83RMyys96XcUppWMk55UWXpQjJDFN5GJ9GiuAgpEgGrthti/OcYtayrs4Zv8KMiwtmwAsQXLpwAY7BDDqqqLBqsudc0/6Ng6sK9qqQ7BjFDt0M6vdmszq7aKpvNyamppt9yatf3P4VnG9OC6bYinBniKfeLltAKpFczgWq4BKhhJk33AjUa7qO2GNo776p7KDxZ6l/Ca7Lw+Yn2r3co6uGrPqs6O5ADqlvj+qSQAGsPI67R8zMADreirts58KGuEiYapdNRr0YSzmzrt05dJq4Sa/dLJqLrNkmPTT0kNrprfWNin+7NgNK1IrWarz3Xcwe4qi5rX0nmrxoP0stuzK5RY3zdg/060KAyiyo3xVrCYBiXVqfqPmp+tlasDPktkMxVUhsta9DMNDcavyQNr8aQS11UdOUmkygiM1GgtrESq2o8gbawMU8BDMwgHhzVss4TGzkYs0EXR0GnYuur/K3rN55Fu2MkDA5OqJtzleiuMKU6f7dLt/cdy1ySSrYm7wD2zBsqhzF6x0OUtsq6KWcvpCs6rdLUzZkX6scBnwd4HeBkAG1CzTT26sttZeem+r2kRe1KQkyJe6yoA9PymMFSV5e7qUV7aQ5XqHLBmm4o+yoyB5S16Aiq8qF63KxjvDS60XxRd7ZekLI7rMRZzi7KHFBigCqbizaotYlmfUJNxui4dsmVDskcoml85EPt7ZUW0WicYs5CuuRzjtL3rUTXUdbIVLqhCHMczeShXu7IDhA4RqUS+xGUPzP6pHlwb8qv3pWaeiyaXcyCxQBT2LoWtLJ17WmYD1Fpcqy4qjIOMsljiqlmFXEPEHa1TpGzURfPsmlPemZviyBy9kTpYHg25XayrhNpXr7f8XAC2a6ldvi9tn/fXvd7q84HJdwI+0epD7ajQ9pLZNqqXpuL1+gPGlpus88szYRsrPM/7h/O3Oc9WOrLs0V56ZK2JzjGiJJ2DQmp1vCbLGgAbSKYmuPpAVwinIGZzapFxpyB2ckgE5zuczxsvb12a9sFyvWxCTPab258ps5jyx1vlNnW8fqsa1aYgYKLOukMu1zv2RqgpUWqXXPSa823WGya41PLiy4D5cJOcLxySgRKbCrCKvrKkRbwrNb7BdrtCKWm6iwdalE7bvqaF6NpvG4K44PORV1UMPMG6E8xIrtreiQQbdb0i9AcW5sign3qFP+yaWObBs67JSrKquAjKL+BhHNfqpG0Wke5zO6MUsyfnYXgOb3qlBoCH/uLorH6Go0HiA9+i7Qewj28+5sspHm/st9RqhUdG2KPpTHjbKvm5BpCHJpP5vi6p8+HJnyOOsfus0qeGhr8jluzFE+9Ti2FuSYDWupOs7bipFuX7ch3YoiageOKr6aiZC/LxbPiwlu+LOXLdy15yWoCBfzgSjmShCwSmBWvpI6aEpZa4SxjA5a95YbqIYxZHjExL5ZFazI7Eygkojl8QdhwlbS2+tpZLjgQuExNVWB+BqJUe2trE4VWsoi8Bi4N4Y+H5RdoilpzAttpcHvWXumOYzQaSI0ZErVcpNaUrfQcb4r4Tgrb5nuCQo+asGnxSw6CrL91EKsRxJVkapCnvm6JRc7nDYGoTH1sQlQ7f1r6RA2//mDbGa0Np0Lw2x0tMtMifuBjaIKjKIbZvSoeUWtrALInDtflKeXTa2bcMp/RdkGEgE5y3Vun0teaXLjRMkyv8nBUKJdMrJKE+dOkVBCuTkohGwEYDOLKZWvMGPUDR5bUDFJ+7fq87Kc8sBz7klVLqgahwg2SJqVy2vnFKD5DExDThafdp2KIGrLNcq/K3RoaaCRoVD9HUGgMbJYgx2RpDGsoSkaapS5Sq3LkHy89rsRb21aFfKqaoJQaViGvtqLZplacgdjvyx9s0Lk7bQpbkOR4CpJB5RmeBztjCvkbDsgaADuFGX+UuwtKwOyuxdgpRmuz5sYOvoBnlcpMwEQ6QBOrsIrNIEENu7FY0qRw7iSp8NNaKVUunPkoVS+SOsVqRitxLyOrDlYrzfLcthjvMyPsvrAR3whubkYud2KwWO9KQPHAB55kncTxiJSyweOlLDgSN+MGAvdxKnYeYMpKyTsVpPK+zI8H7gj5qEzOyMvvUIgGlXtmEKKYAfWajhLgoZAU8bodeDnKu0aywxyipRYz3pXVprqzWOhpsU/CFlNaLZ26YQnc4ZADwIm2UvaSulRBWStQUoRqTqUrL6SE2gog+4QjUrmis8eKFDU96TV6bGofFHxwJ43pTzDsyIeslplakWncHxwid9RSfRcshapCdgCwBOAjHJ+baldIe+zihKdqCTpGtFpUmBhy2mjHjFHPrQn6yzwoaiAG6xo1D+zeTLYaeQPYFeFpybiuByKm8OuByVeiIckj5M68dWyuWaAamyBoWSJoA3Mw7OTwSqsVDLq++oUlT1DUQzurqKucTLSq6lOutjJ42LKstYAoy/rn6cxOwjcGacwfBHwx8BxQjGh28friHalAyve9jKiKbka3J5svKYvhXvNn7xI3hhGcYpyYYdZdK970s6JpLCdGk8JpvrAmahlTuv67GWMKFJpcZFlcKf+gvuuKhpp21ebhCLyZ87523MZn6C85GK5A7K+0ammbxg6UkzM2Kxr6FvFcwjy8Y0ZCaWK52lKa0ql6p5vUnjKARuunMUSevNQDesQoeCdp2YtPKqJhQXw7vwfBU99yulBO/44O7Gxq6aFd9Qd1wtFNMh7eqnWqHGStLbuabRB1pu66qB3rpDyWsXpp8FThnlopVP82BVkUDiZauicCNA7q/dFprof/dwBwDxN7h0O6pm7oZ86uiDs8imftAp3DFlPHpcOmclKMoUmaFRUhkBWBrFfS7rXHhbG7r0gOrNGoe6AetmhUkCaqWvHwPu+aAPSKat8v3MGVE9IItge6FwvSge1kdh7C+W9JxjnXe1v5QYekHrh7Y4BHvrakeuqFS9nLKWhnsvqCWrrbMy6WrK0MiVMulUCepWtzIYaQMwYlSejWpHg0M36zVUM9ant69aeo2uEsme2TkzJWekjMUQOerSUoynSW2q/d+pnrJ8zxhjJgkZpyo4Rem0q5GPHbwBrK2KsTxKSh9wusvIsobpp4HPDEs2eaZzmwUjTuszLKh6eaztphucYp+SmLPSnEme8MyakJC3qdore0bmkgSATWEcBxgWxwoQXelUisnAh1of7ndmzNi7KpJ2ZtkmUpwfstIwzbACrm4G2qdFoTKqYr6zvFHudPmdJleeCzscuBV0lahdeZfYoxrPrdZFpYny4bR0ZQn96e++ShD7Fu2IPLnbYAyqqV/Jj5vukl++aQMU+C3yadsL54JlCrjFHStMrbcJmcaHnuMLEnbLs/TqjJVOrdB/mQxLBrfiLMheYzqqZ/3tn6OoTJAMJuUOwkPEzQXo3cZCs0Rue4rJ0Kc6HtJmgK4yg8f8i1Bq5i2mZ4i+w7mgnnuerI3mWimkI9B4JlftjJeCg4TgXV5lhtzzfxnUpJHtGGIMgbRJp/rsZMkWzugBCq/4DZnppccHAJDM7+Ybm7+jCeWEnbE+YxZ5mpqZ0mxC1uYszJpSAZ5BSjQeZQHamuxptd9GkCzRMSc+hKhM8BvgYIGXWm1tymAJ4wYcaKBpxtRmD6VxoHF3GkcUYGPWq9tTGMjPxrTH4xpgfpHuBuRWCXchZTutbmmCJZIHsusgZeBb5RJpvEf2KQfvFg4WQfG73iBQZWrmljxGJzLYgprEjbcqqlq4txR3O46MM1EaZbDB0ZsyLd2wq35m4x6JcJbA8mwZiLhFOIq8HI8ogZsaRBz3KyLrUSZugppm3qYqUplmBa2yjFkooGgwh0JYVMUG6ciim1pWId3VhihoaSGbqgdrQH7g05u7Jzm5aT6Krm+4vT6ymjhZGKvK/5fGLShhBssn3m0kaYy3hb5rcn6h4XhumWWFqfo62phEXaG3piBbknKZ0YZD6kZcMwRaIu5FpGHXM+4ubmBB1oaxaP0HFqm7OjfFqYmGgcGegDrUvzRWGn8ilt5SqWzYdtDthwTuYM9h3/JhL77YWXhLjhxauxnJFXlouHICrEu+U4y3mluGJ0/Qok4UCrUcR7SCmeHIKNW8MBbbCC40fupMCtVdaJKC9ojncrRnpe+anc+IittfFtgrRMOCubrntMRjJmxGIVx/yEKwxpPSJHHV1RcvKZiixQpHA7W8tSXmB9JZSpclzMfvb47Zkafam5V9vAUECgwt5Gb+X9vMw76lsb9L7+MUcDL+xiDulHObIrg4C5BsQcUHVRmNXtl81ktqlt/hm2YVspaHSz/bfh7UYbbbZmtdeoAeSEYtaTxO4RHrHFs/rCG8+1qaKbvFEueb6keR+eeW08iFpopERj0YXH7Cjbo6C7VkLGeFym5heskP64uah63VoJVlLni3ZdrFfej6vVgExvdmpH5+FgbXZQ142CzGfu30emLh/TIdi6M+zsA6GuF6PqGGzl1ZvkztKgAffkh12ofdZhK8wCZHx7FkfLGX29kbfbqx0te5AE16a35GrCweV9L0aP/AVkOxpCo2swy3seg6I7Qcewrhxxf3rV6V1DuPwJxs/HFmzjE2b81SHJwvzV7rN0YI6y6AqjoqRZn0o3H4yrcfRgH5KjsZmt+9jOMGLxkeiBTX5sobGalY0SpSwgdaBW5WKdb8bomZKsTrkr+mvFuk6qDCnTGwyLIwD+nSMxsMBmWSHDeq7Rxwjfq6Fg60JqA6EfNT5mFO6pMBaWpp8ZRQzNlzRyAqnEgBqch5lrtnXzWizfMGRNmZfqRIigSj67FlgbqmrxFblrFXcZ+arPoCZybpNzmNrxe17715qbmYuZ1+2lK1ksZSs12xP5NiSeZhGY66o0rLcLd9u7VyO7q/QGrW7K0wIOFnwa28k8MI+GGtnTumhdOxrJICOfMB8ahLhAyFZsrs+7qVQ9OvWP9Gmq1m9a+mt1nQNpmoNnXrZMcWrn0k71h73072dYtdVksuR7XqRW2qJ0e52b+GiegBHVkxWvHsVrFt+dL9nCgLtLBoyezWtVUhlx7qwzHTHDJEljagjL5UWe41VI8Su5OfzTU56jM9k+F+zN9RG+qqcOnFTARm9qDxqrLUnfpQYQ8ngcxhqpmDy0WhxROyZsF+ZL5jLbwnifFeZf7zO1JSQZYgc3rlnEuMeZb4hWFIC4BSbVIB5tuSkYB+2VGgaH+2Tl9RI8ngdw5ZfWifbaf87LW5vp9s0di8v4K2CJjvcYkdoPFmZpFw5mHWMdusGlo7K4qaAV56GTfbWjhcdfOVwdkIcB3ymYn0WyoGkrKeFoBsuEWIkYjHMgnp+hZg12yF+MUT7sxRPAA9pshnc7m+6QUt7n2O60kGLs5iikF6CWZndkz/176TYbilN1BerS+lHnR3a596YHBaFi5tcldytzhMWzMnQmS6PCH+bT0Mp/rOOyE9sQj/qHVpXeBbus/+YOEbFgYV+3bYSqfp2QubOLQX7RQ7hJwPFw0NQGDlnxemIsB6DxsGCloLOGVuJsOpOBMu2vd/UUuSgfCopV+pFoH6Bjxu6IT1lMaYHt2JgY4GQ1jMbXZvc7pbCbKc4pYDx3Bspc8GF2hJvIgkm2pf3NpBtJs6pdxla19oTc3JrxLZrJAUKbDxtKQ9tYsGMdIabNK7fc2DByZcs3xl0MelzPNxGY2WSkKwdJyWqgLdDyllvppWXXW0pfWXjqhIu8Hk8gkT8HFdvLfRbPmRZqqmSfVabka1m8PY2ahBt/riH3shIaB5HlyXpSGX9tIammSVhLajJsh75fr7flpNwKGbdoTfHqwcm7OE2wV28ZZE5iyFZMqahlSY6hYVtUsTqEVuZiRWHF9qYOL2Fo4sQmrikAbIahhvSdf9kmPfL3z8VygImkGhqYctRsW4mVrtmVglt83DN6mRJbc8b8H+LWVxQ3ZXQS2lukUKdXlaZa/8lKid4ES+qvRKQCs4fFW/eflv73XeJUeFaHrfSAk4u8J4YrWBa8uBaJi4PMDW3yAt2EAydVxVmCOSiUI+1sa4XhGCsdWooRX6VSW/YuXQWeQ7wn1lQf0i4qZkrKB54R1eanWl2g+VtXuN6IemL5GiqEkLcRh2Ln2dHD1bBSnVmkPqP3W2QoDXJctJZyWZ9gxDUKI14DajWU7cDfAVjNCgsKAYNj0rg3jIRFFTX0aUyzf5U2jCsqXuxjDazbx7KMtBIfMchhlWC2iGq2PQactYzKBaqtadkpaZ2Q+GtZTHttlltptYTV2iQvhoyRw0bMAVVsrXdKPkR61dftvSi/aytIV0qzc5XV9/agPfBgE8spfbChCPX9zJMekkx9wNYvX+jiO2zHfEyPeTlAWd44A2SxyNbLHn2u0tGOT+UtfhJ6x8CsTWZj+/gQ3AO0uJQ3QOtDezXMNyLbTagZqrokwRxgjYBD6u9DvFm6t4E4PlNnPDvHT9bQjpSomNkjsIEyOmWwo7/MA/YXWhQXg50n4VzYps3PugTev3E2J4qGdEtoIGbjLTcBR2dxA/Z2c2YAiLaD05dkTrEEOsCTtk3FKjOGUqZOoPTU20LUrowsAZ3T1arda+nVBn8Krqr0j+ToM3s2KSD/bgOyq2FtBkkjQ4gDODGzQCc2XNlazc28mjzZTUiDipe/2UZ8KgWWADoLbEVkS0LdRL9zPGYLW39+RX2PEz28K83Bs6zaS3duisD0g7/LQdtyGhxU/BTtTtbrNi9qnLdlOwDnbsFnKt0Gqu7RZ1Igw7ixpaAa3WtxdIxq3up7ua3FgVrb3SlZr7r630JAbY1nbrPE+u38MEiz1mQe+D3xGMgI2YaPOal9PNn5t6DMJ6TR78gVseF9FLNlVbTbbJLpauEmmDX4KDO45Dt19JhoHh0IMDmlVYOYp7Q5h/ZB79a27cNr6evDMZ7WEZ7Yxt2egdNgsuetPtU6blMypXWQuLaaDwhQKSNRYgh6vOdWHmaPeITjFILPmbCjnIRT3NKJ6brm5ld6QCBb5vHY62ZkF2jt986mQELrKd4WgQvkF15AnK9FVC6jJ0L8zrenXdx6cvqbkV7MPmCLx/0IHuLwoY6UgJh1gOzhNucFvmjqBesCQbJhrOGct2ySmIXQJyMfs6vd85QN7BGhEQ2mAPN+sixVO2JiSzJ8yUFS8nhUjVYO91lKWLRsCqeBroKpp9ZgnVezioEn8F08s7XHK/IfL7PmTSeNYEpjmZyHH1qS7oPtO+stgP3+pghWVjFeHlahJpqeo6Z96j9fS2ARHoLDAYrNI492YdtRZi6LaeKfeWZ6h3fIW1dyK47IQu7xRMzDMt5Sr3UYmveTO4xzAeGXzMIxMCXHq6byJBDF792LD4tagZZhcAAAAUUlzo/vLx9zJZuIp989b6PEJRo7e8+rh6fX3EiapYkHtc1qgaX99jJuuG1jzNqg7s2orgeHReXY6Fai167pLWTNOWuOOG1s4/nK+4J+ClijRm45lFG1hI7dgeF/bznmfxki9b60jgzLgbcjpqAAByN6rBvgW8IH0WphSrLUumWc7NrmOJnC+uRwzOypqUu2OsDtIxF/Ce8U09hg6Kt3apG65Zn57hvrKoW8RccYTcLkHhzqGlEBBvn/K7hbOd/Q0fTbp1lEda7PwAHgGqxrjdZBP6kXm79XA12E5qsz131q4Gw1xkYfacT38rG22RysYg2w+e2VOupjn9vJPOrwUcQ3rAYriHmjwOk4OvUKo68VGmT3TeBmE7Nk+t0xxhvS5PEC3Ud5OOr8MARortWjctHhTtdlFObiUjqYrJT7cco6ZTyo8Mr8ImP3qT+N+gXrOLaCm94rRNsBRSxYfSTcsPTT4TuYNROy08U3VN5TdpXltR07vpxsbrY9SdNyrraqQZgzY5PftBYIdjTNq7SDOjB2frMuIWv+2xTisCM6rugvIYBC9Wzvqoduervwq72Rq2ZcLF/9jGYcHgtnM5G6mqAs6aWizomdVcZu3LZrugrkFtkn91ArarhdUnwdkzI7s3q1TntNaopCwBl5p8kV7+2Ze8A73u6DKHzM2Kq2bieAu3kJOVMpnS4axrZhq10yc5lnVM+Wfe6877+QXOVZlE6ot1Zv7q3PtZkbdXPaNgmA5q5FHGIVHpt6HqPPoXC2bnIFt+67uOFbV6l1Ga2p2cVUiC7bcARQSedefOFaq2ddm/Z9d2/Pyey7ap7X78ZCjnQLh7djmGIMS3Rs2e+qve29kT7Yc40+w8TXXSrkLi49SFhfqKrnF6+rJZTyzG+EammWYXsugVyLvEe9FdrPoK3avC8XWfuEMQeVhd2EbaUaLu2nfuCdhi6J27waSDJ2Kd7ok4fo7Q5tVoLs3yusk/Ofy4RFhH7RbeQxH1buj8eLzhbL2wU1x4DwDKjZlz6JL1G5VAQAFHMxRqlNoRNXlSIymkfbpvZaOWgWB3dsfDuULoN7mhDZP6Vkmfto17OLlBt7Wl6/zNTqmbgR5fqss71hewKoZZR4qg9mcrH5TLy1gGGQzipUsfdp1HNMzoKHRYd252urLeRMkfcqEaF96HYyGHYVqC6mjlf5sqzbJqoabKpy/nqiyCnirjRkkDseoS6z+wFssWKlA1DsIa+/SWEyLH1bgier+xHnifPmDTrKglL5q7i3SBtq+RGG93/e7uwrDzvKKJh8JaibO91q/saUsXvcDyqVyAEH2klnnIvbA12kfqcZrlKjmvxbpgaWvQ0hfataob9vdPRnn8s7ibVj3Eo2utclJu2uAOXa8LPTclpeJmPIE/aMtVBjrjz6f4wxAv26lYo59YAL0/af2zBz/fAOJuzdZ7uXn1Bh/3urtGbsGKgTGYjy0+nKaeea8859l2Jmnwf+OssrvfKrghlSeIvY6pYrQPPljA5iGHFbA73U9mtifMfIlyyTeWjhD5eTqFmS6WubNdrTuyvpLrK90r97kyXmnuC8FbaOfL5SZhWGzuFeKGBD5m6EOHikQ/BaxDjFdInJDwXY8eZDr2SxWCVgN/9flD2ftUOdhdQ4pXNDj4vJkFhxS0Odcwx/I2gAStlY2HzDgToTuGzaw7JzbDtdnsPhVobpC2x7tEuALLh6AouvObxoi5GHhz2eVWXhwEb/J3h5JTVZvhmqEVjsHy+FeGG39kuqJwRxWMDEiXlBtyHZM3QfdGyjh24qPM491Yz3n/Vo+9WyR31Yo3WO1aQHzsJtg6i6fJQ9f9WDS7o6DXejiW8vXw1q0sTtcT6NYJOUuKTnuGeR+se/b3iJNbtDNbqk4k5rC5Y7Ni8XkrXRHwSUl6HDNB5a5v3vFSor0Hy3rhWf34XlM6LOzn8pemXXBPvfmXB7+wcAPw34A8eehmvl4g+BXjpCTzeroSbYXgz+ZqwvjliHdth316V6Weohpd+6VbljLyVfKslV+SHnl0V41fTpCaSyHBmPV+d3bFWg4q4ih/g/KotqmZ6W6SJ2Yqx5qhm14yvAVjU8ifHX7JBaHkV3nlRWiJ75wcvl67fO9fpD/ob9eiVrg5XRFDoYapCQ3sla8GZh3FtU35h3Q9LviWpYahDtD5DDWHKWlN5pa03sbqsPGWrN/5XWW6qnZbzh0e5cOi3vlulgrhrw4du4M3w4yIojyVpeG3huI7tuDoxI+Loojt668tYj9uDCPXZJI9YvMP+OoUatJym/cnGJGabpYGbpHi8yyJ2oVSx6ik1JHevj9cvNjx37ykJGp3pHhnf2Dl1YXeRC+r54KvVpr+tYZCqbd5ymBgF5XEFrtfgPefymvC1mAKy7SArcyYL8mOr32No0A5jx/lbHjIRY/FH+3SUfWOjbr8yjK2Q+kPOv82y64HOp0+2R2/aiML8rWUHh5OT4MzetcR6LvrZKu/yYbVvnmcvfT5AnDsneZkz7HlAlEe/HqP2hyfe8RoXvPH0zvcYLCXsmGBeyY8GTkUn+RvB+3/OwHLh6QQkotXF2yr+XaNyxAtfjTy0Lu6fSRo8vyWTyyOqeV2RD0HnoQX9gdH2prhE8G+xR4TD/u6CkPo2egf57hW7bqqW8GOvzEDbXPXLGNcJOebUyy7khWTEMbHqaFNcW+01jHEiBEKiu2QqDbyDojLGTlY9NuWT82/w3LbvQ+tuSN1Olvv8QVMpnGHbvN3nGOb6Wfo3lxiulXGxT1jd5ofbjjZ3G9rzs4rmodhpUoTpdkO/4rDBvFb2aXfmMnqTd43jqrdZAasLrcG3HcyqATThszNPk7i04kE07h04zvL84rr5VnT/6bPidg906HHPTku6Jam1PIOget1SM+6auz+ZsrPmb2zecAC/xzcNPYz0knjOqXoD5pecP7zag+xq/rtEUsZgt+8/8z8P9fFdz4s4O+J4ue7GX0skv6k+YZkmfWqwrWQ+K+Yf1347ujLMeQn/sTU17qUXRZLeFtNuh3+0b4t3He3v8EordlOStk7qBq9rRu3Hir7lKhvu9IAuGtDxzxtyoe8a2WY63ZzxWe/vet3+/621ZwbaAfhtwHtAfBT5mpge/KBxifp17+Zs3geJ51fOyD2VYts2VsTbTeorbzvOhNQfOoQTWyBDw/gRDxweIkQABTEnO2v5woend3XOd7hoeuGToeEF0YexGRIQWmyCgrDzguf12DETKS8UiOyNeoSlB+tfSkyVRRYYrx0Ee0iyj6jwQQmfBwom0TAMq5F3C61V1tY2AD56YgNxuOnXUa0flj6cBA0WCT1AWON3/6U5EfWMM168L3Ut6ej1hwawCf4TvRCsdEzxYDANtGznBtiMvVyUbHQMkHALYOch3d2qdV4BSnwqgddyjIGnW0oa8wfWhmRT4kgK8Bt628kKOzW4CpQ/qMTFaYv62pmKgKtovshOeQghUuwtEsBGVXYBZwk9qCzAeUoPHBycymtGzmS76JVlRYqSmEByO1cBpgJTEgg0AmFSkqucBACmNLDnqY0gnWnE2meVuDSeGyid+W9RCYYl24WziyOaMdS/COSmD2fGRky/YHcBEmUzm20i2UuQNke3PByyZXxMkXgDD2e0nfkTgmxu6WQDQZ2WMUkjQH6QwzzG4PDYBFCwCo143N2tylYIwi1QW5QJvmLwBhu2X3fk6/W/cuV34BCpz3q6V136EkRky8QIMUGkUwmKB1FEPQK4OoaEfqQA2ImMVzce6OSKBNO00qclzmyiPEyBatHxucRGiBBXgzULVxA+Fz18WVz1Zem/xDM8VTU6JS15eary/2yM0caKmD82EVE+e3zyHEw+0uIlPyNKwa18aFIICa1Pz3eBVHBe2gUheRS2he3dVheKHzX2iI3EGKLzqWqTR2uu9gP2Sox7GGxy2+J1ziSiv32+rS0O+UZWQKrbxre532gBn13VAVRBRccrHi+WfAeua20CsqoMyoafTsqLE2yy2ynhiAfVYEI+Vx+Cu3e+vc1SmvbRcUfAOcB9r2UWVmidwiPxAAZ5GVElqxrYVXwDYvxzVOYJxyBsWEhOgAP5ufhV3WiA0BO6J26+cJy3ePX0wA/X2UKN5SvWS51mgIRCe6QG05+wxwrGtGkm+4rDFBrpRJO17zsQt70felJyW+f7UXwK1j1uMv3Q2h1wV+xtyV+hd11q88n027J2z+QIS1+k6WNmu5z5OtZyoqgpyvwbt0Y2xHU9u4p29up22gk0p3t+Ad3lOMWSbOzQ2Y6qp3Du6p3+amp0k+pPHDOKWH1OezgOc8d0c+id1iBFOhTuMfz8U3AHj+eLUT+eClzuLp1T+1ZnT+uG0z+LYJ9OPSRABr3gr+SZ0RBigKVOVZyFcTd0ru5mxZgMZ30QNf3DmXd0H+3i272aZxb+gWzb+Jww7+OMy7+n4wlB9LyRwU3RVGr9lAh2/1aYc4LX+5sX5OU4LteAgIBBju29su8iPub1A7Op9yZeY/3UC+/wGqh/zK2Z3VP+F3T7OzG0v++mBv+I50fuY5yrIE50IBykhfuvEMrIj/zUkAkJR8VAIvGb/14oqs3/uX/zluJvzZUDNVkh5swm2kDyB8ykJm2IGQQetHEgBt30VBnw3aI5ZTx6bbyx6sCDWqoJHqSXs1POPs2MhQCHfsZDwu22tThBHpzo2RAOAudPRIBMczIBZtSYeic0tqMFwoySACoyHDzoBiIiNYf/QhujHypmj/T+WYIG9qrCxGmRbA6g7WUwWl/REIKzyOEO/UouwYw4OAOx4Okk052dUQmyoZ1tgy920eWgNHmOgJyAwUmWQayDCkRdV1BwUJUeeCzYaoO3DBOkwqepAyO4sUOqBRc30uw+SQuGXmyhEXAT6E0jCwrj0QGnBzemmlCdqOoks0jtSKhcBAbuMQJoyMVTmBucTShC028U90h/wOlycudjEeyBwIj2UwKR4FDW16R3DgGEhzuA8pS4mhUJxudlUxOK70hEJu3gWa/Q+al1UsuLtmBBKpCH8omWH+dFDCBFFF4WcDXMmQgwXKc0wtA92R9kQJ2Um5q3c6eNykBxkyaUXF03mzAhOB8zW2hwvCcuznVWeOVmkyBLE36JS0zYcOymkrLGZ2ecUsoSh3GyI7Q0CMvWt2nH34uWUNaYe+UL4NggRBtLx260GGRBDtwCW3KWpeEL3wGi+1ZBgDQ72HILCKXXXxBUuh668SxoGbjVJBySxH2fXzFulZiBee7GhOdIxp+vf2b2GIKX2PE2FhOILpeha15Bm11ReMgwxek9yxekUhyaygy7u0pi6W1sTkuQJ2/eQqB1cfZU/82FWZ6TFTlWSoGQKhkG1WZ3yCOpcHtknb3OOX1U14coPVB+snZ8xcCNkIIztmnUVDhaX1RO9sPRO/UJ9eONz3EH/gaUmSEp4gsOsaHez4mBU0+OVqy9BG3SniaIJDETP1XmSjRmymzAJua61ahJRw1h8+35hULw1COsPZBJIHzhHR38ap7RpBPRzpBCYOG+pY1lu3PyVsp70dKoJHVk4Ki/ac3zL0dJXF+I8lhIAQEDKivlfe/ixLggRkJe1Q0dhSeksBExQ+apnQA+j+3r+1dyH+oHxMGDL0n+lEL7upn2g+HTX826Mzg+WZwQ+3L1WWusNX2osKcGkB3S+foOw+893gOCzQqqEryLm5yxy+nl3v6NRQVedyy2kiQx6ev/XfhtjAY+B0NruojBY+Py1SU0u3ukDzXwipkhKGvH0JEzrznedR2teY+VmU+ELuB3H2bOo/2deJKzaGoh2Zmy+QuhGnxU+7HTU+eVSDe1U0JWiLRywWr3E+iz2mGbxU+eMvGjeN8MWGqKVtCVnx14Nn2Te7MlTeUOAQhQekzeQS2zeBVFzennz8EuZ1mqSJQxKkq38+ex0C+qRGM0WRFMsp32eGCoPTo7w1aIT8HvIzljDhyrVOOSXwsRCtisRUtHFBv1yMBQpAmh6viYONIT86eX2PQBVwSh4z1meOcJBhB60ReopSLh6P3NidKQnenHk7Ab2X1YO2RPE8pU7aA62BOYlUjBs117hO737hjVkTBrVjHoq3COBJk1pm7P0PeXPxPeCt1jWhiJLgbw3zBM8K0i971LBZsnngy8JNu1pQzaht1rBooPtk7EkPce33CRyoyFs5sTVGGJk4CARxOO55yFqZRF/InJUeGr1zsRUyIraTlhqgcyKe+wUMwWhmRqUP+FyhNLlckBUO7ITQyf690yDwWIDeylwN06d+xuUZT2kWwE3pu7ULyGLZVdG7oNR+kSPKO770qOZH34+f30qGDl3nejcKaObX352vyIE+/yI3e/ti6O3cJyR270ROjxAGO5SIzBYGyqRfPz6R08JF+IoyaREv2CANRGl+4HTl+Oayw2ZChV+//AtuyHQ1+Tahtum0T5uqVkygztz7B3RAHBiEg9uKVC9um4xt+18gnBT8lGWYELemq2X7qwLSuBiUKHol425RGEOfWIe35R8YUCRALgBM4CnRcO4IEEoWSTuB4Oj+4nVj+DZi2WsgntOGqPPB30znO2IQq6A4zNuW5hiMwqVjej0X9ie3kL4v4Ic2b4LZhxfw0upf1lRNqMDO/4Kr+gEOa6wEMA+Iy2A+9qKb+LL3MYD8I5ew92zO6iMLe8EKk2dYKDBffylBA/zRBLyyY+jqNH+2EO9B6EP5ebr0PGCnwJu5E0hEQqKohdtg3+FEPfBc/y8SNENiRogXYecvFK2p3VSEFWzG85/zXYrEJKITW1hqaQCjOP/xlmUs0AuaNX4hckOUkOj062n9yvB85wkhAMCkhfKgAems2/+D1h1mf/whq4Dz5ud6Stci6LABcGU0hD0AwBSyOR6v5AfgMZTQBdFyQB/HGK4T5zO26AKQeh6Lok+kDcsmDyDm28BDmgNlr+HaOoerkOjmyNnoelS3IBCc0oBScz8h1tUrR6c3XuRMOzhMmX/moO0kW/oJZYpQIxYkAyTISjzlOm0KAa6K3fmdFGOmI+Tme9d3UBQ8wHR9F2S4/Cg2Q6QGFCBgMDEEYxqUgmXamzi1AxKCwI+VRzFRGQL5KDdUBh0FEXQGWE0oVAUSuq0JHySGO+adz0+a7lW+a6K0r2t6kj+ZZwPaL80puvO0l2KBFWyzRS7wWMJoc9UyhSh4lsa+c3F62CPEmu0yaEHeWtBIXGmUIjVtEwA3Yx5N2IWgl0GyEYxBWT2Q1CjnRqOTFDl6S9WyE7oDLgmrBKgjqm+aP62pyCez366oTmUxPj2B200EGPC1EuOywQxIGPDMhQgzhg5Q4xSmJNB50yQOy2Tby0WS+RQATox5eyYRqLHN21mn/mUBiQOo0JcmsImQuVmlIoEMJHqEE10x/wIyeupDgxKBFzEKYhCu+BDkxugTqEyN2zRdFH8BcU2pYsIJdyVKFZhjf1f2U1E5h3qOTWjezvhMbj5hISwFhrcJhe63D1h7MLFhMSwJBksK5gCSw5yPzwmuUKLjBCsGVhBVHJ+UJlhRUJkZBhSOZBWQO1hk2KPEIsOMGVS032NS0kGO+3qW6LwFBe1yFBG326RsFjGASGX6RPf0lBOLyuuE6RKIqrDlBfsMKIpBSpK9eTaIZsk5K6KSVaLs1OOQOOwKts1eo/6TeoxqzT6DTxpgVBymGxzCAxLUHpuBXyMuxEP2iWrjWu7N2+Owtn0ga9x3hDrB8IqETUhpgyziFOMmeef1pBk116+EKKp+TOOX4A8NQkH/zCsTgl3W1mMWkSUw6esdjTBsFgqRIx2RRGdl+xU8DzBF/Fzs6KKxI8bSLszSPVAxJArBnY1l+rNiexWh3PuRKKLuqv2bB6vzM+FKPbBt91suFG36qxcWN+VFiXGRHQt+w4Kt+k8ClOzdEnB5aMvhxaOnyAVAdiod26xf8LqeqcLxx6/i4ElTndRCqK/y89WPB7QFVRCm3DxQUFPBsnSQOqSMry5jxmE10L/GucPbhewE7huEz4xKmOFe+TCSx/iMuRe6zcxxwKJ+z0JzxvULWyEEzpYtTysqFMMNBjYjyUdeO86WVwyhpyy06A2UPKdhHTh2rxocDtV3h78RXBotFqexeNXB27nekPGPwOTWMIhpU30qeT2qSYWFByd6w92R83Tq2/1eENHyeW7j3KWc7yQW7uKw+JyJLYLxxEBuzGk+LLDCB/bzY64eA+UOCnU2N9EvBKf3zubpz02xdwfB5qJJiyLjn+jkLhmUpjTRqH2ZeEEIHuQaOakIaPb+XnzghVFgnuiEJVK09wTKP+PjRor3mhQLXzR6/13u8aOX+kxQLEKaI265EJdx2JjPuPZ3rBhgPpaNPWaCIQgM00ABrSwFlBUHLg7sP5hWIf5kjUv6I8gSKj8WqKm8gQ9gYJ/aVlWHkGw49clHS9MlQs4iWHRr/3JqkkPp+GARkhI8L5UT1i1m71nB6MYKLOYAIPgm6M6oL52okDkKBsuALvRf5wfRXqP3M8Njosr6Pwy76Ibwn6Je2VAJoyg9SKRqtBMuNtBXKwoM2+uABtUdtCHS/fwbRBVEv+WRCTUaNVHO9/2UkXaOAeU514wONT8JgkIHRz/y/uZkGVmYhK5xE6MkJYD1nRtNSUhi6LZq0MwXeq6Ies66IrUKhNuOpo2rWD3wrAkGSwe0R3fOWlk8M66g22hD3PRUtR2266mgA16P3R5Dw0Jj6JnRNXGIB92w8hBqjMJUFxYeTBJTmAULTm4WTwmsA0HeeQNuBvCMDQjdWqgST1W4U7VyegizceB+NuaMCKpmYQ3F2CVyyyjTGMBrkiYW/uxkykILGeH1VouOdUJ2MPmfAWhj8QIyWd6wUO/64+VIaq+NxBWgGVRfhVUBSH0zRtoNEBIWNXq/wL8IxPjixC9kSBv326BVi1XBWEQaiLUO4B7jB0ucXRQI2CxiyDyl5ROxPEIMUXcue0jUqGYHWeZux7WtQmbqOhAeULwKtB79T92En0hEL32o+FVTIO80iy+4hTsIPPTgakgPFeecwxxHzWAxoYLDAw/XjE1eIeyk+WoWOePWJg2QOefhARaI+K8ubIJTIn0z0utdXqBnwNyBtJKkBDJJaOmhFle0T3eJPUDey7WQeW1SXtip+PEOJnQ0alWOsk18xPxDimJ8DhGKxA7Dd69oLwOJH1iwNgDd6HWJZh4H05BBOXr2XMOwGQeU1hcuUkubxIy6Z2KRmlg07EsSz72xIJlhXOTJBkKKyW62OJgm2PYGqsJ2x6sOjRnpM863pKxByH2mxFgwuxrKC3212I1yt2L1yYqkFBMqwcJz2LMAMJHYkL1wGRBsK+x0oI0CQYH+xpiPsReRODhbsDzK2q3DhGBRLKUX1jh+fHJgSOOChGnRB+KBAOmalR8xdFH5JRaBRATozY+gAx38zkJDKROOLhJdluuAdwjGCLVw+KE1jG+P3dsa7VvWpNwqUGRwkxXcKjBzOLZxfcJhR6sPyR9QXUaQPHNBzGXbmypLXBQuOluQx2PeYuKzBVYyVu5ZOlxl/ALBpuSLBpkPmOs1hk4uKK7GGuJrBWuIlGzJ11xJKLV+ZKMNxbYNcgk422O3hLNxXMIZmFuJ+mgsEZRUJmZRa7FZRbG3ZR44KdxXKJ0c5MwYRd4wkmeyOJe85wXBZMy3mR40MWlITyhutDL+sOBfG57gkAIeOIJWEmIx+r18q6ZNziIgLjkb3xk+PyOzxAu0tYxSKV6sEwgRnjwvxsfiAak+PGm5nRGyGpKaBQeF4K10NKeheKoS4qPRWeWSU+BR3vGVFK5EHzxomVp24pMeIYmKlTCsBoITxdSnYmPD2zEE2LFJp2I7h+U2IRFSkKuQ+MmeBeL1JenWMpY0zP6kryIWWaJmKLAgUmaik0+KlK7meEzUotWJTEKU08Rjv30YBk2z6GxIcUMGOqSwMOimBCMYBElOiuf+HsmjCIUpTk20IV0Pjx/OOaBeijIpupKFIASOYEOaPnaQUzzxIUxqB5qHCmxe07yNZWoxyB2vJbWLe4ZRUSmCGNBBXVJEI6xLJYqSjk+qeNCR6eMzxcyiKmloMzYmSFnx0i0YaaGOhWmxJrmeeNSUUGL3WuyP9xyzVEpbQ0whdFCGezP2h+KpOyBy6wehYJPy+w0zCuzFJ0SQXWoxDZXwRAsJkBveM8m9FMU++VMny+TwHa603b6mxQZub1NjI8ixlJN1KmEJlOKuAny8ep0xHq+B33WHC2AUO+IBagjzumJuG6yWBChp8FBYOZ+LKxYYE+m1+I02mFNJp+qPFCBdyNRxKJACHVTNRQmkhmPSQPcn+M6x3+LQh8BKvhHYgiKC2M6aQBImqIBJghYBLC2EaPTeH2KQhMaOrJ5sV5m5ONqBv1MCiAqJpmePCwJRJDnGuBN6EtVI9euoEYpo0xTInM2rOhaLVpDKU5pBBMvuzEOq24rAqSjhXq2nENCJbWwGQiqLnJgkICJT6If+vaO7RQRPCJttIppfFR/uMRKTB0kJXOSRMCJsUE3OikPge1OKABqkJXRcDzXREAPUJ1s3bgrpS28MyJrgf6WW0GPUWRxkP7gDwx+x+2xyJpRP7gAnFMsdkLwBzRL0J7tJu2g6LxoRhPAuXRK8hFAJNUvRO4J/RMChOkjT6CmPzxKQJZJAsQcUtMNJJxC12ehN3ZE51NfQtWWD2/KO9qOyMLxaLGV2UIlB270O9sVFAc81uB7qQDVaeGgOHm+OxSgudV0BvpSIx8807wIYHlKyULZ+yl2560xNis4CKWY89K9Wi92+BRN3S2oVInJJBwJJAQLXJz3A2K2bBaUVDlPKHU0Wk6QLOaWCyOmBYGSYI/2eWtmOL61UF3x7O0yeotDBEXBzspqwMIaFH154F0xtIc+TV25wKHe6BwBYSxM92VT1LmCxXCGW0O2pBe1DwYUJ84I5PQZOxVaEvdPGk+V3kym9QCpl7HChSPEU6GaOkBSwJ0pQ3GkWg9JFJqk2UBC9wOpqpMVKVm29w0WMO4nmMrhFeQyk6NP9whY0KKh2KnyOOSdJH8J80/WKPhmvHdJTeybhY2Jbhbe1cp0TSL+/qMDJ82LiWi2OlhiS1lhvzx7hCsKpBW7BjJUJm2xA33pBi1x4G8uz0ZLIJcpQsPTxxjN6xmZOvERsN5BaL3zJvsUxeR+0th7SwN+VRjUGwtCSmxTRJeNRiRusSEPhCZ15hdqJ6xCLwmWDfx9xFgx82iDnMZURQaksH2DR8Hy5ewUJ5eaZPgR/pPfQWyyFexVXapmTPH6eH3iuXVL6pRmOI+ONyuWk5WRAWBygR/y01JMWMixfjOIOQvR4RofWgxEV0dBmnSseBNywRxr1aY6BMxG+NJ9WRCI2p0VLuJlMIxa0jJjkYZxWZNCMhkHDP0pR43lp/BAW6vrzYRqWMDeHCK9e88RUOr33Dehn0ERwOBM+BTNbBcb3nCCb2s+zMlMOdnxk8XK1Fpt6kUREBmURiElURrhzDRnfxK6ThxLegrU+xaTM/IzaPXUqtnlBQR1dKmrGwKNl05K7qlHhkOK227b3RZ5tixZmvAfgzcjbW6g1WhGU2eqKi0Jxo7wGxlFA+RhtKCyBCMa+a722qAKLq+Cl0VJtRxxGzXyhOm7xPJa2MVh8ZNcZQ3zKRI3yDp43yGsH5MaISLMQyqtxve6txdk14QTaSuKhiAIDaRY3lXhKEWMRH7y3E6vQR228PfKL0ldh8HXZpRaL9RvWP2xjLzdx18LeZcy2GxGZyHuZTIgOiH1TJNxSMZySLAh4bzqZoJ2Fev8NPh4JOD2EY0UWLi3iqoCJwZiMNSKfTMo+9yxWJxQOCx1TNOUiCJ0uDqNORqCKoO6CINeyhHmZ9B2nxzzTNebTxZ+IKL6hwnxIRZNy2ZvCK3xREODE5QxcB9CMEIdCJ/cS03kpFMLkyG+VxWUO3QxvPG0+yTF0+C91De3wkeZAiK1xZLWvyMbwZpHzJk8EiKTevzJkR9nzkRkaIzeznyURrn0OGosghZzh3AJSfxhZOiNLe8LLr+MokMg6slYSEyIbWLJTreNlxbW4OOre7ZPJKl7OLgV7M14VbSeOafQNZwKLseZ/W7ximIkeJmKCpntXZEeWVGyhcM9BUSJswNXxGxk7y5Z07w6+bLMwJHLMCQzRxg5PLJRu5I0yRiY2yRUZPZxeSMHhMt1G+QDylZadnAU4KkJgEQDqRMuIbGZJ1MKYv1VZWKMfeGawfMWa3xRDJ02O4wAE4riMrJHSJLO4rDY5hMHrJgR3POSdLCOsAKqIYtTxZUANhIuu1/SxdFE5yR3nmXH1AGYjOOpR9LXpjyGTpkbORpS5V38tLLR+NKMX+QWKw+aTldsLX19B/rKM5DsP5ZLOMFZx5NjBwrJcZHOLp+sROgo96HSx7XzRxOwhapzcP8eSQJZErnSVp4rKHh+HLDphHOzB9SA1Q7HO/JyJFJOsGybGmKIWO75lVx+tzApXSIgp7SOpp0FPHspKNq65KIQpp+G1+Olitp9t3pZPAQwp9KMuI2FIICQ4JZRI4LZRY4IYqnKOYMqjJaU5+J+JyhBzRtyjzRtAhFRvqKaZ5WRa5YVOZSitJLY1oT9+rtBIAGLgc+DtNCeClR7E5lPVRZ5k1RdpxU2Dp11RXuU02PJhvBz+KXMXp06qb+Mh81qLs2LdxExvXI/BlCMfJrFNfB9SAAhLNMfR8Mw5ptrK5po1UAJ7L2AJLrPzeQtLzOEBO7+ZBN7+MBOm6cBItZJ3NOpezOVpL/F/xa+0RJXbTjZlT1QWjXFIhC/z3u3iNR2yBOiROBNq+J8O9Z1Z3AeP1RS4dEJrR2uMYhiFjNp19wOOwCGEi+IHqSD9zbRT90lmPEL7RgkLdpwdKxqQkNe6IkO9plKl9pY6PEJimniJZXJDpCkKkJcGR3O0aNSJxJXSJMdMyJcdNBsCdNCO8RzLKIcJaRhkJKJIPSBouMU8MhBTUJ0vOIe+cHTiRx0aJ9kMp6BAPp59tHaJQljfRnkPjm5hJ/RzdI+2AxK+2wUJOBSIjv6Q/gBhgkxocZoEhWKeJyErWNZ2kIC6he0nayLxzGe3xLkeRu2gOCmIUp/UmOJAUlOJOQFXAwkhowKyAMeqQH1s8F28U1oWExfhRew6pIkZReMHWHFzaxIfJC4dgPU+fBQcqhVNyeUPFcm1k2YBDQJHq6mNneqbLWhvhEIWdLGAW8nQG57WQrhjimoOfcyAZJVxR4D/R6hPTBjQkP2PQNWSiU6lzRJ+WN0pBwHORNcJ/sBvUFJOVKQOzGKepe1KhWdlyEuPAPT5lVGGKmlBtiJDLyOYn19xXQVkiKXVewSTAaUg9Jl6FcISBCN0hJw/Kd2l0O+aTJJBJ8QwhBQ3I9Z4IP+uU/VT22CPsxqDWhJCthba/82SpaSKYofdQUaDVPd5H8RUZoqPTRNMg0ZCLK0ZQ2N08SZPueKZOX2oBy9ZYqLtZmwHeerOUsZy2OsZq2MjJdnPcojjJLkcZPs5ga2tZtzw52R2JCRK+xGZZ8ICZoiCuxW1xNh92PCZ2LxnuuLyth9LIJeSTPDSV+0XBJknJelTXLph7LJyCAr/x6SKa5/pPyZmwEJBQeSdZj8OghrrJfhIB2xBSbP1h4zXQ+2y36cNcwDZPKMzygCNDZRHxqxNpMimPTPI+kCNjZ0COtJQzLgRrArRYKbIyGp3MuaplMzZDeJBBczNr5VWRNeSPNR4OpMIRvLPWZIn02Z8ykGcJJLO5Y+NvWVmOmpinM75JVLbZ5zNYRPGy4RGMk4RdeP7Z/8MHZaBH4RlK1HZRh2ERbzNERkIXERXzMkRPzIbM+vDfy/zIsOu4OXZUJT5WBwzsOHn03ZEsk+5O7OLee7LhZgyO8OuMQve1bwBx91A7eIIybePbxu+tbyBGQcNBGNbR+GJj2Ch8lPfkg70kFKPwiRoHPeRe43tW0HIa+sHIIZ8HMTJI7iQ5hwpQ5Vry6+lnNPJtxDsZu7wc55NGFxTENfJmYMAqMrOOSowoVZhYKVZZhRLBdHNFGq319M2rOFshXNo0HXEmmYgozm9sNNZ5uPR5GTNyZIm3oFeBM5p5A37u1g0dZJTNe5T8PKZ7iOWJhjLhelrKyZBgq/hIYJMFjTMRFS81gZrTN6pkrw3umV0uWpHzgmMbPuJVHxWm2eEcpZ/Xo+s9PGZzHxSBrH3ixNB3+WubLjYDrx4+2eHNeYhU+kEQvNJGzNIRJ/MbOYoviFdbNaGhzL0pPxM3u9nQyFFxX9Gyn04RvbKxkolMxBNCPJWTzNKFZMnHZIiLfxBhxnZJh3qFQJXnZTQsm5oeI42K7JBZa7M6FQqzURW7OFp0LP6F7h10RZb00Z8fEJKLpRMRAnImFdbypKBOMWF6oANGmozvZTsijFbJT0hHJXpKKwrxFZIx+aYNL7xOMP6pbAo9BNtjA5c61S2Sem3WJ+WoZojMomi6PSk5YsxalYu4eAG2cZEZJuIWHPTGorNp+TwufJ6YNeFSKPfJitwrezpRM03wr/JSrKhigFP/gAZWWOTHOS58vxlGHkDGAorUw6nHKPebG1Qh0oMjaICF9hDZPPOhhS7JnJWra1RDbJmdNyJ5iP3Frli1WCcLCscJPrxwZECeufLRAOfIT2skRsqCxIAWqRxSyYSC7xhkwyp04LBpilCnJrDQfwy5TZudLODFCSDtunyLCBlOIMgEdODB25Wgl9OKeOcZLkKtwoBeQbAvJyJyc5vRB5xeEwMqi+MHeJ7UA23YpFxiKPxO4uPfam4oMgaKKo5/cji5s1hfiIFPVxO0GLJqXMIJt4LNZi5hNRoAStuRuMQpZ+HgQC+HqS+v3pZzNIFOaFmtxIpyq5eFJq5BFLq564wa5FOivGP1Lhpx40op/7MIoXXNoptONlpqku1p9wN/6rFJyA7FLfGnFI/GS7LPMmfLCsA5MCudH0ohnj2AmUJNaGvBXAFwhCIZUlImZUbM2a4xMMpOBDOmynWUpJpJi47wMupYlOCRWeIMugjMBpGtIMprbIVpjoOLmJNKJBc3Ojxi3MYmQqEQZzgoTZlLIYO2mPxFPjKmxGeI8pkQqLmgCwaxIk0ilxP3ihCUvSxIVJilJzJVAkVKUm5bK7p9czipMLSyu0INh4m/MAUwpMDGP4qRY5nSypg2RX5bTLEKf1KiudMO+AxVMxWXGTKpfyIqpbTMoWtuVHJqC2OZctKpFOgyilzVIfFkhX4Z2pOr5+C2uWY0tqEVhJtBhEKGp4V2SBuUq95fAwmpKSiymzAtKW81MCp+Uoaxp3JWpH7KqYWzzaZmUsSqu8y6Be1IEZWpyoRbeOOprJPmhsmRHpp/MDuE+W0paVyAWfiOVI5r0ul6/KGGkIrYawLEGm91LBhAQJkmukvCpE0u2Z9IrEWQNNClmVlBps5T4esgNpu1UBeOKcPCpjuARp8bMHaI1JulK9MPxSotDBC5gky2NNku6uDCFkPM9eHxKvxhmFW5v03vxVAOaqU3A4lL+INx7zItRlyTSJcZ2kFpDnB5ajIDJ3NMKZ98Je5/NLe50slghvoukJ33JYU0BJQhwyL2qqBIDuSzOYOoPMK46FPhFQSnqlv1P0lNUsfG+tLR5kHOO5lItVypEOx50tPqQePOP+o3iFmxPIv+pPMElYvJlmvhJEht/yrpMs0Z5LtP7RZUNdmXW2EJURM55iMHHREhMDpQ21aJv/yDpQvIge8hPAcysujRGRNhoUvP5qu4rl5tlhrgD8Aa8p6IPRNRJeo8CFrWN6Px6lkLfOKvJeofHJLp2hPwBsMzvBjtJN5L6NoenRNNqlvJ6Jb2z6JtvNbpAGNBOWbCahJX1L5MAuy+HvOcWU9KDwr1AL5vgyYoNPGfF+8P75HxN3hfxM9sEfP2hO/2acI810euGNhw+4Ft6W0DZgSAEd6V4thioYP3l67wo4+4N8S89k7pGDS/5V2V3lKpAsBIfVPlxCz/luEth2sxIzRZfIA8yTzv2cI1imn9VuUMPHAxQUrMBANx6BXpIRYa8vwZCvUaBsC1yxqiUfpN9IYZkMN4YyVyYoL4oiuhmUB+pbPQmSJNJGxpKiFDjwWY+QPzGvwLNBxC26yx9IB2lCSNBrO0Ol+uz6m7WJPazJJShH8ofW7LOr2igseJ7V1El2jOGxGAv4GmIOwFugrcFrzx72QZI+eS2LoGK2Plh/zwoFG2OyRzYvFyHYoQ5TIK85TAu8ZaeMKlmiq2F610uxQTJuxfILux+5jYqpJAiZ/fxBFUtJiRl2ghFpSPGQHhRhFqTJkFQSzkFzpNOFPXJ9lZ8OUFmgFUFMHz5pPTQFpWgoqZr8N8ZuAsQFPrN24frIaZHfKJFzTODZX8X7WUr2sFXTKZFslN8Iir2h5OkyRpaDIEpdeR5FiaPTZ/IrQRfgp9qiPBFFQQsWZIQslFxbM4BQn3EpLUor6CoodBBNzAZCQuXewhxRWTbPWlqktOZvQwM6Oot0utzOuZwwzWVwbwHZDzIGkZoqjelooqF1oos+1QrHZibztFZ5gaF1LSdFi7MBZnRmBZdvA9FOby6FPn0NlvQs5aEqwDF+7KGF+iNxiQ4v45kyMjFlJRTFsYrpKn1GuOJ4veuLJWjFNJQVE8Yrfl0FAxl9GL4+ZMMOR52MLFnowduUpVfidYr4RvOMbFYSOyZVSQRluKrwm+KtPpIuUn2mHOMVQTRw5AXLw5krN5+Z71DFw4tm+cuOMg44vnhIoynFQIpnFLEs1xnNk3FGdCgJXHP7+8BUFVKLPGFp4r3FYRy+GFZUblaoIhVXliKI0qoVssquCC8KsXWkCrd5VJOWEoDLZlefIehswh95ogLfpAsQREpMNae8bmhycix0abInhyB5IdGgEr3W33BAlgyIXJxYtLOfhTueqiuOxBIprFujMKWNioMZBUrcp6HOPW9wtyRNciwl/tKma5IrzFaSNTBJEpeFw8MqR/YuqRorVrgNEpi5dEv+FSGxi0TEurBKXL7G2G2NRmXNgp2XPgpiIWNxkcunGfXFnGqdho2t+Mkl7t2klBVHwp1v3kltdEUlQemUlBMqzFakvZmaMvnBYdzopfaqbQrssEBFwPXBKXBMlaljMlleHkREf2eJ1kr4p/4z0Fp/LmKjkqlJx1JcllVMh2sWAeRAKx6p0aB8l8lIAZWUqyBgUu8xwUoAGdlU0pvJXhlSfQgF8nwy+G0p1EMJPUlutP6K1E3k2tE0spaUpsp2Jj+lMWXqV+qu6lt0pmZIauiaL0uGVXlNIZ5UpNwXJKqlj1JhpPfLqlKksJlgICalgAoNB+DTYavOPip2CK6lalFclQpNChYmMkev4q+WwSJGl45UAaKzOWmp0tr5RVNPV95KupV01Xpwiu++K0u+pY6u6hcGsapwNPFQnnIaxbVIKV6pE6pvVNGltIqY1lu3OlAIlRlqGtIufJU7690pQIU1OymGSsKlMGsHVM1JuBy1N8I5UxaxnlJyFZLBXxrP23xQMvsWn4KdeYMpmVsn2B59ZWhl8zR6mqON5xwwK+lTAuRlDu0U1Gkt1oE0wB2ke2xlflK+pnZGdlCypTJMOXI1582BpFMrZ2BQOy+Tqsg1AJOn5inyZlgIH8lrMpylAINRpX60HxhN0xpTwj5lpI1U6hc12ZnzkYR5WKNAYsrJpd+PZ50sp1xTkKFSvEsZplqPAYysqAheOjhFXsptZhSsg+AaN5puspSV+svAKrytmqkBKjR4tL+564uiRVsqZZBbJX+h913+9stVpjst8S4WsJlE6umBwWLtlNcE9lciuOqJtLP+YcsbRpPJ0siBTncccoiJ6cp9po6Kzl3PPpUvPPnRiRLzlsNDglS6PycD6Wjps22PO4RnzpSqsTpyyLmR8OMqJECGV50LgAQ/cE3KyUSblB23vOkOoYkmRGwBHHC0JnFkN5Q8rP0vS1N5DPRNqqNm6JzDxnlNvLYedvKChmYriuCMMmkpWpzA/vMNauqsX6BeJHy/wiJlSixpC1JLTZeSlbqkLBWhRV2UZK1mwxO9JyAmmXwg9IG0ysZ2LqmYqJhbOpE2VkuxMUUNepvOIaV7jCQ1qDOQZTAPzGhT1t2FIrEKh6ucmBCvbKbGr3W7OqQooXUJ073jVCVN3ZE0yjXWpMOdh9Ys2VOxWV1jBytVOJOlJVlUYBSxKNVBYEMy5fLeaLDJwVRStmZiWqZE2R1QWNygrx+0I9AX8zsFEH2mhTup9JzYnXxqtEWB8WBE1yWtzxfH1kyUjzc1fkxkaQV1/wxTzkZFexFe1Rxj6KCNiwgU1CB4jB0Cfg2CBQoA0I2uzP6tMqwFmDSoxDcNkVkSo1lCivAl3MKKZx8KsVnjKDVHSpYFWSvkF+As0AhAuGuA+1DJDA0MV27zbFqVFMVNAvjBdAvcZo2MDVd1KelGipH1USu+VhsJ5BripCZjS2FV5sLCokTI2IHS2XJpXGCWMQtaiiTMKsAy2CSlLzVl93L61W5JpxCIsDZWioAJGIrdOWIr1lOIrSVmYsqZHrMJFQPL6avrO/hZnPE1sSqDZ1IpDZWew+BFRRsF3VJox9grEa/TJ2ZxMtA1wzO31ry2aVyCNaV4PAFFjyKFFmBpQNN+rINbDL6VRbIyY0oudWJUoJW0QpBS4yvzZIMsfJ1CKSFcyo1FaQq1FfQxWVnvxD1PbN1Vhovs1pK2OppopHZ+yp0OhysnZjKwEJZQpZWUiLnZjQq3cALJaFZ5nuVrKFBZUJnBZLyo+5miN3ZnysGFVZJQFwogVWyBXDFAKttkqq2wKBqxFqRq1mFlaxsN6q0NW1BQzFHjIoNwJKWKMMJA5RYt2FGIwOFbnJ85s73aOCgrOFQKMNVRCOuF4KNuFIt35y1Kuw5UarpVL5JTVb5PeFA4rC55hsMKrKtolAo1zVGKIY553SUGUTNEl6o1thX7iz18yihFQqBN1ozm61B2pmxhKo/1mPLRFN8IdZv+uSVowFSVWRTdZ6iqqZDivANuSsgN+Sv2W9kvMF4r0sFiBqqpNgK8lmBxQZmRxwODRRZl6lUTZAxv/aYzJaV5BwzZoxI6VbIqiGnhqbONstBWBCLoNVrwYNpmvlFS4MVFFCLnBHBqXuXBtSFs0uyFbHRxWgLAEN3bJuKBouJW4zMKFegV2VkhrmG5QpUFOXKnZywxqFs7PtFZhwXZYf0XVGhrdFDyo6FTyq9F3Qpmq3othZ0qyDFphpFsBkAXwbIUsN911IKvlhNkD8CMSnV0cN0OJCOYnIBGNcFE5DsWWhHcxVJZ5XdloEt05Y70ZZa2u3K5wqCNJbLne4/EsVQSi5Nnmr4KcHK8KNwoUJdwqMV9jLVhFivhRErLG+jKvfaOJuQKpcByN2aryNE4t1MT7x5VRZP5VkZXKIJmlQBk2pMNsBO+xYwEj4GRHR6qLPPOwONaI9sovF5JutNthoVsdpubaGqo7aoirzxdsWQVvfMpJfBRsxnms1CUPOceUWLzx+RVJGmfW3Vr6rphTYHIKx6Gbxibk/Bs5JeR2wr8NbJr2FmqoiN3nJ5NoRpM5gKMCNQpqiN0hTFNNnNsZkpoeFtKuJUzwqJ5vYvIlaauhI+potNWaumOsXPyNL/EYlqGyrB9JxFBPf37Gssr1xcsrgpCsuI2/Evy5xmmF5SENSsX2vElp8gY2TKNbViEnbVDuN9u3aobMIStgZJMNvpQVXz5w6sXePvTnavv11OWOHMltyuW0MutvUh4LVRqUtjxqlR2kSePZlvqDy1cQs+lt1Pcu5xuy+5lXD6kQVo+zxrDZ28txhAV1JlG+KnVb5smkJQN++C4kD1cxUV1BurvWr4qIZSDQ0eueqc6PkojNFYv91PfKPmVYsjEfozUVQ1J/wUCzp2vVKuBUzCyyfUug53LEc1P8IpFn+qKeFgtBhMlJqqRXVq1yf3RoTVTzS6XKa1pqJa1e2G6q8yM61ruRAhL+rANY+ozS2stsGhfx+xI2v5UoqzeVzQqm5G9NvS02otl2BJPu82twNw3D9lU5s+R1LODEr1S/Nm+K3uIct7O/BPDlRZEElCXJ8JNtNjl3ELv+1luCJLW1tpz3Rvl8cpVSmFkzllNViJOcsAeYdKTl+ZFDpgvIes45pVKovNrVH1h+14AL+11RLMRKqqdkotTwKRRLB1d7NAyV8DSIZWgStncu0hLcqvgBCU7VmhNvRaOv/OlDzZ52OrAuuOsIy+Op8h0FyJ1tALxFVWXAxGlMYZkbL8GgpLCGg7y75Ej14VhknBke6tZ1sCLHWwe3GKh6vn62ev76yZJwWQ0qRVO6CwxKcu3psfJZg8fOqAifOT5qfNWF1hIymW8sKBYeLT51j22e2XgX5cwgW1mVU2BqBoBJOeP+hUVW5JCUp91oooyYq2QMqH8wAVHvSCRJBr7561o8IT4oP559WupaBANJPeLClVmjUoTT3aBgzwd2FBxo1nOwWe2AvwWpXwrFTwi1VRlIfJfOJvJ5nQaG4Sl4Zl9Md1sTyPamABjQGICwAy1gmATmQGuxi0YxxgvMaHkq2JfkS4Ob/IDBgCvqy0Qr2YmVR+hP9lvJ9eIQZPVs2KKOMDQRWMpyrvOhtr0shpEwPrhiewX6flgfFHDQYyQl2nJ7fND5Gupqu1Got25Kox13uJotSAtdJiirQFuAwDVLewee7rN9JjSuJFmsrmxEsLEtHhz7E0+vDJ0YPIFUpsBei+vLN272RF9GSUZreyH1OAq3+2SsxNfKk1yyTWCZ3Ao8VhZO9EFsJ8VggvAlYIqv1W4khFRrMThn7NhFglsB5MBrf1F8JRFD3NaN9rPaaHRqG1XRqkt76F6NbcPsV6lpqZgrzyVx8pGaZgoqUiBxOlAmrGtmRx753TP9w8r3QNjgoGZyxs5FON25FJB15FZeqIN7Sr01wxW6VCFvVK1BoCBUouzNJmo4RTBvAtVnT3xh1MSF9xqOZ3BqeN6Qr4NnbPjcHxus0Xxuf6Pxp2VEBz2VgJoOVwJsrVchvgw4JvOVs5gdFKhq2GclpdFvmHhNWhseVKiOeVjh2AKPQoMN/or8+XyuNNRlmIkzKv+V57OTFMYtpKcKvE5ZbShVwKsAd6YvJZwtERVKWMFtnC3t2+YrjGxrTeRmKvnWnyJxVIvAbF5T39VOjnQd6ONJVWDqFu27ziN3jQSN7YseFuMCrN2/BrN8tzrNTKr+VI4tv41NA5VtHJHkGRCBFK8JDtWJuEFhVjWF4+FJeSCs4BUgq61cdrUt7ttH1/Jt61wlse56IuuebLwktnL0ANGVmAN+tvXVFg1qZQxrJFhnOgNqtrFeVDSQOdIoBpHWRlef1qvp0bPmNadT2NsQsTx35s6BbuPWNDeU2Nv8zaVvgt7tHHxS1ebJwRDUwPuw9oGVq72etPUpGVvzTIRM4K5lHuJ1JBzJtADxqjNmGuYES9uWVK9qqughs+Nwhu+N9zPENBnwBNxnyBNCSpBNR9ofypyu+Z6w0dFqhqvtllM0NlMG0NgqyOG3opftaJoGFGJoPZX9ruG3IzGFO4sBV9bymFXwxmFwDrmFHTsbeXTuLovbzT6vDukWAjtsBjivdV/hrLhgpsiNvLOiN4tNa++ZtmdqHLBRFKqs5fzzn1pDtNymEuSNPYtSNbwom+HwplElb0veFHN/JjDvVNnKqsKhRp+UvKs6Rc4oFVxdLzCx+rI6M2rFVTzqVWkqveuyqtrl3ZMK45kPB1X6QcRXZPBG/zrdNOgT85vU0MyZpJREN2Sv5nhEhdkhAT2BPGj8nVoWJy4KKF9fOAV5gO1Vw1OrFFCoQanqwJdayh+J9eqi+6C2sJSZomdYEqxNKrADu6MP0ZK8p7KBB3/hQ1OGl5ykYBuZoysDLq8ZjC34eLLphlbLsmt31rPhZius5rYq2du2M7FLJHp+iDAX53UuiUnVkod85PlNY8OAqkbSvg2Roo50XObNOao1Nf7RIqBaq7NjhJ+5vZq25MFP1xg5pFS1auEiFltQpokodlE/hc0tWubVg4Ntx1XPtxDdGXNxFMa5I7g21/aq21eLsMlKpxHVOkvdesUsDdV0s0lzqJnVMqTPcpkq4pQnR/lK6unJGCL9JeeqEpIDKclO6rHt2WXcl1TyWYx0rQNYCxgtg0KaKwWIp1qlOBarmqRt4Upz2OlNKUa0oXtwsvz2FQIMl2Xy+mSCl/VFlMvy15tspHNv2afVqnx4Gv0dWmrcpRUv4mIFrCGZUqzYFUvqEnDIulAtviZCBqbdjxsSE2Gs2pQUral1kkI1nUq0xpGqn+EQOC6wYwr1mVOFdP2To1Fkzypn0PhutIBmlLbtKpbDV11L/K41FSkXxJfJqpGGv7VwIOwZSFp2lCez2lxerCm8WqOl0eqARk0rvJ8mob5TFKU1WmNul41IoSWWQ01m+qqZOmr3Wi1M9NrTGfNWZuGIP0t6pwGuyyM7ovl1eskxKxTCdpSoidNxrOpngrnxcMvc1g9tup37NQaKMqXdFbojqY1KC1Buxxl0BxY9q7uid37si1MNtfm6LtsJNo36Y1fKF2D1NxpOeHplwe0oSJUGZlF6pWN2WpHdD5oZNrBpZYxVQ91xWokWF9IY1Qsr4B+mO/V301vxLFo250RXNdtNJ259NIhmPFqhmUcv4tjYIB5ojtLteAukdbRue58ju6NBsv0No3XktQ80Ut5svn+c2o5NS/yHt8HNIhYkqglX7vHVrHo4xu2uPuAcskdCdvK2F92O1JltO1t5E1YGJnu6dPIrpzPM9pbPJf+Gcru1HlpjVXlqnRPlvzl/PNG2AVre1KRIh6s83LlEvMrlkVq7lEnPRZ2THzKWoJQKiAJblICDGix6LzpUVqJ6A3p1u/coKtuhOEdxVrHl7kPN5ddKnlBOqT+NAP/RNGVaepiy6tOmL+BhqsQolJI2VLAPjEpGrBtU6oIhAIk+t10tHC0fO0Bd8pyAegIJI+9LoBfBVPKzuTPNvRBvF39T2tdHo6te/OQ1hTzt2ByPOUkmpV2RNPEZKmIwd+/VB9/WUwtn3iGB2WKR5ueFlFAl2Ce+yPJhVQJZmvnQDNvmq/V9utCF1klWl6ixvVCzHekTvJI9LwmcWF/WE9zCN0WpGteJl+KY69WNV2ulvot/gpMkxPnOWHeOmm1IuZ1NbJOYhmTJdTVq6m09t8yAZuCBVIXIV7jHsp6K3YZGoTMWklIA8yeoaix3qnxS6wJuChx+JNFCWy9XxGI8ruqx71Pk1bgNkmQdQNS7KVOeHeuMGXeqxNPepMa6TIOx1io31titmp+drEdO+tTO4sMWwPNIjxeiqH2csPJBEau3eE+2FuS+vMVYL1X1/evX1Ltpmpw+ud9GsvYFDQGzJXAr32PArNh3itjRvioty5RsAxMXCjtYVn1aDHox4sduK56suMGjtqNpKdtmxMjtRBgaMztkloANPRu0F8erWWBdseJ6jow+mjugOYZuj9ijJie8BtKVJMvKVjIsLdYHqkWjdtZFtSpA1Q7vSx7do2NBBq2Nzjp2NrjuFFgQoHt0nvMxoQoY1pxpCNuboI9f4qntRyL2ZdxvruUTpEZmorOZy9reNXbM2p6yryFNHvJJsNuHZJQqkNmd24teTt+KChrOVShshNfzJKdzorKdt9oqd99rBZj9r9FMltftvnwD4xhpFV9LJFaUbUw6FlgjFMRzeGarS69ytl3uYOIdNEwsQDAcOQD8rVcs6yMzFrmr8Gufuk9RrXRVM61pdHkUYF9vuDVditDVEjoYFztt1tfRpANR5KyRfvqhRUrorByro6RDKrVduZFFa0bVVNurqAprZuW+d8E1ZL704d4SpKIPJ3BFIgp9JvS1JeXiin6/nKKt4Epueydtf12DpyZqtpEtdK1NtSSur9Cjrr96Sp0F/Rqb9+gteApItyKWjtGNdjvGNejsrtj1urtEbIfJpju8lDgtH9TgrqVE/q5F9ko8FRoq8FCtr9QxBt75FyjcdjPp6V+03C9evt91oKLWZiPsCddQ2CdKvo09NmtBl0ypdesyvnta7sM97CPbZ5xQSdgwySd69pSdm9rSdohv8O/xof9e9ukNB9qHNNopPtH/ouV59quV3/puV6hqBZf/qowAAZ0NQAb6FIAbqdRhoadu+vAl39ovelpq+dCXzrewI36d1GnaIALsTFAI3mFnTrmDfcF1KwzoAGBX00oL30YtFX2Qd9LIg5izsJd3LOCNnXyLN0Ss5ZxweQ5pwZFNeIxiN4puId3rUldOzsrNSaurN+zr7F6RuI5JzuzsZzoaRWjPol1zvYdaXONdJZNlGQ7k8MmL1edyloigEIYlVbTtPFnXq7e5sl7J6AcRDN8GRDrZPBdzAnfpr7rYOz3txdUjLHQTKXvVFtFO5TMOpdrJvpZ75h9GcSNMDP7POlIrpBhYRp4dmwYcBHpvo1YaphO1IyDswrIwlMptw5KRqC5UhJC5RzuFEcIabNatxbN+rrOirSI7NeKNnFBKMV+ZrtLVX5iy5YM0Ptw5ry5kUGy9wVhEl3etw6RvxddFXOZw85qhMi5q9dtvz9uzuNC9vQgyF17sU+RjmFR2kqT09oeqOBlKdDAeN46x0G8cHGh/9SbujxF5qjxM3K9yfbqA1HNoTRHDDcmTHosuK7snVyWs6VEyrwmYk3kyboekmGnIs1XjwuASSJ3UlDKjqHUvEox7Xs6kvqThz9OByOoERd/hFhhDAc2l0lPCpnoZgZBc3RlG5PdeRvqEVhmM39/uDWBr61v9mLUT1ZWQv5UQfpDKjrWNBXTHD+XVqqzFvW5Dpk25qocFSXFtyd7+P3cuHVc2qsru58dp0D7nrTtlbE6NNfs0F73MhZ27LUN/npWsgXpi2edENDLnvyDdfPdDl9U9DCXrIhqlttDpfs0DDEKv87hMQkN9x0gDwy/KHEOp5XEPRqtluN5/SETl1XoK9M1uu1D+JEJ33XK9PPNzl06JHlMhIQjC6PSRovOLlsD3CtsdLa9mVuitjmOk5N5xrgnsz692vNhIbIXZ835zh1F6NIjekAaJTcqaJ6Oq/xw8qx1s3o6J83snl3Ei/RjdMJ1dnFW921o+Jbkw7pqjQqknho/VS4MQuUgPkeMCsiCowM2eQPACxduz5FeevfdhesyDoKL4Vwz0MtcXGctOGOt6j8vt6L8pmw2IbyUOWPE9qfWChO0SJ9oKDGGwtr84G1qD1ApJ/dMmPmJ16oym8Zot1Z0uN9VoEcI4N3rtT6w+NJC1cDH7oKlxNsR40yiFAu/sf505JzZ4FqplkToLDo4A29v8O8mY9rmKrQgSxyka51vhEDA0tAa42wLah8Up1EK6GX9LcyBJalDv6mNoxJ1DI59IhFJhICNjDMxtrdmxXkpoXRltfuJGtFXDMujwNtJaO1eEM7qZSbk0hBontbdv5rhpAdCLDpMsHemvk8WZvv9JFvvCVVvpwG1ZhUV7Pt9VUGtANKXvAhbvtUFIZKsZYZJ99LYviNNtpd8VAuLNnAxD9BP14G4fsYDedvHdAxq5BKTRcVuZLcVoTOJiQ8xT9ktLT9+TT1Z4gqoSxlGz9sutslVBplRqgfIDQlo2jXLox5bntTtdQfaNafz/1w2tr9n8NztJ2M9ZnfsLthgvqZJdsjDQjOKV53COpHTP79zyzrtx6tD25jp2a1bMGZ2UtcF5gbKq/gdENe3u8F1WpcdK3ED1hr2iukQab1hQOYOJxtHtIFu39yQYij5WtrZ4Ts4N2Qf49J/qWVPr0yFuopx9avoIVIhtUjYhoqDEhuqDWTv3tOTs1DDQYKdtQqKdF9s5WpTt2GXQYaAlTrWgfQfeVvns3Z6JsEweiKgDD1n4DsAatkkwaz4wRyQD+EbeoWrTRDkKswDGIdwKOAbQD7hsz9X3uk9NeLgFewZ2FIjufDQnoH1VAddt2IIhjYfp1tWApujPUi5DFPzYDWSw4DspsC5PAYolIGXtjgI0EDUobjagIdEDIHUzWOpvApjztIeUIaYqbzoOO7Pmrjd1x0h5iOwMcrT7gytjFtPTtwjrcZR6jmiUUAcYyZcxV29TjGUjCexqUhjqRpputbjFLpdhzyMpD+we71f5HYqZ/TCwe+XlAeodD9QSioVvhDXjLk1TjTjKpVR0eX1SRteDHP1Il1Dp5+vAZ45INBM0dY21d5zqLBA8hlD1J0S5nZuY53ZtNdJapppaofLVGoaHNJUHQ634auOXYLQpkrCNDTapNDGAnddMks9d9SBYq1oZIpX7jTDsQbqpGPsf1NFNDdrob6GDobhp94Zjdwhh9D/HXaDJ4bPpIYa5gKUrITJ4Osp2qPDDS0oGN0YZyO5QcOeq6pZ9njvndKYaL5qn3xjdYazFnoZng8xsaxU9sljCUaLD/BBLDn7MGl5YdHajTGrDdvoj9h3GM6T6qj8jYcehzYePdELTbDnxI7DZwfh2vQOn+ysf7DynUHDnMb1twgxpjcYny6licK6JnqdO04bBMaf0s9QAh4li4Ya6K4ZVl03rUDRfqUFzf089rf3DyIqzG1fnuvtUW35QSluC9+nNcG0QbxGkXsvDkcexWU/JQTmtIXdNRwfDBtLiT5ifYEmlrLRkcaDlqXt+UdaMYh0AAAAMigB/YEgAYAIeAZAI6p34B6o6CbNBu7OUEvcqw8bBMcR/YJVhD3oPZfIJwSALETrXCbGiPw1CZWIUqB2ISzykAWnKoIyV7RCVzzPLXBHvLXV7HrP5awHsjqizjjFhIlkTz4RkAK5W+lsI/HSzEdMjuvatsNecUSkrSrU2QhTzhve16L0QhkYA3j16I4VajefHxltAYSvrDXSyrU9sKrd+jfIdVbeI496h6mpjc3S0ynoVOBvajpcPde1lXgT4926lgr/6YxTbjb4RuE55LmKHzqZrTpGUuM4A3wHxA4APOq3EdCKkLRzGy2eXaYyPVkQUwSnRMf/S4lMC0mUjL0fkLCnyPZlD0w4jbFoTxS+I8Ba2FcaDkRBD6AgdTLMXXTixlXGEG5qaRBDl+6dabA6h6awruNb/UcY3mGT+eFU3kKR6KuIY7ZU7WGkBtr631T/ZifMdaQoalS5WsNCeisr7UlIYxZgfGgt3e4wjehJ6i9fvNc+f/L0qua8SlK5IplHTLIiJprhw2YmaQmo03cJxjXpb6brI3B7dVfAKdHPVaJ6nXtHKHycPzLI60CWO7UY7O93U6k9dA8tozbePrQMG7opgLFRD49Nc7bZGqoUSX7OpCjHhmnMUY03EED2ci8fbQfq/bfrkA7et9K45GVkygTiXnbXGYQzmD7ZIhltxfAHvnXd9e442wbEZ7GAdbpCyiAeKrzkM7VrbBqyU8M8QqUlDoU6OnaU/v7yeA+xYDRzrtpRmTSA5bjwlf4qetdzj4kTHtEkcrln1lFrqKQs6hrqdHgXmmnM0wyNHOTGqDOX9avDUonibU2AAABLUoRfTM+mkWo4xNVnx5NXCh1NVfBvn7Nphh23vRfDRuIUZ0c/9pGu9+MmuiBgqh7+M4VX+MMKW3Qpp610jmydJExIrngStZOhJZ10QJ2c04Us0NTcC0NwJx3GIwLjYue391VcZk3f3F0O2+0UkJq/BO6AnYguBYhPX20hPBQ6riVu6t35HMXZJo9g3AADd1yinulIxQRVZzQiErofIXlZGn3d05UiUy+Z6Xu5kN4M7mWfrLeoSJsJbCEQNM7FAr5DU8aWr8ypW7Brt2p3K83UJ5bk6oqcOSy8z0NSRxPzh0ALJp/+McJQEUb027n+LdM0UUZTOoNICKiOWDPpneGOjAKYDsSNIjZRUbUWx8Lawmn7nRosJMEaNZMRJoUAEemMMaW5bXtEazMB3Yo7hA6N1HapiEZejwlna/TCKxKnmpAdtFgRh/7O0nLN8QkIl2Wwr3G89nniQqZP3amZOPa+CNVexCOLJwU5BWlZNA+CiLpIrZPrJyiMy8i86pi5UGp0pXknJuiTsSVxHg2DK27JnB7AIcY63Jg3n3JjHURQIC6A2NyGsR4wkW8jiNW8r5M8RknVt0yTo587810LOJ4hCq6ayJlnb1KePZRY9F1WVA4mPrEHaWES+qZVFR7h6lmn86ua31IRvCqIRLCvszbMx7KvquU4Zg786ZnOTDULTKFFpzKN3Vga2yMJJ+yPlMc7NM7T8288PcloxvPW3ZoiZbW8yPBjXeEpIn722LaHM3FWHPg571ZP0lBXwe2903hlvFw+yAg3ZH4SHe4oQMymZS1CCElpa8enUsX63HKZGI7ZgIGQDNsOGHaAUo2oO7+mtI6kY00EnZwOooEAr4n4+kPIxXEb5gS1N27HYO8uyvpg5gT0ClEIAOkjPSLvSo1WVa0JzRoyxew8NNxZygPyJt6WO+26OxjWnP5+uNNmRIRBSaXRXECkgC0Ac3NIAGfW++ss2BrAP1EOoP00qh22bxr1W6566O5p8Yl45vnZrXbkElpp6OH602F1pxUMscr8yAIb8PPOo02QByWnjpKPOgkGPNwBqw2Qquyy3wZJRauR74yc7tPOx9PN4RpMXXfAChGR4piJhQ1X/CXKlep/4QY3IO7d8WMgCpiDECulnMnCt1U0u8JXFtPCGEGwxQ+RhFhu7C4DsEZGjvgNSCb8bFQe5zYAD5oiCpAYfPdWWKiu5jZ3im+fWZxwUN7Oj9NpGw50ZGmUQPDJPNaun8n/Bp64lxgvg4o+UOgUvlVVp5UNfxjLk/xy12DGSTQvy+DPah7eQ4m6lFd3ZrPgJ+uO9vSBMXyZzDMbXDOzQeBMrms8wdcfrkxPfH2451HP8asFK6UVhkmVb2rm6jLEXWx9XqkZPUwy9rncpj/nlfDBOoDVbJ8XK0kClEi15iL0MpYJIAHK/0NfjZdVnmIMN/q3t16ZzO41a0z12J5dzsWvs3cSumm35yzPyxZrP+nI7l+FKAv6W2Gkq7KzGBgxu6B4lKDcFggVt3CxDM6AKGXgG7lrhtEy0h3xKq5y0gjcogu25tzO7h7AAMAf2B/kKwAu8AJN+ZkWkdB02VT3IL0EaOs4VGl9W6JlHkBsV/NEZ4Av8F6drZZLPW/4U8bkhikndh6sCwFkRZTvYTWViwVPkWpfaQDMvMDBas5jAVdoZWXgs861yWUeqjOkQzcpk4ijPhWI6Ftclu2qvMaHG54fIPh+GjsmtdNhev822ygnnvhk7WpZmrY1jGGrFZ/L1TJLDTRE6ZOwRqrNzJhIkgPQuWZE97VGzEBAjy29KtZquVnnJba9p52S82ZyxHJxK2KqiHWwIB4Y+ABAFVEy5MtywGg6QZZN5Wn84DysukeJqNizZhGzjytiN46+umcR17bLe2eXE6+eVDEp5E6Us+re1RElpUjx3r0hIMLMEMB163eXJTGfknAl47XjP7RXe8qE3e/8GiYFNMl546G+BtT1f4M4tL1BhNZXK4ukpvda3FoU1MUbvohmzyMpC/x5mRsnVHy52rwKsDXmYxX3aEb1ix6sVMJTOPZBxtqNQym/17AR1SQoWgD2+WoABa9ROthvRMEF6qUE0jZoNRCEuoaoEHGXDmXuRlTWXG+upwlk71JhvRTYe1n3mdP9kxO9LKUsQKI/8vdYFQyJA98+A1/R6aOP6FfTBponJjvF+KV+ojPKO11PhUjI7NsyVNCKuNOW5lmBP6MgUSuo+MmKyfZz5sh0r6i6MeMq6NJxn3MpXFsMNs0MQPrAPMPR/fXB5stMFkh7F20d6P8Ctpbn6rmH6FDP1xM703O5PpbbRIU1OCHkDO5WzMrtbVwGllkOw4OMtxpxMva5wbXyO/2CAIQMynmnVD1+0xON+0aPem0LpMpEO5F24Y1Yx9n21XbUufEzGVWpot0nqnjOtStho8KZekYYsH0R80Hh8gb2pBF5ItDDKaHHC7L48ysTNiHefxKk6JhmgSAA95oUsJkIJ6Q5ZBVqKq3XgW1/rmdeKxB4YjUXM18N4Ms9ULloYaRZvT75F442T5NQ5VByN41BzO5P6SoXMJKEJVGGlY6x2z7FOy+2kFpz5tCmw49Bqp0bsvQ2Hho2Xmx7RFDB62Oe2pp2SWnSBRylPMde5ZHgjB2a2IqHGCc0CvF0cCs/FpKaDkol1PuyyjMFJdPE482IYmVZLC0NUt5ljUsFlhJTA2+ONgUbCtvwy+qalqX3UlpW2ntFCUHRilSL5l4PKoWV29ECn3jZe4SSeiLBPkt9PvB1fMHO6Vkb58UOFAPSCRcyjlqml/jc3RXFYosrRS/acUVxotXVp5W6KtMPNrihtNhck64KVo0ZOxoF19Fq85hyBMUjFzSudZx65vUHStum4ksSwUksA1C4BgAMgAbEXDB7AUa4CQeePhx+lmrpzeFWgBJHZh7dN39KOP37C4PX0MV3z56232280qc489Nk2irUcVhFEXx3Fm0O99qqVlU1/BtlWER235UnNkK63NXGFqh52EozCqX5qDPX56vQr6e/NIU227CSutVd3dotoZlAQSSz/Mrjb/OW/DzASnXK2cbf25Xh3HFpBn1ag7UlhaSzBNBKVqtnctGk2Ok332BH8EHph8t7gwMOR4qgtKbGgsJ/QzP1a9AKNajP7n6OmlnlvbkLBcquyFlYvhK8Itt6eUubRnauGR3xNzcdMvIFalZOHWp3j3E2Vw4O2hnh7jlaRCkIRZxhNpqP2XrVsuG9VzCKPmgV2TrQosg1FLOfhs7WDe4c6torLM08oIl5ZkeUgRwrPAR9rbCQkrPFe27XlZsr0FIz/7VZ+ZMva5CMNZjZMfa3Nx23cXmYRyXk7JrXmNk4ogmyHWwtrcyHERnB7wIFXwXJnCOU14sETZ0ukMR1mnDyudzPJ/czzZs3mLZhb3LZ6eV7F75PrZheU9VqW1RkVbJENU1YZMM+Vpwy0gUUa60KZSLBM6knPQ02T73ulMhkJJ0sPSh/kw/cYpw80qHaRgXVChLcJCAekCF1D+heheqG1W6chq14G0j1VPQiAyWsoNJx5HLBH0wW8BryuinVhY5Wusa0kaxR1YkTphM1Axk3N3zUx44G7C5O19YU/E1IFW0IVE43fwt+atDXUew4qZYDeq2q31NtMhFqqpq4NmTKTN6Y34BGp1lPV6u0hnu/F2okr6nZ4fGGyMqmbDWmvUUprn1BK030/RiBkgeF0khppUtjBHRmFWYiuZKq4PDDPatR/KKjc6Q0uHR9NOmloKtZLbNMoYrWEoe5gMi7MfL3RvfVB5r215ko/Wx5k/UcwM/XtoilxjRQMt0h0OtQpf6PQUS6o79MJXP6jcMtG/dMxKzcPQxjWO3wjO1ee7O3ZlkwMN+kisZJ3rEt+owXwYmwPIw18O6O/D61DAx3hs4x11htwNzGjwMLGyx1YGnwNt2vwP4Ghe6KR/akhBrNmsx6KPsx4qNx6pCgYEmIPfI8IX0G64sXGitmeG6408l0fEqi8GVxR9UU5B3yVXMj4mvG3qUX+6KlX+nT6Elg8thvI8uzDNWO1B6+vnl26KABW0VNBs+1Qm65UwmiyWdBp8sufRE0P25E3vln0WyW/Qvfl9+0QB1cVE6hPMnsjiT4mkB12WN4ZUmlZEuWTVq55iOEaN7AomyKxFXnN7OZi5d3hY9c0hgI+thx1M0HBnItHB1HaIV0e3zOpo0CmzM3/W4U19lu4NrO2I3Hp88kCh3Z3nxj4O1mr9NnvFRtjAX9NKs+mtXO/GCwkEkjSV+wm6m4676FE9Eri6EP/lqMpKgT50IhttPKsE2QVlVANvUOL56Vjsl5NkAV+xops/F8cv6qsmGffAKhbTA7MKlbKPyZBFpg/NoGl1mIJWdDrFIOpyvgSj8wJF2aDsEPrDA6eMs5AIZuJAEZv7x1CUL5vkPHx4KunxyKvBNmh2hN2KspNnfNC/PfMVgY2wsO6wAosEDPh5j+PgZi/NOeivTbckATc6QqukbAGvP5oQWQS0rlVVzDOVc6BNtq2SUdq//M+upSUzRqVPd1nHQhulW1l20ZW99FQPCF8BSEgibVLq5N0UFias9uqau2ndKVng2atw1vcJU05gtWe85tMIeIyyGpcMnYF5wbVgS1CCikLY6Ouuu+lTwYtyCGeCEgCQAKYBF0ke4flmRv0Z/GbXVsISmFtEzseCkI2xAyo3RmTGLTawvzEXFtgxnR34NxuvjMB8OBsBQthWI43I80VvlEezOJBym3zu+qO1otL3JZsGok8mrbrw62n/hxy02Wly2u0yGuVF5OXOWyCNiQmosVZuovXWFGuNFguWvalCMLvYAHScA85hWjSHdFqyGni6ZFwA5XRuwdOkU132Z0SCdI5ejuXtZ7XmQ6iYC6QCb33o1hAtE3OltEliOc12unsR82qVWpukSYaaAGkdvBsXAKiGXFg3Dur6v0qH5P4BqBlIHTx64jUAvYx0cCdl8bG0lhrFA+lSZZYvvCS56a161x7OzQZcBeAH4yxUYOuzeIttzOxJ3UW1H0kp2sqzp814tWrxFqpwbnqTBxSakszVI3HAsIln95dttpnFt6qlKJtOp2q57g4Wz3n7G03XGa6KEdZZBuD0QrXveVDH+mz+sOFnv3siohuN8qyMQnCit1idkTdZapulAc4FDxvP0Mhw7iglvH3yu+2vDR7OJ4kpD3qfPeE0l3fnmNO4TTlg70IO+tnVs7ykx+OXAFR6OPsTU7n/CZyN3R2UuXBuRqgJZAXhK7Swpl9JMsxtaON5jrLOZ8qRECoLxJp4EyD1kh3Gl6MkZp/xvnR7clKOyNN5puqOOKwPPb7N0uJ+/22elwO2n64O0lGtQMK4gJUjuIfzuA/eu9EB/Xwlp/XrhojNn3XyvNGqGPl+jz0/6uGMaF7z0ki5GN+qg21nwt+uYx1yOjhwlMTGuMNlK1A7IGo9UnW0mOgNix1j+wd0uC/Osv10ZkOOmf1OO7u3Mx/XPgN8g0Kc1IPI8CUU0GsFIb+pr58xiMM7+lSPKikWNz28hvixng2n++J3n+1e2X+nIU4+/IUoF7e1ZFXe3sNp/2LhrWNv+wp23lvWOABY8MMZhlqiN1dniNwAOSNp+0DBy2P1O38uNOuVYgIDoighNRvWzOeCuldVZfDV2SWmxYN2yFrutENrsWyEvOLGmhz3WlAgoV15G9NrE2HB8I1LOnD1+Ov5F8m2TtuNqbseNws1ocw9OLjPxvsB+isUOt4NUOpZuXx3OMRQTVhpWuWyFxxVnUcg/PQ0LU3lxxJtn5zY5FtHGsr19Ju1du7vZN1tM9pgys9krZsxZvRulN97sHihUQrWgttiocdppHW4Oltoap1QV1XzktvOkOexumckY1CkKdrO5cetRPdqPiky0jO5fyulmzZ1UdxI3zNilCQFcdHQUXgG/4KMuQFCA1t+4X2LtnttFBvtsHq/aLg1rgOKNnOMxVyDYYmcxEndn4Vh2dWQn6QDMjyJYI1/fVtBN7isaAGQMrN1nsgIQwoR8ekCOARID1JSCCOAMKS1sGjinNlgvWevjCFwf2DngBgBcAOwD1dR+glQIQD0QerzYAFADQARwrkOP1AkANyK23bADplwMxcAWyxWJI3sR8fSD0Id6hcAMeQoAAFJTALwB/Qf2DrqBgDhAe3zYAKYDV+B4YghBgAg0TQtmFaTgMAY4BcACPhTABfCjyfEDpl+BCm9gGpUttDoNUaXvYABADWhcblLQCnCLgGfAHHZ7tlwGGiR8OrvhyMNsNHDWKAaufBVUYgCZwLSBWIE3LN9v6Ct96DMKYGXsKWbXu6937Q5tO26p0cvvIFGeAU8vYAoQNZPS92XslojyAd9pwCPyM5vLyXvta9nXv1dIft+gEfu9I8xEdEGeBjASAAoQYzQTAGfuaR8eIL9rvt5VjTCr9poD99jfvPdkELl9iIAzwG+MoQYBCQAU/tz9qFQt9pfuq9kAQ39u/uD9h/u6Ycvsh1VVZKgFCBnJz/tvh2k5vxg5tgZq6vsS0zN4bK/trOX4x7cylFb15DNYm9dR3N41yVVmc1m/b8zPNhc2vNpc1WhgAu3qBo2ZVZjs7m6ge5xWgdGSiv0MtgMOUJiPEUJyTrA4MMO3qbO5KCBgsWOJgvID+8HW6dtuPgtrX6RB1t4tk5sbldQP7ClMREd2HDtt8lsYzDoigkfEB6Fg8PSN8bWXVlmk3V0VX78SQcCtgFuYC2/WkQuolJeiVtRJkiEn/Iou/VwZNpZrSzlFiCNe0pFtlZmCNI1gOkNFvnkbnAXlLJ1otweVDPfa51sE16uW9Fgyv5lKeLmYUHXNy4NsOpTwzpWoNs4PEGgnJBmtLFpmtRtzoxs1qiwc1nHWPbZnofJriN81tbOHFvUHwasjXWkQEt66j8UAW3etzFWelkkpCtO2MhWqO6pJCZnjUb0h7MVQlmDop9jBYpn4vQdzMOxhyofB9GTL8MzUs40iG2iK+aXQHZod6d3ninjOQ5ztmgh9WwjufQgMaYekfICGw8S+kIBqf0j3avA6621KT+XeR2vM8K1Y1d5rfG87DItT5SY3rAi70KaolNLTUHOy2shlXpzYqkwrkDePL/nXAqYcVlyRkluzjWNDmYcTSBAkIiBYdTM6JiACxt295rv17rLOE4ATluMdnyUFp1TPQFvD10+oz0p9VDtukB1ga6BUsb1tEzrqFlzKKrcSd1p33Rp49AKD805RUIwQWZijtPBnHuziGjsbdixXzdjapIj3As3FPEfOl+etsdxevPR5etpN0DNghhcXJlNStCjzcZ1xpW7Ho1p2vdjUHtpltphyY8WQVsIf7JxUf1yn4tfAkRrPArN2cI5M1IjBeNYmlytyB13qbpjyu9SHdPeV9CNJ229SY9iU3Y90et3tEKseD7Ex57Qd2Ac35gRVuU0EchU2s90yzxV3fOJVi7siBssFLHWAcKh0/OyV8/MLV3DZNggc2DGCzOXN/LmIFU9kgJ+lmBD6c2Jjaqvm/Wqt24+qujg95sEZ5qu4d+aTzlvdMZy8jOe5wTURg6jO3e2jPGnALNKoyFtO2nEQxUjUKaUFYFCxpAkHAbjPiphsuXuqrUKlKPXcI9EfcHQcsqZkD3nekmOGAGTNxql4dyNNE6KZpwu4j69tV2rBsQa4mNmdoiWUFmFvp3aasIt+gtGZmcMWeucMyWOmmJj1auNxazOrhzaua52VukjFEf/4xQeuZ5QfqoTzMnbHzPSWwJMXVxseIDoLMstu2yhZ+6sRhncv5baLPtxnmo656sexFmwc/V1VumWi2nrqP1C/hoGvZZ8Gs6tgCOgR9CejJj+7E1SInw19wdUAydFzo1rZIRmrO2t3v5s1RYJBD3MhtZ/7Xyjspu0xGCtg+DuVGQo7aAIYzRjAJr04As9HTF4NvGaJDKpDyb2Rt1WVgqepJZDvlQ5D0q15DuOY81pb2jYVh6ptw0jLDi73gIjBVw0r+zA5glVzywYnI4wBFRx4d2ZVaGXfZ3Bss6ikd4xynKzQsXq87cjRj08J4AeVeMfNZkvpZVgg+G5FNNtrof1IY+CzYays0QDhBqxOqEeyYKFDMfCv1lE9vZzYyeEkiMOY4iycDhzNu+52ycoEZivB3czpdsEvri+4PbygNyeMZzMWg8UkOV1eTIHCA4eOOgKOGiaIVZT7c2HibnXbahPa6VTaZAnPBlFRzXp5RhwvOT96WhY6VG1D07lS7fnM5h5hOVljOsvW8rKRTlHZQsTkd87I919BU5lHt1kv4p2m1lZdsuc56IVQLVBsjRpAviXOPC9RvCat20LX8J0D2sV2uHt41af/E9ybW1iVPbAPOuyZVvHcx7xTW6zRqkvCqf4uuxyYdoyy6/F3zt1hjsupnCu4+gUopMrcMNmBNN5qQgzLcq21Gl4euB+x0fqSMfMM/GsNLj5OOZdOts0sueuuKx6P8jkPNJ+xSv3OpUO3d+2T2yCFRi0z+1SjxtP6QbidhwK02qj42SXnYug8LTPzgqlUdutymdMTr66uWS0Ysp+AveyF6mclk4T8EDzX8pnwul7b9tI8dEkPi1m2HEqjMsmw0ft5zuOd52f2Q3bzUcz/vOD5qfMj5rQNjNpWfT5qWCz5ylUCs2zmMj7Z0BNhZvej4Lm+j6Ud4zyJumFKTgI0Xnva6HSxpVpLmRjzKvRj7KvSD0/Txj/AxU0IgwYD43FIT2iNBg4nLUTzMeLjbMfED3Mceu/Me1cwse/9ntUjucKdRUrquLvWOfjI2sfsmD2evQMFs6DpHPWnWbndu+bk8D7gfUrcWU4KOauGo1FtOJumkUGT2dYthroBzm8f4t7vWYV7+E54AWdPjlTypzrJI6y+R2R9vjklV5+2omn8fCN4wuY14LP+LN+zATuhNQvXGlaKcCfqgAOefIxOeHuSL3lECwd5FrmOgrJVtFGglTwTzL2ITxDKOzIIkxyqGuAR3VsFZhy1FZ5wdFe/Ccc80r3Zy2ZOVe1GtNFm1sY1w2b3pQmCOt9SG0Tl1vdyhifFETPPsqtB7fnNielEoBBBgMTn7oxIe+tgBCQeeYvfUO5NTeuuebAcSclW0gHc1xNufJqq3FD3SePexfEfCTCLtciXOk2mWtiihqLFT27jaJ9LFf2JKYYXKmbEeixtgpGHjNoLR7XyremopvDGIwQjH9d7Bf59FVMDlRnPIxB1W/DlcdAdsj1eRn+vPplSaRF55YgLWjEchyjMd8DrGveoLKEL1F3nD9KH2luofOLOKH4NmYlwGkpUKx/JTO6yhXZU4KbYkzEdgpc9Uiy1a64L6uGjTzVNkjw3Pt+19siZwLvJBvKcaLn93FT07PC8OqA64anb158zrd8+9C69A9sDvOVNuLhB0BZRD2ZasdDXjIGVkW8DuCiv0ES0TYQILKnuI22enH9JEsvu97y1PbRO9ME5nMuxwtDU8xtlhi9u1DV+mIynUdd5w3YOKHl0DTVgF8zvgv6LuIWaL4RccoV4QV5qBpRl5XPpSGd2Kt5uuKl+lmgkV8IfTgZpfT5+sOLyedf6yymAzsdgqYKfB6qekeISefXO5qFF2jjgNsjywdjLrut+gyZcsdl0sL16pbozzju8CoO2p+yQOVRQTxrmmJ7B80Tu26jxvvSLpe3jgjQNz3xK9L4v3Qz3oRvL7xMpcUP7W+tdjqCjl4U89iTGPZ+GP13MvjLnZdmL6XUllintQGz71rCFpQQa6TV1luZQ5p8vMxkCTNjUuljjDqqNwFlBgVt31CL4noabmiR4rTZJipXPDtIUCUn8EZwtRjDsNXThAueXZ9PDlmY1y1lJ6+F4l2BmzfHS+4I3vTEKPNY7GFMzUg6ncuFMZBmIsERFLuZOh06vMkOJcNm0KABBGjXliE3NBgRttBoRsnm7/JFd90Uld3oNld4APfjqRtWxzw42x0YN2xwoDp0X+0gOiL76rN2PHqJVaLB2I42r32NkSSoj9dnS1+LzNi8FB5eOV2xvgS8OTLzpjGrcDTr1Rqtv383ngS20ZsZt0dDBr2EcEliFoRr/eMlydbsZxzbu/Ebbsqun0dXx+dJjRCXtCVh+NKstaoAZrW5m6NqCasu52sS3Nav8VJsEzuPM+lmslVrl7up5t7sZ5xUDw45WwoUhZH0z3Js/z1teXxtYMcLtjOA0yhKDT0VOjrAPA4r80S+L6egcphwMWkbpuoVxcnHqTH5lw7H5aLMcnB6wiu+JVde/e+sqk/FgNHp9ONnRis0MV7CWXVfKnyqrsWcVnbvC9kJvr52NbpECnk752XG5GnozKlnZtm6csH7Nh2fYz864QZnKsoDt2cDaJMeRQXedvz7Dpd3UwJO3RtUQ1GWr9gx5umhkgfmhsgeWhjlEfN6OeqhUsPiiq5EAeZFd8r2Xbu/DDcKZrDc12jyW4b9XqvPZvTgKACFvgIQCJusgvNjzow7j3OfUrfOdZ3Qufk0pFsNa52eLVoVKDaS8c9JAmCvzwKAuotCeX1ULrL/alcXcsQuaADWBSDtmnC2F5fblL5ePE+JVVAV8eArgFIgrwWl0t7Qe/j3QfMt88MNsANdidkCePVsCfrdT8CIZCkIUr/XM8gSTfVnRNTbVrCtWDr/tPOSDfWbzDded7DeV17OtlYq+VtnZZI48w7qVo/6r0Q0VsgIa9HWylzcO+r4Hrzwnmbz/s4jIwc7rqaTiU8v8PA1gCNg1ltFYTltEVFpnlVFzbSmtxGtETp7WkTurPzop+eTbT7UKJGidM1T+cSc2+DJZUHFxijUesTwF0PWQGhElZ+I01kbMQLokpzFoScRtpqgZDhnGRzWNu5DkwnYIAoe7FhSf7FpSfptsCii9IElbBxn4brxTT5t7l1y5m4HfmsRiXZna2UltktrjupTdZPDWWUdKdA5v+b78oXPVJV82Nt5hf61+pDLgGiD0kbhBcALIjkbHFM1GrbfDE26fWgPbeA++0uMao7fULC4fK7JHhULlyRQe1OpuRxRrGazOcN/JpuVToINDK49Wo0gyrTKZRpzp6OM44jIZYl8HtDDEe33DmhWvIER4Fu+MMsK+wOo9zTlVGi7dXW/d3dtvlO9WipQD1BW3WpjrI8Y9rISLnvknTzJDQgvwZafRcp7TZSanbvRQ2xCMarlrYQ/bvaSlKX4Ejj+4eCYh8AhSgdYqe5IVWadBUG7NAsyejTkkapA7r0kTXWpxHcHboHfRMfTVsNJX1YlxwG8ehFc+b5/lU7khd56yG0ilp43yXHSZo2/1NHEIwy/LvrHq28CX4gWy48wvvUrET3ctzvuuGGUQxe7x4NUWZZcnR+4Mpr1kfn1q0uJx7wirEcPd7L3kc5ktGfulsJnJ+vgUmmrJp8d2l3GaJ24dcR9vBu4JV7tAaUVL4+szdQ35MslPfGGTdebAevde71Td8VVPfp25TuGBtpN7ADoCe4h+tZziA7k9iP5n5VWPSr7J3vETQzaGQbT6HY5XcBATtBQYw58NiByqr+8ssDnlZGx5qgmx+jB6r/oMGr8rsfK+RvDBz+2ewhfDcgXX6Nd/4bGaRzGJ8J2RhyDuPFNrtcJfB2SEm5009ZgDJVNicscTZ/rA/QZYSzsbsrpiOQUhP2pButBtY7uNfuvBNd0BgGPRr13U/ugNCvA7vm5tnxurL5NdHrk+OXrxZs3r5Zt3rkayn7zIgBj59ciVsAyoO8SsjyYunAhwgmgh+cVqjZArLrzGe3V2aAwkWg/p08mcMznuOwq9ogP7/FkUz9g+a8YHX9dlF0Ip1C0YsbbcGWia20GgjtAj/61HD8KEvtzPDTxxG3HMql06cyWdGWTcpY/UvELQnnZ7ryNdBKbdfFQ7Q9rb2PesBx3O0d49cyu09c7twvbsh9KmKfILJMp4iVXrjNfGzrNeMH9IhuyKkr1IoMdMuPMLvrzihuUL9dYziPM9m45vyb12fL963R42LQye7zk7ez98xLx7AdSB9OJW5aDeEDm3GhzmBPhzuSWRzwjMlj79zlAoJB0Dv128p9FCEF0RwYQJAAHVhdUDz083kF883Qt5jdZ3Vjd0F2xNHj+xOzhyDNnj6z1RHqfdGbeWLJHuTexj/xa17yOPN7kPcQWYPeHVzwTd73ve0trQdBJxlu/cgCdubmrdlwxCXWKGAehyuwdTcS/54xQGsHzg1tO0vL35bk+cznbVs4T1OVDoiZMETxc4ujir0kT22lkT+ZOVblSHp+c/C1b7mr1b5uNPUJxEPHAiNtbvrNAIHsxERqYu01iBfDJwMzhtnQkiT28dgqUbejyubOvJmScMPbYsrZ9BcJ2ebdTWHcCy7uqZw780n3D9xa3qGq3zt+d34k4SMiXXx5EbpkNg7krGWkbk0IifrKg0jwvO12dOl7d+Qn0qnchThq0dDlFMPbltvPbhwCvb97frBhqHc7cVF7MCk81u7trS51t15S7LKD0+k/S9H8WcrpRfQ5Nk8jlhY0d+7bXoJ7+X3zP/nmLSvfDR6qexPYWqEwlYf5TqlfVQDklsGsNcB6rIXc+uyNf7tU+JslEk3Qznaka1f0XIunsnDvgt7Telfq7+Kfmp7fHKEXndinglg+p5QPDrEdf/CB5Hgk94aHD3KMBFpafuMKhZt9fdUVcUSOc2zQ+ipk6dMpGvP9j8mWSomEvmZChne2Fbd69L9v3TlLhjHtW0t1g4P+73vU+oj3ft73UskdiY8tnmiv7maPfMjuPd0d9/UUZ60vJ7yY/Izp6Oozw5dZ716OH7XPf/c30sEj7pyi9wTush4cMKB30ECZvxfAt6bMRx3Ityusv2uN5L2X1hTvbhnDviWvxOODNTs5lpgMjhuztadmFfWBhxemC6Rf6d2dd/14BEMiomOaZsx0Wd8mPgLVIsDVzTvuCmBv/wuBuqTBBu7Gvu1L+4LuSttf08xwZX+O0jX8xxnchOqj3TpsVeix8LvH+yLvCJlhH8GuhsifBht9sphtWOjB3FC48tpdr4pHKsRE8NxoN1ClVdf+1ffqrowvLacp3dBnVevlhw76rgwscXuRvgBo/e1r8JVjB7kYTBnJtTB5YOzBvuDsqhYMlN+9miXrt4kVftcDxnet628s/1U1vobn7gPQ99gqw9vM3d1xU+CfLxtgbm0cZmxbuNRzxuzdr+WM4h4OoH6fYGzjA9GzkUMmzit7jB82fU0P4XPx+jkUH8tdJNnGehtlFwSjpSsZNvNY6gsmcaVn7v7J564dxyS+P77+dhXsHzJrTUfeKZctieqM/AdnsNzKA6VVTiAtmTjrnPW1BrdZfOKTzyRoqH//dqH5defI/Q9aHkn5GHhPeBIcq8B4W8lzFMn5ml+0dCsvWdL550dLaUa5vgNABTAcOBGkDPEe+xw+YH5nti96Uc6WO+PdyfNcF2EPykHkuwURQI8VrrKtQUl2fqhnMz42Xo/jjBDO6QPY83NtQO683sEPNoge4Ul5uwJv/P4ZqOerm6s+e7xin1RVMpe4lLDN76696epgf1IeyuCWcKjgtyyV1HxjcNH3TNwthvsFzxFuXzrjdLXnjemono8xHsu79H9482ZuQt22DUbauGs9xpqffqb5qQzHwPtzH86v+Zmo/6bparLHieJ7X2U4PX67OpSOLe2DreclFxCclwANv7zqy2HzrLfP3QXu+Wu2l5bpm+lZorc3z+ot3zq1s1eh4/zpF48ly1hzbyD49zbEIc9F9EMvee76umt2BDFmIfbbWpGjyBIf0TuDKA0WpGEUnieLF4SfDb0Sdm9wvgST7VQbFrmsJt7yFoL5NsYn/UjKTp6rI+lKEtM88qS5kxO8gO1rrbgWvn06+lunzBtc7Jt0g22KckZ0hum7dmPCHmhn7WskmhsthqO14aPwHtLFLaphd0XPk+bAJ7fPgQU/SQYU8/For6oq0ae7eg+VVw729tu32/DrWpfEhvVosGtc/bt0XNZfLgH8LSO8yK3U9vssHONY/4Snc+Vvp1SpeQ7m0ZdR6buM3FHNO/PqdI8e9AQ0pLWQDL01oWjvpkYoVeSRzMTapwIUB3kBXxidaHWaCO8gHIrUcZ36MCrioNFnjTlO4CKXxgBEj/zZqP5hqVG2iBvObD1hlBLu0/FMZYE+a8lPjzxKnset5qL3tg2VKSe+F3071KB1sdSHAOt3t1PWP9QhUlsTvAOHx0mXXjs8cwn3fjdhs9/Lps9WQYc//TqFtRUZG+z6mZt6zlZdZLNZcJk6q8JxyeskgRG+e24tN8j8c8cd8tNcdo3KnLj6PnLilzlg76NfuGm7YIkMt/HEi0F+7vUjH7c90ASB8bLzQCYPq+tREwB8B7gqgAr1G/aF2Y9AHNgeWBofeWSkfekXsffqxifdrXiG/mfSi9YGefdKr0+3L7ui/6x0autC2TD7DWEqei6p0omjRGDBw/fVdkYNYm4iQBmMrQsHkK/klDPPFwaZgfdsW3+xumfcH6w0yX1VguIj2MKX3xKUPrK5Ga/3DBWHpu+ro0ckHvI+4O/LFBAgh2N72GJBPpGHzuslVTW1btbYqy/zXGy8WH0KsGTpPdKx8FdzU4qWvpoa+qu/buNEEx9pELuSJAAhCbNtWoxNgvg0nK7uVpqMc4zjIjRwPy9DIgK+wkchwX7omu3wW02uWFtYsHzrvLbdp9myTp9urv6EO7b1i743w0Yq6kNdXAarjNyZtQHzABTPjXjGHjDk6zs8nimtq9npl0e9CCJ88p1dYEOwd5bmnb37W6xhej7OM5PlntK3Wp+eHi/gbN7w9rVEMdRDu2dwD79fBHz+MxjziXhHv/vLycG/h72I+bX7EgA4DeNkVYrnpxajboZg6/pHp8g/55Dd4Z711Fjm0OMP8KMlHiVcVj7qt+FPPZq0Bw+jclLitqJwB0b+pDDwKUjbEPTTMP6u+cDn9U6ZwR8AamhM8D9jd1azjeCD08fCDy/SfPnQyQ3gTdAvwY+vPi3IMP+69EvklsYqHl8dzv7Bo3x1sVdrG8arhS0Gbhg9nRIW/xo1F+ogEqFIRBi8O0vF8EIAl+wP7CEDJnY9pZ8uD33aGus82GuXztwe3HkreWt7wfyQ2r1+Dhr1Wudos9z9+d1b0W+ut7tf7JlxFfDABftbpAomQmEjet0E+9b6yGCccbMdy2Bcwn+BeaARWJ63snQG3+NtbFxb1Jt7iMJ2Yk+BINBUSPOliZgWgCOqAqZpX1eVAehVPRgO2/qat+YurZFhL0/E/uvQWcwDH91KlHk8eTj4tXcr4sdtx72Jv2dPJvi4Cpv9N++EQ93pZWA4e3i0i5vxhUaRgt8xgIt9fNCFqlv0n1t37L5/TnKebb6CdoJ7OZwFlKYNvlXVjv+yph88Kl2RrMPcK1oH4XISZyR9QHJY+dOcAj3Z3Lh4ulzCDXtv0++zu3wihspbfen7BU0hRK/j9BRn8ETVOJz3Spc2kwG1hi9/SehT2tMM9+FLlHgF6v3kELta3t3oBXWSG2Kj8GevN39x1vt9Krqn7G2dGf+9ylqo/9Luc/C2BfD6+Ekcd1jkeczsEl/DuAhFl8Y9B6GZdZQXasO5h0dO5mPfIH3s8Wl+jtr61J9qK+Gc33y9WG+29tR3WP3NUeP3GwvB8elk5c8ds5cF7+aMBl8h8UsjptR+W5fEjaYfFMR5fBv16exl0j8zP09ryf9h+Kf5D8qlgV9HVjMuhZfvefTp+vbLrMVkVzzcEfwY2t+u89UWlAjlllj+11k9+SZuV43LestbA4HJNlxrJL3XF1tlhnPyp0vPdl5Ji9lsy8B8+zqOZiBYsrqnODvUveTl4PBgduAgGfrAVljhM0UWwqZEave8tDyRNgIvc1UaiedQrrAWr+/pXpOki9sN8R8cNwWAFVii9VCwAJXlxfc0X/hvKPvLsGx9fdarhE2aPpE3aPqRuY3/fduHfR/Grv8u1d6eyCVlp9QV5HpgVr7tdxomtJ0+4562Qb+QOxS8c+xqMXCqQ8qkEbspmsZ/gSjCuI8rZfkj/T94VysvADMJ/JFbD+kVjb/GggiuxPq3E8h+E5mH9A9JP9Z9MVpq3jptivGprJ92Xz9M4HiXECVllUJVl9exNsSsWFJXGSVjy8yVx2feXwMzvYwLOGPvPdJbo7482BcJns74/LI3hBhyLp9SXkiSv7r1sxfNx+u4njZgHiPm4NIq9+P8JXGPAarHEA8ibEbYhlmFh+YAAn8bEM4gk/qj8mH8j9nfvHtbdpw/cBk58jX4meA/5y8i93Vl+H1yz5Aea9eX39ehHoY8q9tFvLyFatVzm27avna+0u61/7XtI9SSxDc4ZyF+nX6F/nXwAvFHrsOjvpXfP+TMNu/brmjq8pj/CI3XwOw20Yv4jvVHsV9LDqP4cDgfffgZo+Thw8fFz9iLcb4eVCpUX+2exWXIuaX8w3p5c2rOT+qfw8+bAZMuCKLveafrO5nVvueivxi843wmZ43kEhjz3qmN37j2Ha6eflEdY3Re9X9sfNRXw5bX95J+LcBybY99INLMp0yy1atuy303ntGM3/LNhE8+f6vm7VXzhGsc3i1teD57UPz9GvWjvc5eeG5/C337W81PietPxmd9pzXidEdK2ALnuVAIbEicF2HVK3jrd0SUtZQnweWMRzHWIL8bfSTybeI0VE+812bf81koePehHOAj+Wv/m43ZRSrOvsrn2v3mw7iCl6doBOvRS0MlyPXpuAtfDjJiOZ0shvF2+UpYJPlCAVACjwAQ/CTJepg97aVg7vD511hAtZg0YHXukazUF3QrrED83I1+LHG5HTxdVJ+NdU0orJ4kGNzuXFIM/BhIxe4sO6XLrV2sGly/rXHNN2zaZGL9/4RAA8G0FFm2maACn/2KEQACSng13cTU6rV2zW3dHC1HWJBF2M1HQNy5vvUixQBAH+BEVSg5m8xljLJ5p6T4ZLHFcXXnveJdxSxRkS4UfVkFjUT8rh1TreP8G3T1FNO9dpjuzZRcQ60hEUlhQ2WItS+p2rV8jeLYsSyKyDLA+cwSxdR5YSWSZFEsFmDmJLhcINXspdaF19VRHfylrdygAlhZUjnd3QJAZTwIbETYNc3YKaThjzw64Oxco0yZDEgC4lSPNSfVZoG2Ibxx5jEWXGkYtnUQfWa4mr3WXVB8Bz3o/VaMaAwCA9wCggMQdWApsHwz3XB9+QWOXHPciHzrXVetWCSecaGJw7UKsU8oHYlDLNDtj31/5CLUoyGk/F2cA2EU3WGJ0gK3LXQ9Xl32tKMYky24QWvRYYxvBdzN5VgMgAGpiy2cGHT90n3JHQID2gJyVEz9Y1VPbQj0ugMRXGz8GLU/PEe8VdWOLMdslmkQJRFZZ7RbLHC8gzXhzQts+CApLBJcQ9hZ3C2gAv1a5NRMI/EZXdt0zgKGGSEE52iIubb0CYzb1SVdR9w1RGVcZN16AvxA5V1zCUbByv11jVoN6L3zIDOdXRTq/O+1WL1NjHfcvy3mPSrsfyw6/Grti1lGiQoAs7F6/DANr90V3CexFeTNkZUcHHy9jTEDksmxAisAHZhFPTMVKgII7WT1YsAVrHU8oeypDP1cAnzhfIu8zUzxVUJ8FP0IXYlViL1ZA781dSiavSPdogNavVNdBrwe/NfNeKzGOHNcs7HZ/F/hzu1DAMQMEmyqff78ekU8MOg8Hu3rTRp9lQLMfYS9or37/XuN0HhVsb7ssymW2E2RsWXCvH4tafTneQ4cEwiP/C90T/yuAxACENT3/OntH/ztApH1P5EGmR3dsERBQDKdr/0J9XBVAGUihMpQWhF9A3+tKgz/3HH8jLDGiFoC5B3kFPl0wPxgtRO14JX0yYwdssld5Z3cRNm2xaZsSzWhRFkdyHWasSw9YPVoXfgC91lJ7flpCe0XWWq9bbxtA3es3h1WVDFh+fQ+hHYFzGhlPNldDbVlkYR9ehBwArzE232tAq1N6olP/HLVIbREBNe9UFigmB3ZcSzwA+gCAgRHbAiFCA09sYAUhfWQGQ2djn0zXXJ8VK3tkMc0pQLAMcBIyn2P0Nh0Be1PnIUMg6QXPMUC+fg3AqXte+w2oDfhFexswZXsuJWF/a3R1e017W/t1+1+0fXtDewj7CYAve1T7f2A22wmAEgBgEH9gKYBPwImASPsQEGM0LQsQIIp5Z3sxWjd7fEAPe3CAL3t2JB97P3sA+yD7f2AQ+zD7Z6hU6Ej7B4YGABj7PYA4+wT7EPtk+3eoNPsTexz0U3sgcAATHPtHADz7AvsWgGFgPQBkaFo2KMoNwPgyGpFEMlDbXSA54QQwevtKX0CtT3F0EE77IgR2+yEgxfsVrx77WXs1+wH7BvRWIOXXbfsNQMLgMfslIOxIKfssiGgHbCEL+xV/Lo9/+ykg58CZIKbUOSCIfCMg94Y1qgsRQ/tj+w0g30wtIIkgkqAABxfA2SCiuDHNR/t1wMQKQuBn+0LgV/t3+ysgxXwbIO77OyC9IMAHRyDXIOMgpyC3ILAHRzEIBygHC8CYB2JUdKsqD2LVF59WTn8g9vQ69C9nH59fDjglYnJO/0DnGE5g5yOvUgcTr3wEZX9cjyZA689ysjaA9ld8N11/SGNEBXo9RC9IPko3HxMzf0j/eHdzTit/f9VbfyYte39aXxLnIQclq2s9VKCxB0uSHKDa5yaA/0xX4kqg2L8plxLMSeYxdSr9eR15RBGAjG9w/0MLE8MQk2QhQzd4MByg0+tHzw5dZIN/N12qPOg1qlkHEzcr7y81DL9fZWnnciJSxSIraLdwtz/IMLMFtQwbUVN/AJz/Mm9Et12PQyAMswwnc48Wb0r/USFqi3ctBv8tJFK3R49yt1onfwd99DdkAy9Nkxa9bZMe/zBPHg8TZH/nTXhh/zdfaWphIkGgL19eJyRg9icEdSR1QbdoTy1vWE8C4HYkNYtDCQjfN5N8h3X/eSde7DNvcpA02yxPbEwJgHBuBcCqqHjfYWhZfQOFPfJFTjUnbN1LoLrEHt879gh3WU9NywMXXnhWCFF4F/9ZrU8nWaBvJyXoBjBkHAm/PwpuYJ+bF0Dj0FnvY09W6hSuNmC9/RxwYWCa7VFgy/9xYN7bB1gpYPi1JYoHDwUXGeMlATyAJxgDhFAmMA8yrGTxKw9WE2HArIUYJW4ZXyk2ALg7Q8kidxUjW09upUdgrxdKLTeHddYdlCg/dhpxLgcUZSZTJg/Be/pLp049QIV6Anp3U6FlNVGtSFcENUzYC2Dmyx1EENdFpH24BttsRyjXDx1rGyAfOs9fd3P3NT8yoMpXA3Mo01rA3jZvl1N/HsQoqAk2OB9Aqwo/Hs80DyzTD5c/5FhnNJ9Lz3VLRuD1z0eJdj9vbRwfS7Ejl3wfGuN4BxFHduRztXFHGtdFG0lfbE1F4NlHJtcNQTngAOEi8DgBQA80xSG/QHEZWl3gqtoOD1R/WGJHM0D5PwUv91GfMgNcfwGbJvc1iEJ/Sn8bGUxrbl8TiCJ/c4h913DVUw8cwPMPNNdGfyZ7Zn8nv0VNdeDNwIRQPAcYKm+/S/Befxu7fn8koP7NCI9L9CB0b7QxfziPb6DJfxXTPH97m1l/FtV5f1Q3XAQCxzOvUqCel0vvGlkqLlUvOGkdf0rHJTcyEI7dYFoDfUU+A80moNG4ZAB4IGPoU6BtoGRoHF8xq0EfJjdfry1RfTMFuWpfMz1jxxMzel8BoJAEFBDhoNccGGD2X1SscmD40TiXRxtjf3E2d1wvtBRvCaoloK97FaDdH37nc39TwwlffQdntB8A+NEHq0NJKLMLN1iSbBC8jzpYKBYsSyJDMWdwqTP7ef5GQNIQ0dMkd3V1HIQ+bVFbb6pjNwOLJ0hQt3x5JLMieXz/QQlEJ1JxadJ0tzQnbLcK/2wnf6CR5TZvYGCHtUb/Lm9TXyqACGDxtktfMiJbVlxrYIdEYJ9fNg8fyCLzN6gQT2GLKK9lb1gQAmBVjzAXKf93Xz93LSw9eTojSbM4FychTIckFwnlKN85JxjfIoc43w23FSdaAmqSVghRwIAIf7cAbRJXdP9qY3GdbbpBgVqER3UsrHqgYuCZYJYXJrw8SF6HbFNxdT1SeNVx+mGQoth8ADGQtF8JkP1/FRdZinwLAaknAM0WXGUKsRe9L68+LlHQZDsKlF92RpdBZxaXEpFUFlN3SIFSqicQ6b8ra0z2TNgCj2FzYPYGmyxdT1cssg8XasscfXFzDpUsCCF9VlgNcG/FAs8uSx0TatkishfvVl0MV28uDP8LVR+JEwDZ0x2HJPYtSTtYOoFzoLC6QL8U9nqxCoZd20umSM1uSzINfVNlmQkyZgCT+ynrK883U0pHAZRDd3IQlOohV1z2ADZEPwsLdXRQUGenYB8sOzDTGuC/AN2/B8d2UN7rFVEaRyTTF8cO4LBnLuCR6xPTPJZaP2c3Vb97F3MnINMeRxRnV0tM924/bPdMZwWvZJtECmpvVUDJR2UrNw99CnNQ4Ctof0baJ+Bm3nFsex8GtwraReBu3j67c+COwNYZKxsuF0HpdopvkIMqKFCZqRhQ/WDgxBJ9TD0eQJ9XRb8sTXUPFddszxGJddd7YNVnLBMDgIqvNYDV+kIdFA9D12svXMC+gEYrD+s/NWRQ+w8lXXTXJn8VwNOfYmc2HEKfYp9vDw6IZKtvv3Jg2BDqn3gQp39Xn1sgi8c0EIyg9OhQ/wBfFDMIOTpRUF85fwyPY68sjzebYhDix1rgxWM571IzJF9F3kELWdCRKhjuHvYJC2M4HhCIWzCeV+9r1XbHQdcmAK46RKMex0UmHDVFazFggKhF8SbfGTJhMyL2eQCpUPEzRq141x19IYZAWnh7NUR5M3WApccyfEEXD1Mq2wteKHlWV1rLEphSXyPBcl8uoJsTHO4HfyfxCRChUk7Qt39sWxBCXJD3Exk/Gbp7xzZQu9CZUNmgOkcpjwxmd8dvM10Q8NEvuT03cV9cby2g9lUEAIDucxDzlD6XOIsJuxwdWSZIThCQhLcWIX+rHmw0twuPY+dNAQNfdm8UkNBgk19m/2tbZCN5i2fndPxBoH+fW19Pj3tfL+d9Kx+PVVgq2grKe7shsxH/UYsEMm+qRW8RvT63cORmxgDfFpCg3zaQimCXkypg5E8P0VpgnpDN/wwXe3lcpxC1fq0HAJEZDsscozlzOuoFkKtBF451h3+WO/lj21tg05DhijNAKhwRn3cne7dm2xUFDZBQNCKfBIABn1cDD74u1nXbExcwpykxQzt8FUp8eHIx132lL91oPSV9eODH0MQLaODy9Q1PAEQrQJlLSd8KvFTqH/B1I0STGm0nA3oQxwMsrz7WUkAFhUswjC0dKQ9gsyd4sPSqKaDCIV29G2I0RGj8XmcXJ1CuUM03+hFzUxQHxVF2KnczdSGwsQEYDgfmPCZ73xhlNJxvVzhtH5Y8HT+9Y5hoPWmww4cilytoKBZmoAXA2OsqdzVgpzs2OkoxZl0kBnrA8NdDoUFXMQDalE1LeSM5+XabadDr5gSyAsYjgIHmOyBPrU5HWMgZMXfkB600e18/RTlpFggmVJQksNVoY61edk7Aw7MUpgaUSo0NfUUpbS4mrSaeehtonTjGflCMpWDGSrxLngduddQMP3QFUkdJUKdaa98Qi2U/eNNPniMEdtJFsDAiRVCh62VQiGdVUKhnS0tRl10/SYCHMy8/Ec9+RzHPKeCJz3iSFmkqOGxwzVCG4LSnPeNruxbQl7ESQDGiBI96D2MQxtMRcIBdcx9ZRGsfFto/0hRZbp9GJ0raL7t/jxVg7cpM5jRQpxcMg2GpMH1KF1HdNcdUFTR9faDf4XmVRd0dXnPdDLDb4OXTVxD2Ww3TO0NzR2UxLysLOVJ/Tow7R35A09ZBQMSfPMDkn1W4Cih8YTEXd+kKzkmw6yRpsIsGbE5DwOAQk8CM7GFwv/ByOUDHd78vqnTCGa8zdDu6ZtDFQJCPBBCLXUA3JnR6SErCPjcu0IfzColUxz9nCDcRMJl/LMd4NygTEdDCoLHQ8gcCEO0gzowHchRwoBojem0nDnkaENoTGIISsLQbY7dp1Rb4YfAhgB0wPYAgIEaAeZ8192k2W5CzKRznARCluVoLO39Wjwgw4C5S5zMzcudc8OYAGRCefHBUc1DHPTCPdP0zEObw9DDNgBJwvPDNEJ6aFAAl8B8AYX5QCR03BY9MXj0HWNEbMHFbTvCylw+pQWCp5ysQwrYA23Iwg/CR6lbwtn4GMLz/cm8/q1vIAHA2HWL/DLdzjzL/IIkctycHI1sXB04w5JDKs1SQ3m9jeSePMB5+bwosODx+WzyQj+cJMNdQx2RYxU7TPuMATykvN2YI5FLhWpC1MN9fMItoFxQyRmspswX/XNw9MPZrJE9V/0guOmCmk32LTmC48SxXKQEaYUHXFUg2pzAPIalcFmJuMFCIRxiyccC8hiXffgjCVyTCZZDY700AYUIKICNrE2sSgh+LFiYFQEMyWQjTslR9b0DDuBEItEddOw0jQxMsgWMTTJdogHlKVTp/cLr6QBRyhDagyhwXgJs6VOphZ2S/T2xUXyapUWD/YJ51d3VwzFSUE+8jHWi1Kx0QcMyvfb0bmRUvIRgUVSOEQIMqTy9Pa5dQ4Oj8NIFeM3M/Iu8/726XVc9hW0AwlD8SgOq+Mh8uH1kFLD8ecIRnAaBfmwJwvUt6kAHrcnDKO3BnF3NIZ1n2PuCUn3QfagN64OKImcs1LxXg/ZdJ4KzJAUdQ8xXrb0tQf0+jZQwsB1kDJc9qwJXPQqxD62MGaMsnnC8TR4lkezhzCwNW9wgUfQNMRRU7e+sxgLpwiYCtULLbRo0SRXbAsKszP1sDb+tKdzEXW4dXgMCIipVB/V0A4t04hCbtSg1KYyy1KZDXPTqgumNFYwZjIIMrpHn9OuC3O1M7A40lRSgvbL9fO15jUyce6w5LDwDTvT/pFC8UE3FXaBp0LxD2CWN4o2wvQoNRsjXtAXd5Y1SdXctlYwydD4CFuS+A0S16g1n3JlZqLyBAjlZqv1UfOE0IQP/9KEDt9ya/Vr8b8PhA9r8zeAC+W2NTAgiAVRsm4xeGAxstG2MbHAND4ImFLkijGxrgExs4KzA1Ar5JiP9JXx8Y0K2rLS8agJZZI4UfsNFNF3DmWWqOVll9L2/g7kMc0ISfPNDw8JXzYa8QEMY4cJsi4A57UcVpQx3Ax+Bz9zLXP78f1yFw9eEfrnqfVeC1RjGiH647UI6zaTDlcLNkb654fwqQ0K9+/z3gz0j+uxGyOd1I+SdrAcsLgJZlcrJD+Rjgq3C0KxswAHB/EJOxBCtd10i7bb8DiKZNW6lJdVOZRNdOzyj3Z4MvcOFA5cCXD1XA61CnSLjwwg8hA3lxGUDAEAtI4/NmJSCPQ5tEBz/XZa9/IIubdKDC8NAItv8VBkgQwdDcELddavCkNyKgu+QJ0NhfegcP3yJbdoi7ry+bdFCeYOJbJdDhq2/1Gr8J8JQAqfCyXxJfaQQ/r34gtjdAb1r/YG9lfn/XBl9BjBbIqudc/nu7HfDBf1BFQlsSiJnIo212TDJbLDD1UEpbalseIO03OECI/3WgpltiMNXg/ltdoLqgoVtZ6yx5DKAn8J2/PcspW3/Ikip98JJQ0Cck/w/wxPCgt3vlELdjujC3b6stjyAI+wd1W1QJGm8S/0PnGAirjxNbRAjzWx4wpv8yt18HerM2/yxrHjlQrTEwkW8CkMJrLdFpmDFqHEDVkV6zUgiPzjWqHyt1b3AXX18J+1oI1HUhtwpUKNtgrDDfDTgDMLYI6bcqARxUcexuCJeJDGF2gOc/PYDLziR+Tb15pDE1QR1hzFvfNqtYyBPvBqIMdyHJLUUJy0CBZSj4iO7IDyUV0CPfG5QuTzzZOWtJANqAo2D7s15PALCElQ34DBAfwAd8RbAU7xpme0Cbh19zD81HP3AtNSlk+g+JPjwDpxDAzgBIiN3hZeUjiLgID9s8AKMGPEMlKMXQ5AC9TzBSULooR0vIlXdnFhvFPoEZkRl6O6FOlzGw9PYgeFEIi4tIv11HVpdUE0CBXug3JlQAtds33QMYVyRpyDgLT4jft1/eQalfCA5AlGloi0Zwg98NTyqyPktxCn6uYA86biOQ9eUV3yiIg1UlwWwLBEcqzwDTSwt/c2FQyuDLfSlZD0ltbSaI2OMzAxiCa4cVC20VFTA2C3KI6dhQMBtzJLB7c2zIgUCaiNWXeICUHz3PegM5E29zDTt0ix9QtPc9UIOXNnDDUMnPR7E4EJexdnxfsSB/QedHu2RAxcUvqPRA08VNG0lAYkCk1C7TPkigaMxZRUBSQJ6zL1DeiAF6HioEYRfbHyjmBA4VRelMNyAA6MjF13ydT5FKEiA5fOIOgM5NBbVCFn1sPkCTv1ZxP+DzvwAQ7J8K0JZ/MLlPqIJgPNcSn1MCNy83ZBpOOKD7ZzrIhAc8kzbQ5KDUBxKgNgtgN0fzdCi0xxQzaiIcEIrww69sM3rwhqscj0nQpvDghnz1AHYF0PLHH2kO8OYmdwt6c09THBp4qJN/JnIJCx1yZ6BqIAg4FqCSE2Jfa38mNB+vEDD9x1U2ERD+B3c8Ol9Oj33IjbBBaP43cQcwi3kQh25AKMXWJQt1f0PwssI1C1Pw0YAtCx0LDQcfPXpI18jgk3fI6P8SMKTaV+JfaOOQ3lttdHFokscOsg3bLWjIsJ1o4l44ixTHCgMNpC8/UpcHKTSLTu9Glx1raCizZDWqFDDiN0W1dlkACPGIMJDjrFvIbSxWMKgIt+5q/0OPQGDCtzwou49b5xQIjui0CP/+KGC0gijuTot4YLonKgj0Q07jQytrEWII/dFFMMqQhHVF4R63GijqCIYkX2d1b0DfEmCZPwesRRDd0g6QzYtyrWMwk29Y33/4TE8BkLBw4QDECyysfFDzg0aQfpDhaCiomdprSVLPBcdEMXKuGTJ6FUcUaqMA71A/AUoHJmMxZCtbKKrfV2gJAFmwfjZtMjNA7M9FpSENZhlKpRFrABjYsAiQfCVzANtBd0dCcx0IFachHnSo+MR/6IcIz8hUpyuUeUp4LTkA2lCoLS9rEMiNfzdgy7D/k2j8AD8gFkxJc7CbrTP/JnNf6QQYu/ZzFxEZNodEeH+JWIJcGPoaQBj9p23Q/hjaMW7vJwQKKD84K0c6dQnrK4iKlwzQzyVq619raVMtn0O4L7DMrHNA/4QDKOKYAjUHxRkxRrDAgRGQx4kkcNLgphiVELPhLwCbVmrg/IiIlUKI+nDtiOUQn6dggJGrCxk3XFkAO/hQZwpw/31KPwsvaj93c1pwtB9/dQY/W0sJMg6XCUisgOcVfVDcgPcVGeCCgN4oT95bclkWaAs9KNWpREYTUPHsS2da4An/e0jxcOOSMeRQMkBoyFU63kMKAgiNVjcsV00IaIKY2XlimL/SBVprQkDEbyiFqXM6XdUZGLqXAEcKGKxQ6NC74IjAiZ8mWTmfFND6kF6YrNCswP5A3kMbbX5DbUjGe1FxHisiORGsfptQMkF+CQAr8KIPVyxKyI3pSsEIxy5okskjm0zwstV+aOkQ1sikKWbozBD5/mgqbsjJaLBfRP4FfwHI9jZ68L88BEcQ4GwAW0B8gijuIAtWGWeAtNCQDyRTTAsXmMaXN5j4GOmZdF9DzRnVTTh3r0urRwBUgAhIfmB8EGpiUnCvdxtguTYVyItojBQbaJW5Lcjrj2RbSDCnaMkQ5eQ9mKPIvSJ1ZBcQxgiyq3jIy5lR4MWItRDXGOmfIP9FoOGAnRDQ0RfItaCo6KWPWOjnLFMQ7/CIKLM3KCiAt2e0aCpvmJ51X5jjdTuA+V8uWL3+WCicgFyTWKDx8NmgMFiIWOIAI8BoWJPwlHkNXwL/GrY8mNp5ICMO6KctLeljWyBg6+duMPzSMGCRIQHo+dFBMKq3VuAa51ABMeivj1dImH97TVxZOeiMYI/OHOkykOGzFej8YIzLfSA5/2WLbej6iWYI7IdWCKWzVBdCh1MwhmC1gCZg0bFMphh+JigLTycBf74u7QvorEc822dveeZ6FxyvNdYcd2YEc+97hwf/Tv1EiKOhSLJK338wuWDNgAVg3ydRAH8nUPRNkPDYqt1hw0jLbaZqsIkeGHg64Xc/LLJu2m0XHNjqyysom2Ix73NQJvtJ8K7pXt9/ayjYuti0zzrdK7MQ0ILNdX0AzU51Z6ZtVRbA2OpYqJCIqpdSiD6nAbtxDknbVcchFjlzG29iFQZTX6dA4KGjflckKCPqYkkYumnbQVCb3zmQy0Eo0IXYtzs+CjOQ6D81aG/fMlgIxgMnbYNRPlhLWRdlfQiXbUsNzWTrakVQ2Ufo2YQuCmNg3EY1QG2SPHRUBkRnehDazwGXX3crN3FQ7nDbGIbgqDjMaKgfeo9+6zbnKICPcNOopB9zqPj3S6iYZ2uom0tbqP5nbc1mcOyAhP08gOiY4/V+iJnPfPc/S3pZHmwN4VXPdXpnfj4dCvdAozqNN0kLyKB7Mjj2QNI4p6c0OKJ0YGd250WjaIpBgM0LBiR3qFGAxo9VqOnrQXMhVwnfTZYNHW3KQi4hU1KopudPEPKw39D4GP/Qof1tyxPQk2CCin4ITOF1OJ9vJ1ooSwDNMdcOEzBIx6cuUK7HHYDtcNmYUxYEUJvQ+soyhG13N9Z9J2sXBJcOV0aZKb97PDcmY08nFnJzXhgh8jIYkEsvOIVI4Xox/WyyVxh1ySWwvBpzWHv9MR9PgPH3YTjKDF17Yr8Ly1tCFVkLRXf9Cr8lHzvLFR9JWLUfIgdmWga/CRtaSK4veliauKNXJkiTVyMfGyxswlbWdSstQIjhIpiqSi6INuNPuwzcA0CvojLgLri7DSlvSspPt0XlVjikJkHeeqiOmOtwgjR/VyAPINdYDw/fUQCHS0gPJUjIZRjXRsCnNTow5LijvwPjTUjQXn/g/Mj6VUjw6Ziz3j/IJfAlQHAQ3cDbn2CAUGhLSIFw9PDSySK4XJjZ4P8vJ7tjviFVNri5Rykwm1jcQO5/friPrlv3AHj/uLho0Mx5XW7Y9Uh2ANjGRtihUJsbKUiYeyeglHswwRvbVWi34Lh7S+lhbSELbxiqRiWfbMCfGPp/b3DLv06omaF11yOfE7jaaP1I6UdcmOu4isBZMWTwsOQrNzTw60jnn15oxBD3nwZMNuchaPFmCf8S8NElWecJaKDnSvCv83BfOqsAYFloocjEE1UuKBpFYgnInRx55z7w8gw253TnQjCLfxVRDqDqC3XIoRCqX1RYqWVHaL3IrFjOeJE4jfDLBHNY08iOXzzoKMDUyLs46Di40wrnEGcFoL+wLudpOLwwqFljZVV4wxCPyOyYzXhR53AotziLoNAPQ6DNcwF4vI8FeM2PYy0UKM1fdVs/d1gIrVj4CNr/Q193/nwo/VjeMKIo819B6OyQiKBrxwtYvGtWvWoo0IcikIXgWH84oiYo70j6kNGiCnkcYJdYgvigFyQKUNtPWPSHbW92kOX/ZBcjbwbpGbd6YP/4SSic/UOyYdt0RxDERycUkAOQuV9Oc0/5Pt83uGnA1DCdUKZXLhjglziIJZDda0LY6t8pWLWQzFMNkPNrReo88T74hLEPOIWYfsBbMPfYwiFtGIcUS1V/lkn47VCJxwajWfi9oiH4m5ClyM4BfYQOvmMo/Bs71R7LbwsgqIeHGztVhxaoxLidFz7VOqd23SAAjWtkVXspfdsbihC45qE9kOF4Y71R12npC7IZ12CoqLi4GPzYIhYo4K0nZhjf6MIhEKknkNlnTBtyqKWpN44R2Id1Vbc/3TAAjTliNVc4/akYqRmEIqccUIqufN8Kh0RHIojkR2lQhvMwR3l9Wqi28KMYoWtz2I9TOajYOJwHMVCrGNOgtFd8Ozewx8d/aPQ4420GEDWAb4sqiIZHHDi4gLqIhkEGiLk41lCL+KczB6jRzwiY56iqOJ4/M2EEoLkrC7VdvmXg36jTTSK4DPx8mObXN1CHZjh/QHiHri1scS8UfzVw7EwXOVckXeE0Syvg9gTQmNG7cMCQs1KvK8MKwN6wmkIEwMXeIISx+JCE9Ui041/ggnjT0xPXH3DGQyXbSxtBq2pokUCpmNC5a1DjBNp4jKBtmwZ4kYIpK3DHE/MNmLYlRsiwjw7Q1zNueP0gGPjEjzUPWLNBeLyg4Xiaq1F4vMdxeKIQkqD5aIDVIgC2KLnQgpYuhPGiMTY0XHrHddDPr3v4tJEWMx3Q128AwJtPHJBex0SDEXcVgIxHc5Rhxy2VFBVRM1vQ6fj2Sw/PCyZZx3mA3eEupWlPQzt801YEhKZ1MzTrLYTmQyAwy81raK14ufDuoIXw3qCUW36g6DCKhLdo0mIMxzGg3fC86Croo4S0MLjTTDCdw0MDHDCgoFd4o8MFyJXre/D482zUMjCiMwowhVtLEOFY0jDIJyIzeLMmqWf/WCdkKM+g/6sdtk1bCAjS/2OPJm8IawPAjVjdXzGTHCidWPr/PVi9kANY1AjMkL5vUiicYjZCa0JR6Nz4hGD4egnox19BuPyJJYUPUJIIsvjMYNMsE9Ehsw4ot1iwiyaQobNN6L4o7W8l519YySd/WJQXY28g2M748ewz6KT0HASO3Uy6T+jw62zwBw9u+OxMYRkARD3yRad4v1cDH4i8cMOzfc1JqP2JQ7II0PfbHDcfYOgOAHDlMkX4mO97KJp6MBjh6AgYsHjVuDAEtnc0SIJuFNjBsjywwdUPARpLbu9j+IsWa3BhwmlJI/lpkPCWfQibKLwYins2EwVKGHh6bXcYVL9i6zpPYYpBIycwmocuR1i4zt9mbXuAoM9JpDAEupR/6KnAk9jkxIzEmll/Iz5tEusiwMQGX7Ii2ASpTNC1KNjIU/iRsJhFe1U7wj8I2NcgxPQ9YFo9sIK1MFo1dWHWYDVRqPlzRF8F/1QGexjy4NV4F6d2CksYxs8CiPGAoeDvpznEqJYQgNbglbB1EKIxeJ8HGW7g3NCaP37PKsciOLhnIJiAO2+QxdMkXnCYp6juiOng/QTjUL5/WCxcHj/wauCxcIfwmDcKeXfEjeDz2TssB2RbZivOV6hNAhdQ9Rso4WWRYCT2iFqYtPp6mL1HYFpZyl5JLGiPVTN0bpjI4wGYlMjIAAwkvbjMwNFuUZi5mziEhn8aaMLIytDPyB/EuJt5mMWY8sjGeNu4mEhX43WY1JjW0JBvM8i3n3vA5BC9xNQQ2DCAEziPbESahLm4gHBy8KF4qWj8EKIpQhCI50l4310L62TAmHcQmOb9AjdtA2kkq8SfCwo3AYT5yPJIoTFJ8PhY4DDVyNDDZFiDMx6goG99eM4tUAIcWK4kvIJGRM9o4rlFEIDuTcTm4OtMDiSg6KGArwBloLpYlr8CMOxvIjCY6NXg/kI4/xfw9L9A+Nc3aJEBJKMHPaCv6mwRaxs4i1IjFb9V5xAorJNRWJZgcVjSbzgnTET1W3WTK7U/oPbok48OMIT4rjCkCIIotJC+MJ5vZot6vVQjAIcJ0j1+Q84WRPHo3v9aKLdjBHFAD15E/EDR/zMKIMBbzm9fV1ja+OBXXK0YF20wreinIT3nSul1izm9Q28ukMDYjvjOCKJ1FUTEi3xlePp3vEwtPoEHSHvosChH6Mp1TK88pU3VOXMB8T9ApMBDYIiDUHYXd2KYVU8v0MO3E4NaIwUI10TxiAxTQRAfi2HE+YTPP26jHd1FKL4KZ/iNONf44HIVpOgA5nV1pJEBGXotpOIEplg1eOcQaF1Ltw9HbGF7PzkaKsDAQUlJBk9/21Q1XjIVhz0Y6/jl7yPY1OphsNFTN6ZI9iv5bu9B3wHY0k9Cp0ynFOpYqMXuDYCFE1CI5aV7dUEIx4d0fRzPTqdOMyTPAIFEz0gxHZ9fCCuLa9EeAJ8FP7IyZNYZMMwTOM5JDy5J8l2hWLV5KWoRSHitdyyDKQ5UBNcA4xjjdyrZRwEu0Bg41D9ciPLiTD81xMY/VldiljQA14EqR1D3aTB9wAj3A8SlYSPErUiTxMMvRoiAmJSAlojmfWNFb1gtZK0ElnCdBIfE9nCBUmB/EMpGJJtIzwxIfwtQ97i/qKcgz2SXSL2THUDOiBbaBXCEfwbaEmsQeMRxMLDdCOA9D+i1pPg9H6S9mnIuBUoZejl1Y5QTLxtk1SisSQn4xD0VyyQORlIz+mKXPet4eM6YubjboKz5O3DywIdw/nMKcxrHdbjBmJp/Fq9lBLhRaNVieJ+JNji7S3uHGzcKXiXAiniSJLpozITGaOyE1P88hKA6HL1meKefLZi2eKzwpBCVzD1kyoTXLiOYkLNypMEkhoThJL7Iy5ja8JQ3USSG8OW0WsVJ+QHyHdNOqz+bPeSlmFtkw+TduO/BEQtHNiU4NXhrUHxIUTiPrw0kpcitJKuEnSSbfz0k4RDdeOMzf5cnhNNRbcwTeMf7Pi1PUW9/QCcH4OgPFS9ew2+w2+84023MRyTJOO7nEETPyzBElcUIRKKAx/Dl5LLhDOSD5Lv6I+SzB3O1XySxx38k9+938IRE1yxgECc3RudpsOpJA4TIFLHQM+ScFN24uKT/EMSkpCiI+JSkiJCSiGCsTVin/nj4tFjE+L9pHujObz7orKS4LGIo41ih6PYCHEgcCLtffPixbw5E7dEFeTeocmtjk2YouiRdfl1ZSgiapN9fMyFupLoItIcGCOZrM/RQ333okaTD6OjfY+jekK74paTfEhUeVqshx16VYcN8rwJpXaSixN3jVQCZALsw2SNvmyifRx4ydxuKIfx16Tu3F0Si2OjOWt9v/1apKhjghUcUj5peSBcU1KjF32dPcJdiFleBBLjzlH1BPxTrNACUgDYbYM/mUfjDp1w9AsCMBM7fYC82pyOzaBVx7xfYfTUPdUHpeWSFdU4RZ4dz/36ITvpGSz8laHIUlM+heQF3sJQY3CtstQjI/XCfSScUrM9/kPbxHRY86yx3LKxHRNLmG1VbrQd2Mddmm0isWHEO7RoWb5ppaEA4tepcEVoY19tQwPrrBMslPwXEkVDXpzfXFcTrGNVky8TFPii/d9CHCy2/ITjCcKioQP9xXQ8YqFFYgOBePDi+z1Nk6Rjq7UCYkjjzlP2/fD8nS3I4u8SuiOvER8SjUL6I6c8ZtUGI+KQAhMXPDKx4K1/3dwpSmnbvTRRa2LofcbtffwMBbNN7lN5fepAsVLAfRCQeHwmqY6tMy2WWC881ZJw/C5TOfUMopADtO2LtYwj8y3zFNMiqVNPQtpkyN0oElSY7pK+hehlZKPdeVLCf/0ZTRSjmsKzYKj56VySmQhZUsmiqTzdco2SYQtCTJFC/KcTwvz8LQHd+WOSTQx1bCCXLBL86sXTdZC1WVxrElPUkZTfwpfYsvx87adCVY1S43Ej0uJI/G/RsuO4bPzQyv1WGQrjXjBX3ErjFXwK7HSCNHwFWaEDquN33Ti9vVO4vAVpeLw6IlkiNUEArS1cOsxG/LkT9QPbjewTAdX6/Zico1K9EuGSrOPDLR1NaQPUvekCsTWW/CNNmBI7kgKVLPyZUkejVBMj9N20elNE/RlSrlKbFait3GNorXMi80LLAtSppuI/4zXcMswmYsiVsDyjwyiUXvyZo7w8MoE+/KBCJKxnsB7iFQJZ42UY81mZqLJivxNGvaBdWD3kU22ZnrifgTuMwJOtYhRTuXCiHH4tlHUGUtRiZuJjI+YgbELhfcn9TiGJ/V+Ds033Uz+Cqfxx4g9cYhJ7gwiTUhILI+y9XD2FEUdTxrzLIouNhA2fjFXFx5PrInmjmJPbQlKCivwLwoqtOFMXkwkd591OYoSTzmMS3X/NioIoHNDcLrykk0KT1vwZUwst/lOPkyciYZQs/DRNWP2YQ1SStZRBYj3iCsMt/afDrhMEQ24SwML4HNo9GCz6gqDDTUVd/BlY4MIECKRTEMPGgjQAKFLCAvZTsVNY0v39Uy0FfEP9EFPpbF1TFj3/HZljCjzZY/3iN9V2XJOiKyKR4hYi0NKVUwz9kNLrokdJI+OVYiJCp4CiQ1CcQa07RfESAYMJEs48z5zgIi+ccpO7o419CKPBgsRTr0kz42Vlk83FpLos8CPtQk2Q0ehZnUvimpKUwpUAlQDFQzRS8YNr4gTgxfn15egjWkMWrVrjn0URPYSiA2IVE8aTvwEUnc28Ft1hXLG4V3x7vQKBdRJbHWU9OZxZPENUho0N6Kp5o/C5AGH0HWB8wvQj9dTTAiDtLRKCUk4kQlLdEnaAiID8nDoAAp3ivf3AVpJjTYUADkMyBFMTulKXxAgTNhL8/XACaA3S0iYcfVh0A5XdAqlnLXtjRhP6nA78YsKEXcrC52ORksA9FU1V1Q8Q8tIvYoWN6sNTdE5Dqd0cBE6FNPRbYi+lVJxRUiX1WS0dLNQD8BO1E7jF3BOwRVachqjIEo7c0ZNlrU3osGWFnWqcedgBzDbCg7w6+T9Dh3zXLVUl3xUBYdeMPtJDEN9jiXVuUQ1T7RIcLMqNb2z/bImTAcJnrRTi7RIFlf3Z5dymokk9NOME4iuCBBK2reDjhBOikrYjkOKew23iblN2oo/DMOPkEpZcYgK8Yqism5L2xQtT3OJWootSt9UzrZuddUO0E+8TgVKdkoX8VxS5wwjdqwI1TdHMdS0e44dTRR3XA+DjPxMhE6UdPqKsE7UCqmI6fPbVo1KVwkpjXqC+4ytik9BS0w4d5tKE1Nd5sfwR4/wTvhPCE/JTIhMJo+boE0OCE2d5Gr21nS9TjxKpo/ND8wIBkQ08sxRLQgHTjOUCbd9M9SPbU1ntPqNp4wGhn4wBSeiSihLdk1njv1L5o7PCSoHt4rLj/1NI2D1je0PgELmECYCg3EF8eyLnNEST6uVaE8ST2hOHI/mJUFnZk1Wtib3NEIo9CrBmkpqMamzrzOMQyj2EMd8A1gGSgODQ96HUkpsdxqw142FtiNJmrAyTtyKMk0G9QAiD0gBTwGCj0yyT65x44hdskZxuUoPS4FOd485NXJNWg9ySDEI2giWk0FLzoX3iRNL8klkFxNIfDAuBfDzsLJep09Iy0unMs9IX06USs1Jiktf0kpIxEpjD1WyjuTLMYkNy9dViRFJ00h1Tct0yk1m9XB1yk5PiqRNT40zT0+PnRFUCReQ7/E1inW1wI2RSHX2sExtoFRCvOGW956On/Wols6WXomvjmpLWqRfAG+IMUqNtnSJchYLThpMjfMxTukIsU4NirFKTYh3lruBZAqBpWbSkZYVd+pUfpfhlpyGLPBLMXQEiIv5MFmSndSnIuWBT2ErSY+TK06AB3/0//K4kiCXDY0RZ6Y1P6azCVJga0yU9ruAGWbWjlGJuKf+YuCjRQs71qkjDvX4j5gV83cci+2NPQCtoNOSUPWndlOi8Eufi/BjGjIns110eQ6nssbVfWeF1eS12BKYd/T113HSiP+LLExNCvEN+4cZlG7xoM0i0nqVRheWhLp0AFP0Se8P9w+qIVOUmpKGETiJ79CCZY9UXYpcEvCIv/KkCXdhPQuTIiqKhEDOCTHQAwlEAwxIN0yk9qwOg9L7DZhFB2VhjYUJamCnUcLTWwohc1RM91IqisukcLdLo7N2nqeYCJDJFFAEQaF3lteFcHCw20ju8ijnUUXGTVPVepMIEBxOCyYuD29R0cVrC2tIVknIjwOVZY45SRBLUE9UspgKqgwj8AZ0+ecIDnwEiAonSTqMpw2ojqcPqIvxikgOp0uuCo/XndZzC0VVvE7ojWcMdkl6iOcI3pdnStkJywMUjNaH6ueIENdjWuH3TdkDiHfuBPzFMEtUDPYXfMIRxG1z/tZVg8wDVYHRslFMB4lkpb4FeMkk0rzjJAjKw4JLKyGwz1dJLktEx+m21cbCSlSMhM6n9Fn3WdZZ8swNWfWy9b1Me/Z3TW4AeM64zKJM2bQyBbuNwHL3TayJ90yeS/dPZ4tiTBjCGg/ZjQ9IMgG19wN1ElHaD6hKtxfKDpaO3kiXjk9Kl4uTsfyLjAhqDqoPVol8MwDXqgq40m/hYQtSTSuJGE6vTCNLfkqhMbhPr0+4TDJMo0zFiXfx+AtKDcWKZpUaDGNM+E6wAreNTAj9jOjJ6AuaDDnAJUnpptEJ7nEV8GWIE0qbUY/2Ogn0E4NPZM/aDOTMCki3IToIIU4EtKMMsQutFTaQbo001H8xBoHEST9LVY9jC7aWwoj2lr9IBgpJDdWLyklPiTNMNY2kTX0gwIyOl0/EzU6RTxMO/0yTCfSMbaYOT5gyc0+HUPXyh1MAy5FOaku+puKPytXij9zCjbJf8EDIWzJAz3kyPoxUSJpLMw0nUIi2A/Ci4pAVEPAV1jYK/scE5DF1W6PQylTwcUNwzexMDEkujSJgLY4JTl+MCwthcSAAe9TMUBgViMm7CdzwB3aXdrQC7MoQzzOl7M5Et+zKNzRCYn30snY7NsExSIhqD/cMCUoOtkcx5QhLVxlNYILEs4rnaKGk9AsR5MzlDoOL3fLX9JDy6BY557wgbmXrTRUzUzbsC3uBOnIFM5JgajY9jYAKJQ5NCzOiF6BockrkS/K9iQPzaKZ9td+MvbO9ZOd1R44e9PDLJDBsyH73ROM4jhCDKeCQ8tuLGojPS9iUgEz91YnR52XlDOAQdPfa17CNGwqz8MzxmmGJcJCLC6XlS/3R+I1JREuyVTdLI9d1TqAM96nhD6HAtAFBtiB0Z3+SywirhFyyh0zmUUoWqnVlgzRJ75R4C28XjElMC2QLaMr9xlNwsDcxi7bCGXXwDEOKx0vNNFLN2I68jZUOkE+Zd0ECw4078nlNJ07JY5jJUEhYz2R2zU2TN59KwfQFScgN0EqJinxLBUwoCBiJIfaiFLlwyI9T1u5IRU6ajkhJh4+KjpiJwhSaCsxP9JeYis4OIUmaDN/H6A8TiNCyBXQaA+9w2IjVCkOM0skKzm/VvPOYD7zyV1VKz4DjlPVlSBSw6VXgpBh0nHbacTkPT1AKSCV1tgIldFAMG0odtCeHJXTzcJNydLCVTR71uAgpSPFKfQkIVwcg3LUt1WrJJjKBUtuDfwH8yK8R/PRhiHOkcdELt9mSSFbEizVJ4HPEj8yD+AsBJiSJy7YEDnVNBAvDTCu3UfdoVKuNK7L1TYQLck31T7LUZI2zBmSI6/SClXZJfE57id+0a4cdThdOJnBAoxdN+41MzWOHaIe1dQ5IcEuTD2VTpNdukpd3s4yZkJD05XKQ9rMQtsEVT8HUPbSLBMIhRU5CSD5DjQsq8DdIiEo3S+mK3XOGyddIRs+uSL1Np/SmjCeIt0hIS2DnPXadIW1KirCsAHLzXAtntfgwmvTZsU+wrEa2c6IBd4j9TuaLO6KeSdmID0/PCuJMwHCijqTN2vTNS381j0rDN49IUlRPS2Nk9hQaBMiC9ib7jN4K/SOeBgcUzzUTkwXXKYpVVJbJcuJUF4MH+MtLYWWEOfOSkerKlzZmTzcP+szCJAbPm/A0dir1Lk23C3KzNHYCzHcJrk8WdEgKD0N3CDZJFZWtSC0KtoPGzS0MAQyZjPgyp4xohhbNqfIeSZQIVic7ou1Rg01X8euVvMoATkd38deG0q9xQ04OzmbVDsnWygSIBsp8zFeJyAYktRAGfAZ8lK9NqPZ+TLhODDcUykWMlMg8dpTMb0z1JGbLLnaz0WbNo0/Px4zNVMliTY/zLhLSy8mQ3BOBS4rK03WRtauPd4jySAvSMQidTlbOJYvBt9yQ5Y7s5p51g3eNEbNwTDQozDvzMHd2ZMdMA7NecseTYcDUyILJbM8Q947L1sxOyJNMK2eKTA5Xgo6tFg5VIU7IJHoOnso1SfHR5w96DkpIP0necxokBrVujwI300mv8+FLv0wRTkCOKkhZMzNKyQ0qSrXBKIKkzTZktY2zSl1KJA564eFis0lHVykOc0heiJ0jK0YrgczJ/0lzSaCOgM/zSWaxlE/W9EDOpg2ScxpKW0KqhxKM5+T9EZSG6EeUhBRGMYiIMY7KsI0Kcz4US0g4jWWGYRZd0hzNK0kcylCMNrY2tLyGEQBNSUxHgZArTOm0D2AVSud2BzQG5jFHxAPSiqHLv6f4QJdxBQqnNiDPtTKhjmzLLmT2xZdlkM6dCIZQNwyDs3BL1TYSkVdPh0iYT5MSk9FMRZkKWKMrCPWRoYw/osGU0I0AT7iwsjRk0R11bM4MYqGWkWa8Zzt0Ro+8YGGStgmw9ZpP4srqUvHzn4vdDzGl6o/fjnUxL2YXh6r18MrJSJtOcpZSZ06JxuWbDTKH4c1bTOxJ04+4jR2yjIYRyPlJV2TJAqrIAs32DMxO2JPaRo2MGs3/8wl1bvKWTG50yIoiVlLOFscFRiRyxw3yyxtMcYluCpYQxUBAA28DNrAKs8JLx455SVYXJ09cRVBIZ0/i8CSnKkvHwof16dYHFXjIKbBVovSNAckgogVXMCaeiaZxgkzAzKyyP6EhzMgN8EjXSpTEtMkk84V0GQ2uTrbNM/NZzgxHt0hZ81uzx4uis8yLrUiwjiYXnoHUiheyd0s7jORh6csmyin0mvOfgBJ2fjG+N/bI4/TgUuPz0E0FTS7JAEHo86nLIAcDA8uRZpQwTkmwBwL7ibrMn0pW4QXPhDH7iUzKa3L4YFRC4PfAjYXLIUiB0xuMgNX1C90EictQCxp2YRFJy1png9YbI4tNB4QvhJSNBMu2xTLDAUz5d4lI8bC/lYdKnoGIzmFUuyHhjRDKuYU4BWXMRshswMwOOokZi8eMRMi78ryRDVRMi4qMXtF2ziJLvUosiH1KpvTNVjSIudSTTn4yrI+JtChPxMi6zCTN3Ipsj+aMPI1my4j0vsoDTunDpdOky+VFddSJxGTIT0sSTsjwkkz5txBSQGHLSYeRLYZsz52njnGh9AYy8IivE7XM5dZOcKiPWQGQBUgGcAOjN+NK6TepzpuVzs5KUxTIswiJS9U3GKHxC1yLr0guyS7FAfGl9LnEVSE8c5TNNRDVyK7IWCT+zO9K4dbvTiqPaIpYjKiIBE+R0HyJpbYfS9EMjo00yzZSE0pFls3KtchydaZNtiOeppWzAomfTCFLn0g1TT7Izs7QAA3MVY4otgCJ3nJfARk2vsh/4EkN6WW/SjNN+6AqS0+OEUtdEJFMs02GCgSC/0tkStFLYPE2QArF4QXr0VFL5EzrdT910U9qTwDKUwiTgoDLgcnTCAtNLMoaTyzJQclE9zFOrMiLS5tyi05mCNaPzGc6E+1UEGYKwyHPCza7hS2xkxK4xsLOIzHO9fOMPfK28M9R/wJGJpYOdEmhyQGJ8nSrSy2Oq0itiN+ORwx9z4cn9dF9yBVPlbcddHFzXlKbSep1MxeMRcUP+HIVduLIGgQDjV7PKUyMRfMPw0yrRKA2FbQlhqdmCUcOpFzKSM5MMrdlY/ETIXoTkIyM8WmJ9A0+TM5OP5KktbqTpFL9z0PNnYvoTY129YA/puUPOUOV92lzvNcfomLPMuZ7I9YLuAuKUuDl3hVF822X+EIKMlzLfFXqjeST4A8SyhqPp44HJZ7y4eOgS7dnekDTzCvjKxTsc3iVGohqJDgUr1Xjid33vbGRdwdPycpMSbeNQ4lHTFZJ6M96cVZM2I9cSIVwcY2IIlOPY00YyMOJE4wyyKaKyWFpytsVeUk2TEwKS0wc9B4LJUgTje9KLTOyzKOMcsz5zbjLng6g9rriL/IXTwXOJnfLyxbPwIwUjBi1wDaXTia1+Pcry7H1RclF9P932BPhygSVayL/cfDKLYHx8F1xQksOQy5PXTU2z7cPNs6uT8POdwzZyzzFtsg7jpTQdsy3TgxBwXFHhajTbw85zHdNO4jISJXMyg2niaxi0camzCuAu4vEyMqxZ4lVyGwTKE5siuePJM/Lk4yKZE0qt+eKX0/Ac74JLoBky+bIDs01zx0JZMySSDjJLYVfS3zNJubPTXvLced7ztDML0569ZoGIAVIBS9MWAZIAW9zBAw8zEWODchFjOoI/knXiG9LRYnciDvOd/FNzjvKVM8QdF9OsHSTt/FgXs8i16dLt4wnSC3Kd4qTih9Ovwtuz8u3LckwshNMX0qTTx7Qo1RP9B7PLomecrvKnQ7LJhGTmhSBl19MLYcPj60R7c1CiOFPkwh/4Dj3P036C7LQDM/WJCHAfs4zSJ3Kf0qdzArXpEoHw8TRazH+ykzPwI2dTnrPtmDMyrk3PeQb0oHOTM8vjTLA9YomD5/0MUmbMY2zLMuNsL3KMwq9zwtLIyLgjrFNoQyizR6XGwwADNTJdAKHMz2J49EgSHdyQOdOi4jLkaQWdQFVUnOHCM0NiCfTU6DOu9FLBtiGcANhdQ2367aUV/fKAVdG0P3xeOEPzjF0VMA5CV8WYRGhSO2N2fS7J0lL9vC7C4dkPYlKdExJTdVpTYtX4MrKznOHhHGX1ruDY4xRjzkJYrewFOyHJ8Sbj4U2npA383+JmU3XCNYPnHP3Ml9nC47HNJpD53YFZoZO7MvC8ElMf5N7JXfNEVJJgkaLzPFpR4L2D1fCyqYyXsij1+M0FcyaRKEgK+YcTgD3WpYAT3byhwyzFVaEP6LTjGxI+QmGTM2BslBWcgeCnaRqi5dyQA7gTFCxmo8jR+BK88y3jMcK1tS6NkgJZQwYyE6KsLU3NQMB2ots89qJUwA6jxACOoqtSFBJmMs6i2nP44v3VPlItklYzZANLou2SKOPeczLzXqK9LHCRTOQR2KxcnrXaIoFycZzGiDRSvZIafD7jSAqlw9riUzLK86oh211essviZcOq8+gKXrJ+LP3ya3Sr8yyhgi2kPXPSMXVqGSs4pEzjCKGyu7hWcnTsrqSx4+KiwrJHE1Hsjfzz5NGz9nLhM/Hir1KdHNZ9+XI2hIi8dhPY1cnhyeIjwynjUTIlwnwBSyKv4CmzoRK+/AEU5Q0Vc3byJ5IbIgX8f1P5o12iQ9OTHDKBYYNSsJXzubKN8QbNMqDu89eSZaLaE6DSYX1ZM41k0Lk+hUjU1ROZXDwsrKC8LGZSkz34IGOzkC2VUrst/KOnE9vDkXzCsCajlU04OAHzi2L+gCWAEAHB89ayloT4Qq2ig3IpfbXiAbwR8vXjZTIN4oVJHArMk+WIlfK4LP8EeCOfPJWiWVOkMjL4i9NELZoLZoGo3Q2jpCxNo6uyLeO10eOjX/NDjAnCQAqJ8ubgQ6J0sMOjfMwjok0y78K7s26zlvlGCvj1AAqx5OJJm3NCcmJ59dyiM92U/ZXcCojMMgo7fMEskeC4c6Wsc32loOAt7DLcI/bcPiWunczj7pNJ4rEdJ7JlIvzyj7Ii9ZP8/EOK2beyj/lPs/fTzaTC5W+55i24UmGsO6JDMikSwzIf0iMyaRNfs7moZ3OOScPSMI3yQxdzPNN/00iQKwCsRaIcgDPL47eRnUMn/dkS8zKTzI9y+pMWrU9zKYOQcwzDTCSrM23z7IFvcxmCLb0SLLgKs6Lt9RwEHsOaYr5F7gNaMu+iMDNqtQui1HltyFJcla2GjQUkKLIfdAljN6WHMlLB1kBflQYAKIAWMOrztygFC2+lU9GFCyD1h1jFCj4E4pUZzX9yEwxHfErUOgQ6C2oYZVP1CzDFIfJqAo6TWTysAgutIoxgYt/CtRNOC+LY22KAbEgzURPs6AH1Z9MWE1qdWPKZ3P0CR8lEMudonKT8IJlIWPPjEiINzPIvM4HSgBRyczZlkYlRfLyRR+TgaV8znFgMncKiJ/K19by4SQExchYTmQwFzRJyc22MUAIi0ZKkM23cEkDZgwt84tKD8rx0SXRLExXMzgUpTV0AKrKswtfzv+OzmSG1g+TExL+j6onq06SjYbU8UMM9tgM0uHVweQuVtdxDHAKUstHDBl2XEvFSTlL885Lzt3zbcyQTvrzlQuZd4oECnLHtG5NgC3Dj4AvW4mnS1qPCsvpc0vM2Mh2TmdJ2M52TB51o4iFS3LLhvMo1hP1VEryzrQmqAr7cNlOr3Zz1U6Jk7EbzZzKkdAnDElVWIwwNVO0sDdTsxBKS/Q20aVNLLOlTniJjArwySlQRTQx0kDUuI2wVriJRXapUMDQpjX89N8Vsdb+tXiPwMhqMYBIf88ndAY0wRCC98tQBI41TKUJm7fP0QSIQvfkyISMotbsddgJ5Uo/14SMwvREiaGwxQ2Lt4cPCIqhtLDKYTE0VprLy/NLiJHz0DAkjZH3kNfLjsu2kRXLs/NAp8w2NKSJYvbazdV12s58j9rNhA+rjjrMa4rpz5VkyIZU0HrLGcuI4tGxJNWk17BMJNQxtVVRpNQf9+u0hwxlyTWRECuxtvhJmdJFTlu1WdAjjowIcYmb9nG1vo89TFAoxs2ITVAqRM3uSxXNIkxg8lTTZCNbyaORHkvjhLu0Y5K0innxHU3pEvTJZgDeA7JktyUEI0ovSis9AMgDsmWpEPZPwPN2QMoHXUTQJ2AEN4OyYjEV+fcqLakRLgBPQGAEpqODQDAH9gLWAabASgVMcTrMK8kmzQDI5IgOS/9JVwx+BKvPdbL4Y8ClMbL9wVQs7Yy0gkaKEyHfj+XWp3cTJHZBKgVMoSXNm4yUoevOxMPh53KwG8r1lLR2G81yLXcLJo8bz7bKO445zpyQ4smsKB+PhUoiS0hPdsgwL2opBoSUNTuz1dM0iMoE/XGsjrAvrI5KKzyEtidKLPou8JdgAsopPIQ3zwHl1+fKLb/CKikqL6QDKiyqLi6Uhi6qLaorB0dgAGoplgJqL0gBaitLll8IA3GeSNsHLsojZuJIyg0Ho+JP8WXHpcoPpMxoScx2aEsOcBbKe8gIKd5OE3XRkA8FxcmJ8vmJpiwMA6YqjuPWiVYkwgOYK5qkKC5lMg3P4QojTZ8KlM8DCHhIxYmoLTUUxivo8maQJij4Sa7P34YKy1ATskw7wm7M03YV8991H01qDO7K947uz/nV7suny8xNmmczc97LjFKuisLRI3TMi57OyTOF8WFIU0pVjwkOBCiolcrWP0jTTmeUHc049L9Nj4nhSDNPvssdzqakf0yMz4QujMhXy5nEMHBMyqKLRCwpD5FKJAuXTsWWUUkBzMzL93NaoLtT182OKQ6gQA3zT9FPgcs/RW2kGkykLz3OpCqbdaQrEoyLTGQui09XDYtTUoT9CJUDfczWCNOXkc0ctNDJFgxvMk62YRMy4xkIjg/NS25iv8s3c04P943/AF8SQmCPz3ixSwVtslB2YcoJ1xXmg9WwiEpnwtDJSGtJ3lDwzbPwG5eq9iLNOwvIQa6wxYTBiy/Ivgz5DIlgcUVTyBVLP8nPEuhKN1UsSa+SfPSg09sK7fOlCQfRjkkEj9RI4YpIMx4pNwOsBe4pNoLZo+F3hhVGTLsgyAzkprzIMneEcLDN9NPksmQ2g9PPzyZR9Ez0hOU2RVURdLtOD6XOT0qWj8V4ED/MhlO+KQEqnQJXMIOIcbVYcujNDTTW0lo3Us/zztl3CGbWTdLNI7FTBh4rI/LcLPGKNkw7jfGPVQu6CrLPDZfUdWO3ss7YyPnOwC7js16147Bjj+O29KWJkglGE7M6LevAVow7hGgLVMm319zzPrbaLBqlRFf39r62is4pk1iMRjc88wV3wStb9Pws/hfYiZVO2c/wYxjVPi04i4sPgi6Y0wESiMlkUwGys7IC01tK1U2mNALxhlYC9dXh7tb4jwLxQbSC9otxgvSiKGFR0mVEjD+PBI8hFL2wmsg/0mIrFjDC9hXKi7KWN9gMSdTxL8LwVjXCLC6MPLHe0pVyEigr8RIoWs6dklrKkilayySOFMkRtNrOfLakjKljNjFSKR9IOs9SL2aJB/DJtDuwa7TqKKTUk5Vrs2AucsDrs3rOa7J01C81dXOpL+u34Sxj1huy3U7GjqABow2UiVSPlI0FE5uy/Coy8dLwnYlZ0hku8ijUjTdONk83SFvK4rS5zlvOxNert4EHCi32zARUHUwZELjI8gOIdAzBMEl2S+Lzo4sH8dksC0x2MaAukvYohhORrgVGC5bPF0iOK+12qIIaLz6Mcw9c1Yl0h9N29uwqwMwOCEEtziYHtgwvCC7pkyizzgn+wC4NnjJwiYZUZkuEd2/JgPYn47Iu4S6tyX0LkC3SlMJIxpCQKELJYpHCSuXKMsvyLJbjUC9e474q/iy8DSwMds0xdKVPn44sLP4vAtVMo2wJU4jQNvQplkoODEEqW05BLAEQcPOZLr1wWSsUM84AeM3ZKa0Puc5jTIt0iiqKA4zkZveZKtZmPAq5zGOG5Sq7jzwNn7CjQrwIkAWjYjBDLgAABHKwAAAFUYACLgAABNAfAuABgAXFB+aPV7PjcgoKbUN8CjeysAVaguIC4AECCc9ETUHvcE+xAAf8DjgB97PoBjgG0LAHgSoBIAAGsE+0pbQkohlx/A94BjgBDoqYBte3f7SlsVoH0iPYBD6BIADJj/YHCANpNsSCk4UPsUAFFaMaINRj2AFAAAEAh8CQZc+3z7QPIGIOL7ZiDx0kMwPiDygugADPkxIMv7USCf+1sg+yCDIKAYY5LlQDJiEFyruLfSN4YvILSIHyDAgj8g/mi60vq6RtLmFClSiL5pOMig44BIBxBoLtKxvB7SgPS+0t+0AdLwGCHShEhgjgP7I/tQgknSs2Jp0vRi6/tAoIcgptR50ubSiH920uCOCfs1ILsmGKCkpI5oh59ihMSgkuzcqwD00QcTvJA3W24dXIU3QwcPArA04dDSYsyPcmK68O3kkhDUNJoHT5KvvNqg6CL0LUlSOcicNOGEp+TRTJh8zXjo3Ntor+SxEJ/kqjTzM2BMNvSJBxPI4BSkMPkLfoywMpGMzQAyErkdP7BVBwXwDmKtEXJ85BTl4NQU0H8QSDfS6TsdEucDRmAzB0R1Q+y8EWiTdES2FPPssLlyeXeoJ8LR3NDM+/TiJ2fstGtyJw/0gW9JgjMKLv8IrVV8lVZi4CTpVogHZgVEV18+syLpMrR25Q80sOKe5XY5WPDSQslE0mCp0kQc8N8qQpEo/OLWtkwckXFsHLRoPBz1ApjCgpcftI7hZoALgBKgUQwGnJ0nczCPDXvfOQ9fEswtIRiGzMIcwEA8bWAAZaxqczzxQBsWAJ4ipgN7FI8xS7cvzINee6QLtKc8c6SGDMgAYUJnwBWQfocc5L9CzzsfMuSIxkNU/Krk0LKbQsc8kO92pWiyg+9hihXQAMT/RK+QlISTeVIJZ2iNMFWATFtNXIQzHjLywX3mGQAtIG0AJWBj4GxgB5iJOCXwZ6h8QE6y9IAQ0pwANwBBNy6uQGSS4smEivytDOJzRqZGPL/QnsT1gvGUyILVsiSpQ3SgFA3UliyWdhDs8yiuZzYTBYC2rNFCrdtThG7vMt99nhi1GmVPkqpZZKofEoHAqvNWmMIhKcyY7WyqLyzpAJiyEGybOwx/DLDNf0PYpk03zVvMvwg0xOgNclD2LJCMqak2x1ew8M9mNXbi7wMs2KIsmp44cs3lSttvC3JARwzKQLfPIXdd8lP88QyB3Qmi7ZVOLMNCygzjPKpmcMS4ss844Sz53TSI9BKI7W48+YdYXSwSzFUt4gx0keyGcvAEpnK400X0beALgCKTCeYyAHx0xNM46BkLKYzsOKUC6LzYyV3C4ZLltHHgzj9fbXPC1nTsvMefD+NwQ0yIXOiDBLuMv6jxgEXwIBz0+Glw7PhuuyR/XqLkfxuS/SsjcuB46GhqZ0gY6yRXzQaYvFgjRM/FKvkMZPGC1vN01KwQk2yj0DWivacLbKG8jZzJEqiE/bjpkuoSrGy61MHEJzKXMpFci6Lb1yuixg8dcpTHXlLNm3zMuVyDICXhZ6LiAqYk1VzDvP5oprLgNzay87y+0NpdeolaUVSPM5jP0ouYvwKk9Mpi/9KwywWyuSSaoIIc2SSyWMFM+ySKWKgyqvTigpr0vcd87IQyyoLv5O4fX+TQAlzy14TkXGLyzNz5oybcojMd/PJ9LnKblKayuBTAIvIy1SLKMsFgdu5PJOi2VeDBNwFS1OjbJPM3Ehw1rJqPefLu3PdM6UEMOh1fdTTMty007CdxfJvsuPiPYtwogTLH7PykuXzasz9i7c4A4vAcFUzmvSqkq1iuottmDVgpnK18mYtAEBpDaOLq+NzMlzTkCj22LTC/NOPcpiMKQv0w4zLQtPb4guL7fL5CzfiOo0jqKyiDpN5NaTzfTXfcwD9tpk8ym3UwUvHiqsSlPKMS/TjMsLLvNkR+4tf/DTIsIGYMn4tU5MRTCnV2jl6U/ZCkGMtEthpiCvvQixdYGLelEV1S/MoK5CLsxQYaQdhPFM3YoEzpdVkcr+k8LIrZGPx1emjrHtiSGMRTJpiE2Vjk7yprJGzYqoysCopQ2xzPHMDg9LEq61FkkyNJhzSozcy/3UCXLGlVtP2E3KinhA1wgHZcPPBLcC1/tPw1LKMbIt0SzKjf2S1CKTzDF07INKMP2KM4xAKOPImBU4N0wvmkY1VU0BkyH8ybeOCKvDzUGII84dN0GykIXxcCUq/wRcz2mSyBHyZulJBy2izLsoJuZIza7xxk8bSPEQ4EgflSFzOHazCtcMEM0IM1KAjs0IqwpIBkkuCKPNUnboDsiPKOXozZwtwy5Yzi1KGM6aD8MqkE/UtEAAmMxULoAuJ0hB8TLOQffDiwPmWo82S//Jwrfoqmc3noOXK3nIVy1hLdjLejcFThkUhUzihxUtcreQN2OJ+jUQzvkKIlQKzYtgAypEVKdKgil308QSe5JTsBgIUS/cMkY1JUs5TpNLUddKyL00OI6KjBW10S89s7NSM7C4iB/SQi6ccTEss7LwNx/R+yyf1oGyWUxzsBLPgbexLXO0cSqaUPHSiUnfTASIfM2C9vdjOCmiLK2X4ClFCOMymVaEi0LzRWZt1cgx4i68MRj1obTiLJ/O4in81Eu35Y/iLcvyM+fL90u01jQkjxIqMAQEDlrNJImSKV8ruVDfcKuI9Umki3yzpIijLW7OKS/a5NxnuM8YM9IvOSmYNZLwkvT4zpgwWFJt4lSpHi0IMswB+zG0zOQ2LkxaKV2neCqDlRkuWdK4UvItmK7S9TGI8irErBkvMvMnSlAvdwrFKVApxSgKK9Ar7kj2zPhUEvVZLbuPcvDZLzrPeoy6yTNEaC8gKHSOuuXSLKkq3Rf/L44WlvPqLlkVE5eXCo5N+4aqirdJRhXdD6okdy9e8kunoEyecx1x0KsLo+US6SrrzwH38YpAKFit1hZFKQip9VUsr24SzI8YrpjLp/a9TsbNbk20RED0pzEhVUSsJSpcBDov4Ky5T3kGbCxLyvlLEEvDgyexpS3oRPBJ/dTSghrKXqNMrhigTxIQrrXMvTdQrWZU0KlQrtCtotAbkiJTZS5w8gov7klbzlTVuiznt7oq5/WUMSkuEAEVL2UrFSq3JFktGRPcqZUrl7eVKlezwkWyDHwOkgvXtiOAN7I3tZQX9gEABQ+3KIKYBwgGpbLwArEkKAfEBRDG/K8IBD6HToY4AUACiwOaKYIJjSuCDPe297X3t7fFQg4PtQ+39gcPtdMBwg6PtfnwIg+PtE+xIg1PsJ0nIgzPsqIJzS2iC80tawAtKmINL7aUc9yofOaTitxSigJkTS0szuD7cMBBrSiOBq0uEg2tKd0vrSvbAZQSV8hSC9yuUgk9Lp+3PS6yDK0p3koVJZ0uCgwMqB4GEqsKK9+3Mg1dKT+wkq3yCpKt4qvvtd0qAYQSqFKr0q9yCzII7Sj/t1Ku7SzSr/INkqwyCxQX0q6yrddingUdLx0ov4UyqFX2cgeKDhRxKEuwL/dK3ShTAyTKcCydI90VFoy31aTOu85dNbvOJikOcv0tHQn9Kt5JNcqmKgsEuKhLEOjPaKhmKrTNAynUq8SobslvL7iv5KzOyYMu0kqHyygpI0tblEMvaPJNyRYqHyhUz0MsJgZmpzeNSsXHz0qu8SqpyEywVMuBTDTN403TcO7M94ryTveI1uWnydiKZtRYCnqyHsh0y/eK9CsTSlwofDG6DWMu87Wujk/wi3PqqyIuPspDiAQs4yoEK48scKD8SJfMicKXzx3Jfyl+zn9MhgizS+b0ky5Xyf8t/sy/dn92wKMI5wRh4WDtcFMIdYsmD4aGHsjTKOpJ7lcohsi2uSZpDYCrJC4eUDMvN8s9zLfNzitf8bfPQcrgkASEsy3BzUAHwcxbdAhSIc7aYzjMWk9Aqnkrd8veEuDkFkpYptKAOQ+7Dpp2gNO1NrP0sjRcKUFVB4GTF/zMqc3S4ZMh/wB5CEWH6mIkrDdQf8ahz6DNoczABUsokAdLKNSuxqwizAWDxq5K9keKTKq9sv+NJqv5SN2mhyGmqcCrTdGmQ2MD0nJsCyc2UmdGqtHP1JeegsbG8qq/QQvGA3cYAXShT4EqARsu6y5IAoIGGAfrKSyCGykbKxsv6y9zcN4sDXBKV5yrgdDjVh1nRWQ7Chy0Lk4/9WwuqMmdCEHVlrIcCedl29M6RALUcXfrSicyp07EqSWBRyvVUZwJtExy55nKQaLQLIFkIvAOr84Kw9QzVaPXSyRqFeNW9sTu0H+JKou2Db9XksoVBp8svQ2fLPPO6MjbpWcr6MjzdsFIdYK9DBiugAHnLaNxJAfnKeAEFy0AKCBQAYUXLyEs7g24VJcqcZWLyaEtPEhsxViq2Ms8KNiovCv8d5BgpqQTZoPxDs6BiugiIlDPLXxPfMbmxvqOHqwmcrUJDFUyxut3DK9p0A4Vlwvg8AeLNy5ko63k3qheBRaj+7KptMUHHjdvIQTP1K4WxwTNlOaEzJEtvqu0rfGwOc2Ztg/SO4zcry0LdK2PKV6vnqzEzvDz45OVzx5DpszZjbAu2Yq/MA9OHyvyr1apM0CqTC8qSPE6r30tXk8DSIXyuYtW9+bMCCl7zVbJMYwLyuTLSC8BTMGvnEoasr5JcYj1xjzTVii0L2oJDc2Hye8pRYvvKkMoHylDLlq1VqkfLN8JOqqWLhgvgwSfLU6Nzq3TzI3IJwo/KpgszOZ4r5gvFKzJLT2jXy9WLuqofiFaxH5NEa3ez0vSU0m2LGDy2vTwwUJ2diqv9b7IhC/jKoQsEy6kT+6KjM5Il37OiiCgic+NRCy2YiQtuSvUZHji0ZIArYhwE4ZAowCuFEzqTom1TizW89Mu9Y1msTFIrMmmCQaut5WsyNs0B7V6kd5huylksd1xtTEPpv4p4ctVNG4sfC8ayTisZhTzcdd2k9JCS/MOlClLhlCKwgBhzTa1q0gJrPbHNeSrK64tCa20Ql+RKsofjNKOi6GNjomrhK2JrM2F3jGYQj3yJDEO5ZHIn6A3VP+IxzQ1VxijEeSrJcSS2w+lNTNSdM7H0gPKgY2LjnDLEMyZDySsuHeIKswrARa9DCIRHXMTzkis0EyBkyspieNXMEdLxSv8iC6vKOPIiS6u30jSyP4sYNVs9QgKPw28jW6qVQyhKVUPrKtVCe6sI4+DsbqJAi+r5SiJB/DAL1iqwCzYqpzxcsw5LdioL4Tn9ygIysP3zxPxtc+mKHk3CVbWL3IoeagPLpyNzclLB83OPPfUzRgCLcp8jFHXnCt4rLSrBavYiRyvIcl9D74qBbUTTggTVrPTjRCuH9OYSzsNBRIRMzsX3vCzj5XTRo9hN8mrWnLMUdoj7KxRzerJoDbltdF0fi8CzPqUBpAlyKZOGsy+jjmDXfOIj53R2nMgDgtXE01OCZqoz1U4SarIGK1so5NSt06nLbiiSld9BUu1ZK0lsWdGSSrdwtHAUfJfdHVKq/PkqM7M1XbJKxG0Uiti883nDo4RqzWslK1qKtIrCLYrgo7lQKaFzDQPmFPMIB/zivZywEXObjTRswjijiq5KNCMYTGLcpGIha3qkOAsAVepIFou3U57QGpJskxbjOQNSU6OqH0LsJPcL8S0247xTwD1W4i+SYTJ/g3yKnSv3eB3TRUv0CiVLYQ0k8P1BaeOQ2Ny8n419KjpEtksdIob1NcstQxp88YmoCh1rZRCJA/GAq2kYC0ZzHWqq85pL1QHhxL6zRT1GayhsoO2AZJaqXrVJQ5QtFVJ84Pmr5GJWKzrz6jTmKksr/WrjjBALY6pMHJLzbSxrKh5TqiLMs5uT2r3DGKFK3kKQAt+qgEPzaq8qS1gba2njk8rNI+VydvJnq33Ss8pYk2yDU3Kxirk4AcCCvN/ZUrHLgFI8Y9LLyvBDfAqZM/wKbmI6EhusfOKnIyIySlQdczyyKipTazcdm2S6CgXxxADgAf2B+gGYQOBwcqsDcqHzeYtKC0DDiqpoa0qrxEOTclvSMW3Qyz+zQPOx8u2wQWrHIpusCcOhaqli/sHha6BrjTNVit8imWM3ymVtHTIIM50yhqqZ8kjrs3NIM6qMPdhg66hpfEPNi36o/gsQogglXTLAgDZBtADCkYNQ0VA4JPtIekwkwXglH2jsHJ7oTrE0awiddqqDpD/I9Gr6FcTKi3koo7Id6JyYsDdznNNM63GDNMr+sHijiYNca2GxeLA8aq3yaQu8axMYD6R3WLZS1ZJSYl8TnCR5vE3JrYsboxCc77lYw4XyCRJ1bTIB9wHfrWJCiRJF8tjDtWK7ox/LpfL2qkTLnjw/y1hw2aKkyrCMZMrDUt1CODzdgHEKHqrK0d8xDfMTii9FhIlrgevjjfK9Y/qTOwSC0gGqJt2QKnYtQaqU6oNoIapIyazKMGv8ysVBpmGJLOwAhED1gUQB2CAwQBuAEtId82GJ4uPP8qcSAcvhylMgOT19WQ8R9+OcWFbiobV/w+7Lw7xTU5eKk6tlzSacXjX7IOgrZYKZqplBFsEggCiAX5WXAMfCgp1qtcbr0nPqAtx5qUIgSzU8sypTEZYS42rjElbqh7zW62VqIBhu3LbqBANH6ZoroMElqx70QniHDZKy8pkndabK9RKgE0M1MUKnQQ2CR4IQ7S6ddfSiyjN8hVwiMnVUJYP7pO/z92uSdbhj0/OsPQaZyRGcWLvySUIrtXBlvmhKKrRiZ70uyb9zGTR4YiqNYsXH5cazBQqyuVPRSlIOkymT071I+TCyKjJ0maD1VslF9FNh6XKWEvsTOQJjElATZh2k9KC9rxPEIrgT0iJ0cIQCT+XqSYpzqvm+a7oq86JyEW+KNLmXC25SVYkWwPrr4alrK7lyJcqmKytS3c17giyze6rCYk8KmdI4FEFS2EqHUuKKFxWnsLGC3uIoC7XLCgBd69er0Q26i11rGKN3qztrw1K6zPNBqvA1Kwadv3H+yst0XDKKMjTEuFwyFWFLY0OhUqdCqtTLU3LCPmlCE9KRtdJmatPrA8qTXPaLaBXN0rsq6Upx+Qw8gLKHKolKpvPcitd8mBNB6uVL+Wg0Sjzq9s0xGYYckKA8/HPBkC02yxJro+oaxCIqQclhaUcKb1MCilEyC2p45D3qMiETy7w9vRmfjNK1hUui6xbygHnFS09qAKyxgzyCKRAkq6wR7ypvAx8r/IOfK/SDXyrIQd8qBtG0LP6BQgkWOcCqg0q97DoB/YC4AdiQE+0Xwf8qvyoYAMEhYKtd7eCr4IMQgwCrkKv97EABA+zQqzCCI+yj7PCDcKsIggiq44qIq9PsKIKz7Y/AaILog/NKi+xoqliDnerH60DIyus1cKtduhKMAVircyHhPHtLuKvEgiyq+Ko37RAbiQFToIgalILMgsSr1IOcqjdLzKt7SggbB+yIGkEJSBuUqldLLIKoG8/saBpnSugbZIIYG3TBSBo8g4yr10vYGziraBu0q/irGBtH64gbg1OX6iKCe1LHS6KDZUovS8mg3Kpy8m9KiTOnkjnjvjGQQMQBueKC6l9L8b3S6wmKDXJ8CyKqa8OiqqF9q8qA6ih9sEVZ650McGu9QlnqodmyCs8xpGtyqzvKKGrgy/mKY3LI0xfCOj3Kq88ctBuWQJhqnXEJgT6raqq9o51xPkQV6/wzK6oHGZQADesd4qCF/E00HZfKM7IPAXrr2qHhqcfTh5xQiAwbIhusGxwbvq1SGvXqMhs2QQEK1W0QnM3s1NKd4D2B2Lxi64dzxkwfyrRqn8vDMmXzfYoOqt+y7W3vSAwbg4u7/UOLXqu/nJOl9WHCOGtZnWNxC0DJyFI6IZUsXqr3cypCJhtKfZxqizKosfiiauvgMurqV/wa6tE9jeXMyi7pWusoBdrqCHPyyrrqLgB66/XqBuqG620xeQu3/TMUTpyBlMRi/gUbU23BvagkMrlh7ANzUznzzCvtCwTMlsoMPUGTomE0YrFqccyACPbqVkMc2HgA7AGO6rq8zupukvN9Z+juGoz0Hhu8qJ4bx2sWaijUyLmJanHqCbnYMmd8s+rPmT5Y4wqsJCWrZOJy/e28yVMzxCHqNDOCIwBswuicEdNj4WhkomlCBGRqXaFDdrUgsn91f32VUmGEW/J/Q1G1BWIoxY+98ZLKBUJcQ6o+Jbylq2VQ8hbIztJ19MUtU+pxDPvz4u1cwy9jjzOqKjz8nvWsuRgMpdQXi7BiiFWO0p9yD2rbEsx4MDhuzaRVw3WWU/m1CAI05ZS9X0KjQtRykaLsYUHKvCttwYRUThpKG+zpO8Ex3SQqg9Sjgvnd2snP4yYFkgpCywj5+XVgtJYCY7Vc87coohrxKpXqpwrg4nBLPVSuo8TFNesS2bXqhctMJdIb+uqiAo3r26pN6nlyLqPNKyyk+6tPC23qWdLvA+p8q2oMRP1Al8B2OZXK3etNNNjlKxrlKr8hBhqVBBHF33kXUsxEmxuFqNANTcpcEikbtmUaxaWgmUnfiC+rw2rL0ClymHw/gl+D2XNYfJ+CKf0PUnPrjqPFyi5rnSvOi5EzRQOH6+miKxr/wC9r590280OF2zSsC29r9vI4tbPL70oCG7njKhr0Gp+Jchv1csKq15JMG/sjN5PMGwDqU9Pl6/IahYijsqwaHBvfGy+SMkTQ682rvry7yuP44fIqCwuzEfKb0lHzUMriGwIb0fNJiKPTQhqwypjTj1AiGq8MIxpEjGIafjFEMDcKTz0SGs88vxx9U2SLuh2KG9Mb18tCTc0zXKGvGvI9UJpsGiVi/XMImtMbMhtWq8obbYoYkBdS26PUakRTIQq0672LYQt0at/Lw6SOq2HpRbO/ykxrEHiXc+RTc+FFqb658usBPaKAxkRK6luV1ZH0geYavqrTiuAqz9HcalvjOkOQMtByzMtYeFnocHLa6qGqbMpYKwMLcsQAALUFuPYAYAAxAWgBH0wri0br1aUwuWPq9KPIrYekrLgBLFUbsV3GBWD995Ntq5BkJayAYpfiUsFlScEbxAlO687rriVqtdnyZvIxclj83JpCCjyakcoFqqoqEe30TKzRoAKjGwHrarWB6kkagmLJGshq4gRnTfj1pupUmQWTfF0gGNfkACEyK8IKaCoI7Vxd4pv3LQwqFmASagm4OnnuComqCZOGMhjVc9LmKCASULPdC2pr3OoyYNYTUdzGJImSMFgEIj4dXmMHWaUboPTEcznq+32v86vUXQr0qKdiU4JNZFZUegi9AuRjQugp1Jz9b1kinXwU1qWeyLN8gkuRVSG0y4qrE29iRshWk9ngxS2nvMGzcZORQ9ASmYw1s1bLI+trba7dC/M2KQnNx23Vgtplc6rDGjKyc3Ko6/ZT5qK2rLZq1ep2alRLtiMo6kVs8dMbqzQAaOs3amAKzmqpwpcb5jNoSs8SbmuI4u5rA2vhm48LAmULGuP0eiIxncgKyxqO+XX5gEzBcmjKy+zibYBN/ZL7/Wy53SMPkZwTO1w7a5tqlbPbXR5KZaVSm0uZopucmuKaIv0+mxG19R0mdFB1PctNHfryfcsG8gUpJGL1020ddouDyibyDouJS/j1K81jGNZh7v1XG9ITOUpoPCPgn1OEraiSekq/wyKLZBpva9yrVBvva+wKA9Kfa7582yPLSy8bq6GigFeSiYrvGivL/2qry58aggrc8zhEmzgOlCDrgOvWVf2aLcCTszfxT4AIQYxAiMAZoEhqzaKKCnmKSgoKq7DqJZVw6ijTHhPoa6z07ZpZfcQceZkXqwliCW3jROGasiOo645qiMrm4ejr2qtvws2FqMsOS70ENIhlnEGabMJ/fUOb17NNcDhrWfNhEvWKoKMk6lVt2FNtinSB4TzjlcLrahqZvJfKuICYQFIAAI3qGskT4uqaGxLrhMpb/UTLEQujMqmaMuvxrLLr2xuwKJrc/537je1i+s3eoMVo/ZPYoupDQMgPmqYJdMuLM7W9jFM0mg+jKzJc6kSFthsQsXYa5SCMmjrrDhvNQTUpABK4KZ3JK4uOpexjlCHBHKYSXgvSDLb0ta24K2TVxxNyyqadSctpk3LURevGtWLLxWr+UqODnuqC8g4KXCUurSKAB5t1vOyjkspCmiEbwpv67XYl2ypc7cu8EWCH8PzhafSQGSuYT4sgWxFCTJH/ml+kugXayKrKeE2e6muj2U3bE1Bb1T0JGmjIcpob626j8pvI8vwoNGOBaKdp6LLLxAcKfso92ZoitYK/m6qzPmF29TOiuGQsAkqkRrJj6/0bzgOAWpnM/KNeHYIFuFuiwqwFLSA1kkJ4+yqqoxEqyFs+YCeKlGOd8v/iqbVDZLnd0sSkXa0zTGMR3dF0SaqHEuXNHT2cLAr5IBkzvPlTb73hyabChLN5XZwr2dwA8TTFRqTKKgaFHurkaWnL4QSj8tjT1GQOU55dL9Shm7S0WExwOZMbEZs6aBXsxAGcCQ5wHSsi8jJYqEpVm7ur3lM6cp5rS00Vyksbqxopm/7BiVNra72Taxp8ARpa+nM3mxXdq4CeuQiNKvJa7bebLGpZYn4twUMV6NACPpo/6drJAFqQAsNrukuWcMcbIABPUycaFZvHG5+C5xoUCuJ88+oIk/yKVxsH6tcbF+oaW6ABtxsrI99T08stmxa9rZq8qjQbSTL/UlrLC8OwWp2bXKFXmwwbbxsQasXjHvN/S2Kqa8owK37g+7wD2RG1hmutg+SSMGqAUH5aHCuri67gAWKyq5gwXBvQ66ZdE5soa+DLqGtAmqoL05oI65atrlrTc/o9HltYa8o50VJiG3FTsJumPHjSS3Pww9uyx9OjojfKequE0mETTNwsQrjqDYsZo48Cx6uBWzRydikcKhEQFup58t0z5GoC622LAzDu6cAifTNBrEWQahsi6laCZEAGADtUout00w+dp5rwnQzSEuu06m1tkuvQI1LqjfHaLUiibNI3m4b8FhQ1WHFkKwFGGgrrkWXKISYtLOv6GypC+/BJnC+alhqlE3eis4sQKnOKTMvvmrYa9Jufm0hB9hphq9mM4auwKiPo72JG6pGquYLlzbmq8BPzvPizkbSBSpPyqczGeJEbQAPR7fjEIFtkC6gCu+oaiATzCwNpajICUjMP84BttR2BGxQjYGCO6sKaRxAim1gygy0aXaZh5SlTEscCAdnmQgMZo1tIAzw0hu13Y8TFIVkTW8nL8craInnqmsPTWmcrzhOzWxZwspplKIabBYJhm6DVMnwKmxucWox+WK9VJrS13TaLQEqKwq08nHKZzObw9gozq9KpwPyYVV6kAAv9zYWb7ELSmxkafdjRlZnddhyNC/3AG1sDG5zhdFv5qvAsUox0tX9jD/LqvWGSoyD7pelLk4NFzShJL/NJk2lzZAshtaxaMwosMkW1ZAoTCgDwaerc1BQ9VF0HxfRRd0LVUiWSD5SBmi2qy4PN9aMbxuwsNBDi7YQVIwLyiEqI/T55m+xFgRpMUZpzI/CSTS3RmlZ9cxvR46pzHmvS8zAKXo1eat6jBcMus6ex27GrGkMqjvgY2hsbDcp1WjuM/0lvZN6zOyTCOBVpVtjwDKd8lwTPW0IYkGT+w7yaOFs5auTjfVuHGmZb1ti105GycRt108sruytJSmUblNr243PrlZv2igvq1ZqL6mlqiYVO0Ans9NvX1aklrsMHYGKatpXaI6lLZgPg22zc7gPwXE9bymBE2rIqgONYzIjdpvxegud1GfV+JFKM7EO1slcqkULf83NrzypPavWaS1gY28fqE8IzcFOi+1PRoN2QFXPX62fq82rDpBfrwtpY2jiQV+qsg9fqFewVSzfrMJFYkr5zl5B36k1KgGDNSjTAuAH97C1L/ys0LQ7tQSDSIaiAo+yXwK3tEMi4APSBrUo0wF3tq/Ff6xCqkIM/61Cr0IPQqzCrsIIAG/CDgBuIg0AayIIz7SiDs+29gXNL6ILgGkvsWIKTFCJtT5uRZG1DJ4Xc0k2BMBryfJvsaBtwGy/tOBtEG+/sARi6IbftItrW2xDJsrX7gKeAdLDIG8ftVIPEqhQbJKuEGo7aXyqAHU7ajexhIC7baiSu21Ih2Qju25gaCYFUqwQazAE3Sy5aNsEsq3SqVtq+2mHaK+1GsHtSenJ0LQyqX+0XwN/tO0rYGsHaOBuVqqHaBKph2lyCftoR267aAdqLgGQa4aEcqydL98tWsK9KCTOAa29K0Yoh2rfAOJO54vlb2bJMwMqsr4FVMAgcf2t7I+8aN5LMGpX8LBpfGq0sxyqd8kZqnQuBHLK4M+UBWsP1Rdrbi5M9FRuvWroY4Ou6HaoAEAHbyyABlUoQAZOh4hvjmjDq4Vo8G+Fte8qRW/vKqLFRihrKPtGZ2oIa9vHVW8fLKohBa3fKyWMB0ByS7yI5eNqriVrd4gibj9RrmomcaJPY6sIyGfMy2a6CopOhmz4LRTWerTnb1erisS4Ls5OVTA4QPBNDjYGoM7K12nXbShsYmhCdgQvYkP+rfTOHm0Vbh9PFWyeaMpPYmm/SECIVW7ibWhrhC9oaEQoEmzYB1ZHe1TVa+hpmGn7t0WWSyN4zfyHRg/eas9uxIGW8HGp7ld2Y6yStWvlRYDNtW2rrs4sBqx1aUDMKHUeaXVu2LAya9htfmg4apovsyn/dUFl3hDmCHJq0uJ6bietZG9tam5tBWv5aSDks42/i+Ru/vORpeDKu0h1hYvVwRRT43pPcKis97h1DWmBLr7xlLUkgXBp0gLPavApi8YBiUuHwWgtaoRvZqmEaPHS38oua9GJYKvFrfvIBLVqMGgQcWhWrCQ0v2la5r9o0nN5LcRuFLeV1H9r0cuW0X0z7WokasSJB63Zr3KXB6sdbOgJPEKBYP1ocLOIqG71GKbya6718U76bjsteHTX1odNJlOFTJ2r4K75E/Bi4xKpc3FlTqIQDFhBCFTM8vMvTQ0wDnOAZ4LBlwAJXQZfEqDuDNO0LTEq/WxwsIUo6yNlbqstOhdMqlilYchQCqYVJKsKk/OIA7WvzQ2QMpW/aUixy/GA6kFu53DpV20Bfo7qU7qLF23Spc4IkyTBjG/JwsulqnRCTglfyMhjR6hHIi4J0K2Oz/pRUO9EbEw2tqkTZn/J74uvLJwsXEwkc0lrE4sRKZstOAgbD0UrKInJb/NjyW4hRq3Ai8ykFFBJeU6XKA8sqWyjbnmuo2oerAXNOW//hSOVRAs64mNspW4iRueyr7Njar9z6dFgL3jL1ytMoHVwMbGOEeSLJNDUqpxyNPQA7MGoPhPUqRxrgqOZaFltWWzCShjq/gtZbohKzas3SsbKPat2yY8vXGmUQqjoxMWnjITyLXKk4I5GrgQBqPKpAau9LlatMkiuzAE2PZNnbKNjm4hh9QNIQa8vKINMV/KDTvZqccO5jxsqi0eE9eWJ6OgM1TcN7w4DLCpqyuLfzXjqSan8bnxmUACWAHAErCZQiuACmADZA3GJEa6qhwWOk6qFiNYgVY8kaAJvcG2vTPBuN2wWKZTJRWvwbrPT2OrGLzJIVGMIarJId28KStxOd2ilii1thapySXJLJ8lIaITqj/ClbNYsIjPqrO5sD2zJNp5zr2ikIE9ukOvtUkmqtivnyo+MpvMFRvTMdi3LMr8pbRaoaIurMysP8C9slWhm9Z+u00kkTcJy2qty0y9uXOHiaRFKNY8zSDGpyAVk7TqpEmrSErOvNyn2NYxTu6UHi95tUUg+bBvTak01am9vdfd6hRgnXo4ByNb0WGofabVo0mi3z6uvlElArdJv2LfSarMoX2j1aUSvndZfaLCO/cNfa/VquG2FTowr8Wq0FQcJMvDrDYIokeFg70sgkOhXbGDXp1RA6TpM+YatjTgJOw91ktKLQO1oc8xJp3ZSSo7wzsnUN+Tve6b/bKnDBGghbC1pFIwds9RtAtW+l8AuY1XRiYcKSUmTJNKM4M3qlplGX+bn0EFTxKsaaSsvv2oIr0DswExQ7Lsg4yKu8EOH7WolV6xTwO4dan2CEW82iFLNiwoPBJDplTCTasPO0aclq6avL1e6biFqp3dLpABW6yNoc54qeWKJrrJDm8hUaVsn203bTIZVcYX6TcctupFaQR+I1CAw7D1pXvHCy3Ns1Gvp4/3R/wBpSUBMoSD0asxQ/6Nc7JduQEjdVTelwOT9aENuUch1gQlppzMoct/NL2L75G1oLvZbKFDLnHBIr/ap3OmHMEDprCrMVb9oByD61WPxl6Q+kE6oQEgu8QsUTrTkbruF0czASNpLxLL7KOUN4s2Edqo07CgErN1MNG0d84Ns32mC75FSQ2rDtIjqWotDbYjo0GBGbDmoIy/cAY/IKWtI7dZwyO1pzt2op0i3qzzALGm3qSZrt6mjbYotVy7ZKdLF1+J8iaZtrmmDddLoYkP8SQHQDhJOkmtwPFX8gRnPPZcy7ORPl5BijWxqVC4GbfiMPVdk7I7LDApZy7bF3U9+CVlrGOkY6ZxoPU/y7NNoXGx0qpjobKmY7W1L27YKL4+GMuqTgfbNu445aDxqKOusFShIfa/yCsTvtmpClsrWRC9nbnK1OO0vKP0t/avnbK8rNc57ySnDuOh5iHjoO5HPTsES+On4kfjrIzOwa3vTqul46GroA2VmLYEn+OwE6GAGBO0E7xAAMBFwbpWOhOuVjYTrJw+E7CcMAmjVFk5pvxE3baGvxUwfK6aUyu7ObSYi1O7FaiWIW40I7tLKWIlBDWqppYo0yVYtJW0hqshrIm2JIuio7mmlbOOv1io6DuWL6q9y7Giq1LHfSXEJCzEPaot2Ao3fTWFN58k/Kwf3nwNxMnYuFO0/SoSDFO22kx5slOqeagzMSQzTqjX0VW5CNlVoz4jU6gCiM66TLG9ogK37i8fBZmiI4KwCr4sYaVb1RAzCrphtRu6f9UqxCCQfaw5lJgrfS96Jvm0xS75sn23Ytp9q9O11akAHdWvwoTJp+sywiqowIRf4yw2KNK9adEFpJjAaqKlNcW+ehf5rvfSZrujoO0nnVVpyjCxbSjhC3WsprgwtYWxFN2FvFG+QiMFt/HX67SZ00BCs7YcF/2k7qazo6On7rnlmoVdeo38B7CirKwPQFulu8hbqek8clz31SUG+iwv2g9fHchejluy+oFbrzOvm7PmG9Gm1xpzrLFQdae8NJG0dbhFuvFN9DyRi5GqBoHbvmKTghTppio9UKWmpxm/5YVbpzU9cdxCG7vTVMfzPGKbM66LKY/bFyBbV3xKFN4bJ0ISFZYitau8oAfHJLPKnNF4om6zc6bisItcQDvDWcWDlaZZoIs45CINrg/DAsdlI66pvLtLOV68DlkJvSWq8NjVW11GIaUxqrq/aAv/ymMzMbxTQ7q6gUcxpmKsjb8xqt6oma1LtecjS6Cjr2M3AL79QHssk8Hcu2lN1yHeu0umg9CYKaWmsb61zhITUYDcqR6VogQJM6IEOSmAobaa+7akp5EnsbUyJ6CLwjb+hA6hZyFv1JcknFBjsCu09Sj1IaI0Y6z1Ifq7NDtNvz66Y6CbN27aKsdypFsdIgkdUOW27jr2s2Oq2bkfJtm3Y6rdr8q4shNbo2TA+QsVUMGzAA5EIZRcKqCoIfGgXbrjr/Sywa3ALoQnw6cLvExHhqmrsXefzbr2KUM+h6BTOw04yUgSnigIlB9oHQQeTYNdphW8hrYMqROo3bEVtROouz0TuMkpa7MHvqCnpJ8HqaC21FWivYYibrHENW4RYdqM0u5T7A2EN/VThCoIHZIPE61A2skojNHdu2u8lid8FJOiTj3dspOwpKvdvBE5YK2ovpO/3b6fME81ua6krmWvCZd1oRteMMcP2eupaLlospcjxDruroew3Yo+Q4yr67uVo9M7Y5GjqHmkVbwbuL24MyobqT45oaYQor23iaq9v1mGvboXALgC9cVSgb20xqxJusErslHUNJZZTLTTvII7kBnWN720YsTLD/IO07XyD0UlxrL5vJuhAqWCJC0907Gus9OonVvTshqhUg35qX2ndif7yDO9fb/VrAobfaVdgg1L2Cv1vTqZvqyrOW01TaU+pKmpGi0CyyWijVaRr2eKfjhqIZqyPyf9qrOv/ai1sDEMZ7sxQme6MK4jumejs6giJC4TPqGjNqGJILSeLCMtZ6uVwv4mLjeFrc6/sKBFpAixc69doHW+LYfRsNur+igNqCc5cdSc0cOmADjcOT2a7gyDpzwK+LEzqzkvFzK712mc154s0oAmYRrCM3dFfaslxkOoF6n5lyK526GxKgGNg7HrrNwp1o1jNJ3NwhsZIyUm/yEsNXi/gtUtPSqBX0gLuL8w4dgDzfM4DyZ+SoW8Yo7pMJekfzgwN/c6hbkzr7sybTD4tHHHbD9JgKpf0791vE8nLViGJixThMdDL/ct4CxwpHcJKrENvCOgtFprwHuvI9AANU6TDbQvIF8MbBa4GSOcmj0ju3CpQSlAoSA7I6AVOt6oFSixpqWwraV8O6PTQwr+ApwTCB3UXq6Qo6VBrkrSPhPqoMu33brUK9ei+6zkp1GPjaeotrTdmbXUKKekN6+yQl1RgVbPNLuuGkjPykWjZ7nnvj6++CEb3/uxZaAronG4Y6QrtrKxcbMbIiuqB6sD2iu2B61Rn9exB65XKSuy9KGJOVcuna1BqZs5WrfKpuWpCkm+FcCiDdANKeWmioLjqQax8bTVzN7M1CAqsZmo+DWSgSPMogArAKbdtqCTXGc0b91QHHe5gr4Xqp3ImEt1TxQlz9ZNsLK1cS6PyWM/XN3BhU29EF5isXatMkN2sacx5TsUpzanuTXSu3K90qj2X7egg8jZpfU6UDvSvGEQpMWNkoHRvCA1UzdVNbnFodLAFaG8oHPd96O1v0Yld6nBpWMRABToCswLKINdqde7QBO1E0k7OzJq27yhFb9JOrod8wT9FEQvDrkMtRWwaDKqut2gRxsntI6kGMpA3qq1YyDoLxWlqrXduakKx6CktLcxYLq5vse2mbPwBGq5ty+mq7mxnz6Vtw+qPaGLvGtTZSWy0UG2ib6kEg+r1R1Xx5O5TTbYtoPLhSwutiekG6JTonmqU60allWhU7SaiVO5GsVTqZvNU6OhsonLzwKJ2Emhdz8nvRC7UD1Wna7Z6zGpNji20ixROPmsxqF6JLgdNLKusb4/TKWnr9Ytp62+I6ekG6Z9vjmOfaX5t6exfa7MoGekGkBFxhk97rvLJbpTBdMxX6jJ6kbHiFG2Ni2zvDuo7cXjlLgJyawfQ9rG4pMwG7vFrzjztmUnwsc6xRkjek39vPwN2QBKNwWg7q/THzWvW7/9pfu+F93mLhU7Ur9RtnTH5aHI2W4/a1Yvt4YUts11lnKJL73NpEsqfymUu8UDbKBEqmoX26t1n9u9+95zrB6guEiDpCOn0kHagoQoBaExObutWze+NBtZY07swSxOK5GSuW+/M77JwymM0TDJzA1Iw6Kg0DwmF7ybW/pEHMlOUzrDL6ZFkunY6L1nqq+uksZKWXK7EbmrSg28c7YlvoOy77ULKdaXqiBxoKs4qzyZQYoKdNSjymeVJyHgvnxL6aIiKgOuLU4wKouu3VGTRhdCds9tMJq9d9YfQP215RXhDRGxNT1HOy+EFa3pmQxVJgJHlpXVZrF5Xc84LzklvBmoywyeTUskS7R2riO9AadLKw2qKh+gGSOmS6xcrCu6kFzmvzey5qKlste5e7rXvUu4sa7Xv2SxRt6lpJAQH8F6vde5pb61yF+tjbsyn0+t/dqiHda61ipfq7TPuA5OX7akEqPuoJ9a5k9vS7kl4sCyq9GP+6s3uCupUjgHtfgsbzwHs2W5caB+vPeofq9lsF+qsjy3qvayt6lBs5o2nav1POW4kyitqN4zLjueNE++5b4MBQjeBq3ZpeWloS3lpiq1Bq4qqNipIi5aVytOXivltCDZeUVdqezHXaG4GogX8loVv/Gya7ETvg+5E6xHu8GoWKHEwzm85s0fNkejHyKJwMehajeOoJ+jq6oWsJ8subPBEH0g678Jr/G8RraTpWCn3jcvlToxk6XHs307PQmVptqrI499PT27ecVK1sau115Pp62OeaYbvInOG7xFMyeoXkWGuMa7T7RJt0+iOE63iTpGy4ArFdkA1aTk04ncuB1FPkm12ZFJpM0ciNSbqf1MFQwKMpu1071hvaezYaO6Mfm8UhGbuZusb7x6q9WxstSkSSygr6WarZq0r6Vzt2mTJBcypWkjUbeqR4Y1dcZLMVu7qdPkOoXYJ1upQ+rS89+oj6+kRaOcus0CurtcBz1SH7BCE2EPej6ssN4y/RwGqbekAch/s1q7WqG4F1qvrKJssNqqABhsq0gE2qSAe/DQR7haE1TSDtV/VzK9DTePPiIoM8/T22mMwrAjoymXqiEzp2QrZSzshXY1CasS0/e1dsMlM2FfGreqSC7W77aQkg/Vh6fakq+2h7BVNcYHe6OoQ54Bhjv/uTU686SQEX0LggSQGju0LiMWFE849b/fN9WhzyKl1Nu5AHs8k7QQuB2CFGuVt9/1s1E3lqO/NR6p+9eeECc9LIorDZu/nc5PLGpcP6uwMU+Nd9oLTjs4kQ2XqOnfJr1pM13UNked2zbIpqBuSbulqcbEpS86Q90bgCsuXqeSjLq7wSnWgwGAS7gvQeKuMaWYPgB6/iaoxiG6uq+coFy1zKiQVXCq8AW6tCu4pan6GzGxS72nOUu29RVLq5+1e6efs8VLS6TXUuMkGhMiA+3H17l6q5Sx85G2vFsveq5MuBVWOE1tjUrBVV77rtkKkoZOC6zNbZ+Vs/+4JqPiWjYs4y9gG0B/vMdAZTexHj4Usx4tFKqfukC2TM7dK2i0B6hmKNeuS6GgZWsQvrOVPaIyK7CbNFDPitBgd6B4wK+UrN0SByzSMDMAoSq3u90mt7nfrQei5aSTOr0Rhq/Ktc0nf68YpQiOBqbxs7e4q6PZtiq5kyhdp9mh/6qsnwatWjmrvMW9jzTHshWrcw9xIEe1P7lyPyq+FbM/sQ+8R6wJuqCqR7BoJBBwv7YJrHyr39sMrhvdubAlXSBxnLpau16vhrq/udZRRK8JoWCpjqeZHZBk67K3NpBqNqtrqD2lyrOYsPysRqz7LWq4UQxsx1uQG7c9ri65HQdqvL2pLrF5vmTMTLMCOEwsgKtPpkUlG7oHP0rTRsuvRpMH1qjPqojDTCx5HXcy07CbqQKdWryiHZCaz6YDKb40/67VtaepArL/t5rem6unrv+306WbthqhdaqilGi6SNTvvHshEZDEFKTavA7wDIoukTtQcuGoL7o/oHVdAs5pWDBmeoLsu9Egd8MlLty1oZyLMfOv4bguwRaLqVm0AX46O9wPNSa57cP/ucuuzboNiOhO+LuvoGhVMHclK9vVgDvpUmitjzaevr8qnLEsPDZY7J++t6+nA7GZVXWhAGmcr2AdJQ9QqJDNwA0AawyDAGXfypB/Y7q1WM0XHoOsq6ywgHesv1qkgHBsrIB42rPgANq6gH8QZh+/N9gcley5Op5sMwOsUbt6kSc3jEVGMDAn/iNeuaUCDaprK4OQL9bUwkAxOdmLLIbOOCaWuh+4vlCZN+m4fymp1myywGVstzBiEqtUwl2oVzYxMBGuu7wd0x9P2sajKMTKg7Rh06eFwGqbhtGuLDxiianXUaiXoJhYXd+koIaCiltFsfdSdiYlp5nOJzZ3gGm3KUAXsgSqaKoDq5Co+LcNWaarRarNBkWlkasIchlRlLolt04jK90LTR6t6lJMh7B4I78geZBznLWQff8wuqd7lyB6I6BIcCW8ur86pkSzAASgdrqsoHR7tNyZurBgtzepn7l3HqBjGbzLKxmy3qNjM5+5hKB6pea9e6h5lva8EMPZjtI8o66TvFDcyHhgYk5Q0GI1PeMslkw3o9a7AouvRcRGmdB01DctaYYeBrB+V1swYRESJaqbUAhtXdkDWIZdNq6QNUPY2z40VWis2yZvtLtWdarbItenN78NrrK1n6zfsbK4ya/UOr1P2rrKJEB3QLdSKW89Lawix8AYI5pXNveCia4tv/KSwKfgaVc/0qjxtRiuMcG3pnB59q5wblBiEG3NyMC12ajBpIe41yQ/oRBm46LXJyZDw7p2OwujrImV2/e7kypErUc8hpA1qvB/HCQW23EjOyQ0vDgFKB8aGkNYO6oWymuhbkZrtJpVOaBB2Lsut63fqwB5qHxYpzm8FQyApL+ifKjYq4a6SHhIbnyyUHaOpwmyub9EMYvfkHyVtImwUHOobBjYaG6cS4OcaH23IhO5aGmIDWhtLQyhoz2xRrjVtNxEf6R0TH+lUGF5v4wpebp/vl8mMHcnpV8vUH9fK/IXyxbZiraHhYB3vVvHG7nSir7BFqzPoKeiHVP7IiADHQHQfTi1uBnQdH2+1bx9o2Gj0GAYJv+5zqOIzc+t1afQeRB9+b1SGtPbyHsoac2y098sLvccMHDkF3gI2ZzofqSEW7C8n6uHyHPCqCK8iz6weiYEM8MwbxPLMHqdVeLMDzGapSwd/653rwhxMGCIYG5EMG3NUVh8ZDGwa6Ok7KaisiouWHWJjlGuRp/oZ7B8CA+weAugcHCgfrEkcGURJR4ccH9ainB6jSToY2vB/NIYcrmAgGesr1q8bKBsq7wcgHRsq3BqgGnIY2hjZ8V3rsYQKGAIee4Q8GYPx0IOWqqBNQWFkLR2KCBtndU5OHdYBK/nqeAqEBEeqDAjdp/Iw7C0L6fJTEKPRjB+KAhxO6Dnye+yn6fiIuCx6a/rPSqguGLgDZkwdgqatE2jGrV1poRDOGSg3oW8LKOijcmKHLBGMyy1+iZhDxXNb6burxzUqb2wdZAS6dIXrWJMAH2rIwh6b9s9iyyJOHYOrYcswj4IeTBoiGpmstwloq4AcEhwcG7oY2alnLxIcD3c+GpIYyBvgZIrPqQeSG9gDrqkgAG6oku94gVIcKWu2y1BE0htKHMZqua5oGl7o4FfuqbXsHqpXK+ftMhhcU8Z2bTV3rmNoQKEqGW0xGBrMpTIvRurpaW3iu+f3qd/BCODBHeEFgBQTbw2JGdYJjmmqLGBTyw1t3qQMG5sv49I2GAvrTUyKGloslm/IBvcu7vEkRLbPkC5FLxjqDyyY6ZktDyvTbpAd5XJwQcoZtiewjtZp2W3WangfbkSowKSjKhpVlL2qPK5XFqyOSuj16nZ0OhnY7Gdp8qv2HNfk2vQOHvfsK2VXqnXW52oq7edrhBvqGAOsoe4Xbq7h+hjuKl4cvTCaH0Qcpy3HrbEf7h/lS4/qD0FwagYdWhkgslzqEewkHDdv+vTci9oYdog6GXfs0RlWrmsoxW1l8vofWu0SVGQfpyi+HXYZMZBMsHoYSGgRqkhrNaqk7ePrCAyUGBQc3yiWG57hsRv9b5arcRnj6D8pPNLxG70mkNMGGB/vWqjWqGhvJEriblTtSe1U69OuncpGHF9Nn+nUHEzPRh/8TMQOuq63L5LxNOzdzHqv9mC07wCv1B6f93qvjio/78PuIkWmHVhrH2t07HPqv+kRSWYbzi1z6fTo8+v07H/v9B5/72iKlh2SyOTNqKkDa1DNW4c/boLu1Pd9UY7qDW+IrnVXg1crJiao3Okhzyapmh6d9fTVFqrnN+KRzWi6SUsrLBm3KSo2CSikVbkbB3DgGyrMeR2g7ZGI8K6kUh4ZGhudiPkePQMWr6arscWAGQ7ulqv800aup685GaAZ2RkA9hCqp6/4s/JpcRrktAgUdqyGTlPRGHMnKZAPdq9/j3spCKgDb/nt9qk/aZp0Dq2b7CqQYh4mSW3QUYodamGTkIKOrU2uiSgsKeZPhyXqi3HMiKng6S7Rs8tOr8QwHBsIFNdFSBnOqCgbuZXrFe7qLq2+GiytGepVHH/KaqnIBX4ffhz+GdxJISqoHVIZShvN6swJnu5KHcezHrDpyOfrAR4ma2gdtejoH2Es8QRFTdkaOGlGjQZr9KujbugdXqqOV+gf/LB1J56pqO/eqrH0Pq7erjTuch3p0D6pkw8NG6eJPqpZgz6qGKVd6D5GvqyZ9hmyLW7NN76tMsx+qlAvQlU37T3pdKgqGwtqkRgkpfUe/JK59otuVBQaxdxs6uMMcaoZei+mz153p2xqHwkewB2cGEM0gazaq+eN2vKEGQquNDHqH7vOfe8h7ByPKu9DcvlpRBvjYZdp2RidHvE2xB3QRcQdjm11TuYv12raG852AmoJG5rrQ+uhqMPpAENtHsTv6PWf7Loc1zeJGOdIsxbhrkkbb0VJGuNKehj3bQRIzst6GWOrKScpHXodyR/v6Kbw3G+pGZ5qVBr2LmkdVBhGH1QeXm7c4ukes0tGGdPr1O5kpLquda7slbqrAKgmHpkeeqwkLSYcqQ6ZHcZyphtSaaYaeTRzqgavYInpDPQfBq2fatkehq30HPVr2R7gKryMOR2cr3APzPEdMSkdRuLGrABKtq7RK1Dv8OsFGypQhR2BKoUf/W8xaKavjA35aEWCRR75HkmpLBlvgdYY1K6ADTxkYxuK4QUfYBlFKmfTew//6kgZeR2FGG2JKnT5H12MExgHqnYcoxmWrbssZNVOGUk0nB6SwLdoiRtWqNqvwBpcGQ4eIB8OGjaooB6OGJOB3Bia6osKBRglHadS8ezTytDomBMlGdGNkmQWcR1xGBByVIcvPBksKW8Ox6+As/2Koi+d6fNo5R+gGt4pH9IWqSFv5RlbjBUYrK4VGw0jrAxOrx+mTqsLUAqGlRj6ZZUZXHU1lUBhuhx+GigeZy5yti6o1e1nzisZZBzIHigd5yhSH66vKB4j815GqBtSHagYvUABGT3u0h4BHOjBaBgyGIEaMhqBHLws3u8dHuYZzwSeq8ivOMi6yfUaDRk+7mNsDRter2lqCOENH5gZZm0FU40ZwRpYM1Wi3qtMUI0YV0sChATNaao9Bk0YduVNGemPTRqcbZnwux7hHcJKaoPNGX6tmSwt6OUpLR3GIy0Z/qytHs9sURv+qUHrOWgEHXfvte3dHtEb4lbUNO0egaiPTAX17RoxGbvJhB0xHLjuQaxqs7fiRB3BqZ0fryyaGlJNiCoD7a6GIa02il0YSotwbhHoz+0R6SQez+tE7hYopBwHHIkf3R1l9D0YQm0RLCuBPRtIGH4Zqxp+G8VqvR9T90kdwmseaqPt5BlJHZGorc1OJn0YdpB9GuVr7mxg988oaR2eamkaU+lpGVPraRlosOka3y+vbQMYX+8DG0EbGB5mbY4XJg1PhrGqJ6VTKdIHGRqp7ZhtI5A+yYCtUmn6qz9D+qs/61htb40aSwtKa60ewvQYIxnp6iMa5h/p7AR3DykkBnMu4Q+yaRnuxm7bLnsqOynLL6Fsee/zKVQECy4LKalGhewGl5wMHO4XqlmoOw827WY3iymrLXgs1h7Z6RMf+R0Pqp4cEOwPG8Jl8yvLKM6imJeEaHOyJRzbSKEWCW5xZFbuUIBLKE2NZkJ2HqsaEh2rGkAYtoZ9avYbaJH2Gh8qBx3LkQQnFxxcH0gB1qlcGw4dIBwBBNwaHxhzHRvrG6h77IIpHg6Xq1zPAujcdKcgl6r8H/2L+yvxz1VN3u2Pairn2yxTylRSDxhz9E3t2R9aKpCp+G2HKt+MrW4WqoGlfB12DP1T084YQEyM9qj7Ku4tqGIZRY1yrxtr7buu7EsEtgcqBTX7KUIduRQLGQmolewf00jl+m6brrOyCKwWrr6KdsxPHPhr29XxhMcs5XakkWMSe+uIG9wZTO4PCEFqJygwj+ZRIWqlHTssekqMTRerxyxgD4lq6xJkGmccbxlnGysb9XCrGojrvhsKwG8cvhpvHucvqxt+HFIcSO5SGRcpNRo96t2qzG0padNvN6nSGVLtARkmbwEe5+x1GK002S6bGnevVymPN/Ua6/WQmnjObjC3KyiFibQz62xu1W9VZdTGtysTG88dVhm/GdsqIXHnMXcuBjN3LGEYLRfx6cJQrkjzij8fihp3D/crzGvyslZt4RkPKGyrDyxzLPccjy/KGLnMKhl7GNUF1ynfM7nKTyncbi1y284UAfsbURsJH63tbRrvGq1Vay3E0yH3tdHtHt8qhx0KqYcbj0v9r4QYsRj5aqHsbyyhCLAyj+ru78iaxBjh6iGvBO7JGN0Pxx/xGRHsCRlo9SQeRWsnHm9IYaynHToZpBmnGyOpKchnHFUcSR5VHVEJS4dkHHoY5x56Gy3MvRvnGqfPyRyHGx6pRx7ubyCXFBk81hcbka0XHhRGuM6o6c9ok++/LGkehuuGGlVrVBi18EbujBr+y4YLOqrVah3tLgTpaHZhrWbG6HWPZ8WBAJ0hNWiZH9fNHkMjlIKoLMh07bOqae71jLcZdB+z63QZWRpmGOixc+tmHCMcyhkjH3UabyGWH+YYQhoPAxEbDBspNRYajB/2KLobTxgeLSwbSy3WGc4ZMdKhx2T13JInqp8ak1Iu88GX0xqWhzpAhJjP8REcQhjb7UIrzDdvGjMcwB0kzYibQ6dsEViZy9PvGB8dDhg2r1wZHx2zGx8djh3xHpZMh00NcN/Xrc/Frpx3XxhxLPbpAhpnNfDI6owiGmwaAbLEnFussofsBVGKJJ9lq5zOcczjyX2EyyHdMZ3WLhwbImAYdLTRMikcnLBeHCSbmh4VruVPJK2cC9YdXYg2HaEffouO73hFKs8zUeKktupdaZF1/sLBlKXrxpeHJUX0rCqb6IzFJJ3zjIeMHHT7Lh4cxGxXbxMRBSsFI64fHqrvklIJl6F2DfEuaM2e9ggVr80NcP7olJg0FR/Lx+zVGeie1RpEEUltWqdVH13qgdLVGVhP61Fvg9UfYJr+HZl2NR3+G9ov/h/gmIHutRpoHesZEJ15yxCYdRyBHalugRlK6tvlv8aQMEEYqO1IhByZh1Qd7dVm3greaI1OJAjGtcQtwRjuBziZ94kll0Sa1pasHrYdyhmEnPLp/uieIxAtpU1FL5p2jdRNr3h32Bw8n4jozaqZK0JRrU1WaK+pLQIMmhp3JJ6EmkwjPeotGP6vmOsw0jVpvet4HYm2GIyKLTrgtm1RHUrs8q/7GdIJF/BkmtQx7xj8xViaSJovKvob9+7qH3Zrhxnt6KHpyJqxGERWNJsLHlJn+h947vZQwp4cTVSYTahaGnGIqJzQBKkZBhnFGsNtXRljd10bqJknGJHoNqc3a6SeBBlomVrtHymJGhguJyLomyyfzJisnn4ZyRz8cyTqMDTJGbHpyqhYn+ccpW8B5DEZCKPCnZobSckIsk9sBhhgAVoaqR0GG30d7czI0x5FGCCXHv0cU+zwcZcYBg1T7q9v2J6MzgMdRh44nekbMu+YUJnOdkZrc4DPtOnG7PqI/MNltA2xPm9Y6McJNxhYb3ietW/TKFkZp6Km7PGtQcu3HOnvwxzZHncZBJ/06J6rZa2/zM63ASnvSrkZifV/7tYczx5YH1OmD2Tl72kth60mEwgSgBoca8XqD5LFGL8f7YxIqQgeQitHcfbvrx8sneIpdYd2HmmrlwCcHqHg7x5ongNzVkLSnWSeXB9km1wYjh0fHtwd5Jr56nkrrzF4b8l2uR48GedTqgbu9HeRn5WMnUxCEI0AmHxTRyDhk/waRQtZ6waQK+Im0f1ubm+Xc1AdGhxW7VDomBY/Fh0FDZTVNhxIUOwKjocjfYilg6EVmerfz9poJqhXNrYffFIMHMXph3BN60seLAjr57CMiBkDqRnii+y8G5Kdic4nLjI0kiLam6OicBgbTaUN7KsVHkeuhRu/YR1zF68/o0qeA23ybbFt8cgKGZqN8Wj0mi8kxRjKZrNUETEqnRpok2wpz0wbQJgqdNawdE+Jrcyfvhs9HboeYJjoqb4bJ+xnGqaZKxhh6QvM0AasnGsaUhlrHuCc3Cturp7s6x7NrusfZ+2yyrXv6x8Qmeyd5+n6j+ydnqko6YoHkJ5ECnSm57TUCm2q2xzWxrH1JZIyKTIvGcrr0FWg7jHmbp0YT8hTjvbBjsg7KqyyBLbQgwMW1+0QK+quOB8zkHCYXu8QLZAskCtHjOXMN69SGylv4R28nAzwNppn1TAfipo/Snsd8J74NpaYSup5zd7giJoCntjoZ2oEHGsvAp7GLtQxap/B5AqtgalImzjv9+rt7Xlr/EQXaBobHRoonMQbUdKdHiMb4u5vLSiZxBtvLF0cspOFjYPt3HICaqGuJxxEp7aNdOXP6d0bAplimG9BGidom5kZm6Lim8yYoJpgmqCaTLNnGCVs5BwRruQfNawXG+QdfRx9GrIc6iSYnXUemJxnyqdpcGsSnQkIiemslvEnEnRJ6BFPnmnYn/0b2Jzob0/FMpxQllcd1Os1bRgYxZWNTkf3jU4ZGO2sfeQoA/UDIjXf6QMjdkHSwPzHLgWZGgWvmRzDH/Kac6jZHabvtxpUSsHKdxwybtkYLpt1GP5oUac2nCaoByyULEqJLU7L4kNLOneWcPEtXxu4d5ntyXcFaCGL+puZ6HC0BQ+bLnA1oM7A6DnrxJ2oYRoZBp1xGs6qIBRqnKQZbp4HHH+zXphEdg4aIB1cHrMY3B7kmeqdl4xprd4a2Axr7W9XBR+aml3w6akEjPTzRemC0l8c+YJ7TgIe9VEBFY2pnxos7UjLmYK98qZKpeoIG8UceCm2G5KK4OThmACZXahlHvNpi+mlrVSZGp6eHJFoGtP2DTjO7Ww/9hniM8uA9M9Iq1T26/Rqla5Gm91jMWcanfoawpkBkeLuOmHimqqcNtVVGxIfpp7ome6aSR3rEliLZpj+GmsaJwn+HZLvhMqbA+afCutn74vPbJvSG7UZXu3fYxaadRg+6ugdgRuslaI1lp000DIAk4Op60ykvu0yLrwklvSOTmZ02xzApSdqa3OXTd0RVsv1kIGYmXdr7AWoiho2ymEeih6wmbGFsJs6F7CcShxwnmDGN+lwm3abcJgRGPMdxzNjG+GfERi37dlqKh/JmJ+1t+r7H7ftxgZQaVcsbR7XFm0YQ6FKCY6aIqeolvNP0Rr6pIcZTphCmA/rJioP6nxssRpHG7NrnpvOmf3pAZ65n2HuXQlvh24Jxx8umYPuznAnHq6YQ+z+TgkYbp3wbycebp4jraQdiR7vUu6cppi1486qvh2SGZGoXyqS0ucZJW2x6A/wnpwTSJiZSJqYnu7tFBhenLqyXpxjDpQZFsHVITNB+go+cFQaL2u/K77MaGqXG9Kb/RoqSbWw1B2MyswOZEnU6N0XM+n0iR3v6LABydcd9bd6gTLBHlCyFF/qJu9iRDIE+q8UTepLs6gLTfKbG3c/6bce0moKnnPoZuwBn59uAZ13GvPsdAy9N31prLLP0nbzDOkT8b+L0xn/C2yuKYTO694t3Qz9yV4yh6hzV3FIDO/mT2ptw/UIih/HCCnCIiwa0jIKadnqK+yEb9no2DMsL4LNjGXmGHQKHWi5HLvuDOjjrnliuBbnqvhqVGpNxMsKo8twr28XtZ/UkQyyksMBrtme9nF0oPqC1qizHGGaHxzknI4coB+zHeqeXRoTbfBgZe7aUYRhpQuBVZ+lZewUaZLOKUyBsffPZWxwHZ0xa+n5ZoR3BpnlsG5mCBBJz42o6hc577nu8+84LDOKnbJGIGfJqU5H60Utpe52HU1qmpui6bhu6mITUXvjh64cTk6uYO4pr+TOAB4WtHiOkPfu0vvtVZ8+rOjqqNDxmbGZg/XunSsZEhvB7aCeEuhmnwWfPR4JmUsFCZg1GanPqQTmmGye02psmWfq6xtxk2ydlyjsmJ4JFp7snBsd7JiWnAKZ6RVQcqxr7JutqPuOA5iX7OySAk+5Kp1MVwtVpoOdHhMFUKwZ5MtfTWwrFR6ndawYk7bcnL6vQrXX6/LpAeu2nvVHTe7N69nPWWk36HscgestDj2rfJq366tsNm78nlmKOW/cb60cPG2t6oidAapqHqGe7x0jYU2f2Zs6JXNK6h55a06cD+jOmUKZD+z5b4PM+GpPzA5vrMutmCFUxxyVAToH3AKQBcNM6quOGETo+Z6a6aKfnw+onTdpaqRa6qGcBZgTm6QcQm+nHrocqp5d9r2f6JgenBKcXysP9ucaOuoXGkWbNMwUHjOcY+3IUAYZIp1fLg5QKTO1QgAA==="</script>
+    <script id="__LOADABLE_REQUIRED_CHUNKS__" type="application/json">[252,323,182]</script>
+    <script id="__LOADABLE_REQUIRED_CHUNKS___ext" type="application/json">{"namedChunks":["vertical"]}</script>
+    <script async data-chunk="main" src="/public/325_59bb7f7d379bac0699fc_walla.js"></script>
+    <script async data-chunk="main" src="/public/main_d0f8d7a3e7ff23c1faec_walla.js"></script>
+    <script async data-chunk="vertical" src="/public/252_3a2273c2ba3dcbd45b6a_walla.js"></script>
+    <script async data-chunk="vertical" src="/public/323_edbaab22f775a026f7bf_walla.js"></script>
+    <script async data-chunk="vertical" src="/public/vertical_684bb6ea55ba22957237_walla.js"></script>
+</body>
+
+</html>

--- a/tests/test_news_flash.py
+++ b/tests/test_news_flash.py
@@ -44,6 +44,7 @@ def assert_all_equal(items_actual, items_expected):
 
 
 def test_scrape_walla():
+    # Reuters is marked differently than Walla's authors
     items_expected = [
         NewsFlash(
             date=datetime.datetime(2021, 6, 23, 16, 49, tzinfo=timezones.ISREAL_SUMMER_TIMEZONE),
@@ -52,6 +53,14 @@ def test_scrape_walla():
             source="walla",
             author="מירב כהן",
             description='חובת המסכות תוחזר בחללים סגורים אם יהיה ממוצע שבועי של 100 חולים ביום - כך הוחלט היום (רביעי) בדיון השרים.',
+        ),
+        NewsFlash(
+            date=datetime.datetime(2021, 7, 14, 9, 10, tzinfo=timezones.ISREAL_SUMMER_TIMEZONE),
+            title="פקיסטן: שמונה הרוגים בפיצוץ באוטובוס",
+            link="https://news.walla.co.il/break/3448092",
+            source="walla",
+            author="רויטרס",
+            description="שמונה בני אדם נהרגו הבוקר (רביעי) בפיצוץ אוטובוס בצפון פקיסטן. בין ההרוגים, שישה מהנדסים תושבי סין. טרם ידוע מקור הפיצוץ.",
         ),
     ]
 

--- a/tests/walla.xml
+++ b/tests/walla.xml
@@ -21,5 +21,12 @@
             <pubDate>Wed, 23 Jun 2021 13:49:00 GMT</pubDate>
             <description><![CDATA[<p style="direction:rtl; clear:both"><a href="https://news.walla.co.il/break/3443829"></a><br/>חובת המסכות תוחזר בחללים סגורים אם יהיה ממוצע שבועי של 100 חולים ביום - כך הוחלט היום (רביעי) בדיון השרים.</p>]]></description>
         </item>
+        <item>
+            <title><![CDATA[ פקיסטן: שמונה הרוגים בפיצוץ באוטובוס ]]></title>
+            <link>https://news.walla.co.il/break/3448092</link>
+            <guid>https://news.walla.co.il/break/3448092</guid>
+            <pubDate>Wed, 14 Jul 2021 06:10:00 GMT</pubDate>
+            <description><![CDATA[ <p style="direction:rtl; clear:both"><a href="https://news.walla.co.il/break/3448092"></a><br/>שמונה בני אדם נהרגו הבוקר (רביעי) בפיצוץ אוטובוס בצפון פקיסטן. בין ההרוגים, שישה מהנדסים תושבי סין. טרם ידוע מקור הפיצוץ.</p> ]]></description>
+        </item>
     </channel>
 </rss>


### PR DESCRIPTION
Fix #1824: There's no reason to look for `<a>` tag, and it does not exist for Reuters.