### PR TITLE
Allow to import anyway as a module (WIP)

### DIFF
--- a/anyway/__init__.py
+++ b/anyway/__init__.py
@@ -1,1 +1,5 @@
-from anyway.flask_app import app
+try:
+    from anyway.flask_app import app
+except ModuleNotFoundError:
+    pass
+

--- a/anyway/database.py
+++ b/anyway/database.py
@@ -1,3 +1,6 @@
-from anyway.app_and_db import db
-
-Base = db.Model
+try:
+    from anyway.app_and_db import db
+    Base = db.Model
+except ModuleNotFoundError:
+    from sqlalchemy.ext.declarative.api import declarative_base
+    Base = declarative_base()

--- a/anyway/localization.py
+++ b/anyway/localization.py
@@ -199,7 +199,10 @@ _fields = {
     "RSA_LICENSE_PLATE": "סוג לוחית רישוי",
 }
 
-_cities = pd.read_csv("static/data/cities.csv", encoding="utf-8", index_col=field_names.sign)
+try:
+    _cities = pd.read_csv("static/data/cities.csv", encoding="utf-8", index_col=field_names.sign)
+except FileNotFoundError:
+    pass
 
 
 def get_field(field, value=None):

--- a/anyway/models.py
+++ b/anyway/models.py
@@ -5,7 +5,12 @@ import json
 import logging
 from collections import namedtuple
 
-from flask_login import UserMixin
+try:
+    from flask_login import UserMixin
+except ModuleNotFoundError:
+    class UserMixin():
+        pass
+
 from geoalchemy2 import Geometry
 from sqlalchemy import (
     Column,
@@ -33,7 +38,12 @@ from anyway import localization
 from anyway.backend_constants import BE_CONST
 from anyway.database import Base
 from anyway.utilities import decode_hebrew
-from anyway.app_and_db import db
+
+try:
+    from anyway.app_and_db import db
+except ModuleNotFoundError:
+    pass
+
 from anyway.vehicle_type import VehicleType as BE_VehicleType
 
 MarkerResult = namedtuple("MarkerResult", ["accident_markers", "rsa_markers", "total_records"])

--- a/anyway/utilities.py
+++ b/anyway/utilities.py
@@ -12,10 +12,23 @@ from urllib.parse import urlparse
 
 import phonenumbers
 from dateutil.relativedelta import relativedelta
-from flask import Flask
+
+try:
+    from flask import Flask
+except ModuleNotFoundError:
+    pass
+
 from phonenumbers import NumberParseException
-from pyproj import Transformer
-from validate_email import validate_email
+
+try:
+    from pyproj import Transformer
+except ModuleNotFoundError:
+    pass
+
+try:
+    from validate_email import validate_email
+except ModuleNotFoundError:
+    pass
 
 from anyway import config
 

--- a/anyway/vehicle_type.py
+++ b/anyway/vehicle_type.py
@@ -2,7 +2,11 @@ from enum import Enum
 from typing import List, Union
 import logging
 import math
-from flask_babel import _
+
+try:
+    from flask_babel import _
+except ModuleNotFoundError:
+    pass
 
 
 class VehicleType(Enum):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+from os import path
+import time
+
+if path.exists("VERSION.txt"):
+    # this file can be written by CI tools (e.g. Travis)
+    with open("VERSION.txt") as version_file:
+        version = version_file.read().strip().strip("v")
+else:
+    version = str(time.time())
+
+setup(
+    name='anyway',
+    version=version,
+    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+)


### PR DESCRIPTION
Changes which allow to import anyway as a module to support the anyway-etl repository. It mostly prevents exceptions in case of missing modules. The main problem is that a lot of anyway code is dependany on Flask and related modules, in the future we should strive to have independent packages and especially the DB. This PR however solves it for the moment.