### PR TITLE
Fix #1869 news flash api returns wrong error code

### DIFF
--- a/anyway/backend_constants.py
+++ b/anyway/backend_constants.py
@@ -109,6 +109,11 @@ class BackEndConstants(object):
     ]
 
     class Source(Enum):
+        @classmethod
+        def _missing_(cls, value):
+            for member in cls:
+                if member.value == value.lower():
+                    return member
         YNET = "ynet"
         WALLA = "walla"
         TWITTER = "twitter"

--- a/anyway/backend_constants.py
+++ b/anyway/backend_constants.py
@@ -108,6 +108,17 @@ class BackEndConstants(object):
         ResolutionCategories.SUBURBAN_ROAD,
     ]
 
+    class Source(Enum):
+        YNET = "ynet"
+        WALLA = "walla"
+        TWITTER = "twitter"
+
+    SUPPORTED_SOURCES: List[Source] = [
+        Source.YNET,
+        Source.WALLA,
+        Source.TWITTER,
+    ]
+
     # If in the future there will be a number of organizations or a need for a dynamic setting change, move this
     # data to a table in the DB.
     OR_YAROK_WIDGETS = [

--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -99,6 +99,7 @@ from anyway.views.news_flash.api import (
     news_flash,
     news_flash_new,
     single_news_flash,
+    news_flash_v2,
     DEFAULT_LIMIT_REQ_PARAMETER,
     DEFAULT_OFFSET_REQ_PARAMETER,
 )
@@ -1160,6 +1161,8 @@ app.add_url_rule(
     methods=["GET"],
 )
 app.add_url_rule("/api/news-flash", endpoint=None, view_func=news_flash, methods=["GET"])
+
+app.add_url_rule("/api/news-flash_v2", endpoint=None, view_func=news_flash_v2, methods=["GET"])
 
 
 nf_parser = reqparse.RequestParser()

--- a/anyway/views/news_flash/api.py
+++ b/anyway/views/news_flash/api.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import logging
-from typing import List, Literal, Optional
+from typing import List, Optional
 
 from flask import request, Response, make_response, jsonify
 from sqlalchemy import and_, not_

--- a/anyway/views/news_flash/api.py
+++ b/anyway/views/news_flash/api.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import logging
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from flask import request, Response, make_response, jsonify
 from sqlalchemy import and_, not_, or_
@@ -271,10 +271,14 @@ def filter_by_resolutions(query, resolutions: List[str]):
     return query.filter(ands.pop())
 
 
-def normalize_query_param(key, value):
-    return value if key == "source" or key == "resolution" else value[0]
+# Params that can take more than 1 value are kept as lists regardless of number of values supplied
+# in order to simplify dependent code.
+# Single valued params are converted to their value.
+def normalize_query_param(key, value: list):
+    multi_value_params = ["source", "resolution"]
+    return value if key in  multi_value_params else value.pop()
 
 
-def normalize_query(params):
+def normalize_query(params: dict):
     params_non_flat = params.to_dict(flat=False)
     return {k: normalize_query_param(k, v) for k, v in params_non_flat.items()}

--- a/anyway/views/news_flash/api.py
+++ b/anyway/views/news_flash/api.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import logging
-from typing import List
+from typing import List, Literal
 
 from flask import request, Response
 from sqlalchemy import and_, not_
@@ -11,9 +11,26 @@ from anyway.backend_constants import BE_CONST
 from anyway.models import NewsFlash
 from anyway.infographics_utils import is_news_flash_resolution_supported
 
+from pydantic import BaseModel, ValidationError, validator
+
 DEFAULT_OFFSET_REQ_PARAMETER = 0
 DEFAULT_LIMIT_REQ_PARAMETER = 100
 
+class QueryParams(BaseModel):
+    road_number: int
+    offset: int
+    limit: int
+    interurban_only: bool
+    road_segment_only: bool
+    source: Literal['ynet', 'walla', 'twitter']
+    start_date: datetime.datetime
+    end_date: datetime.datetime
+
+    @validator('end_date')
+    def check_missing_date(cls, end_date, start_date):
+        if end_date ^ start_date:
+            raise ValidationError('Missing start or end date')
+        return end_date
 
 def news_flash():
     news_flash_id = request.values.get("id")

--- a/anyway/views/news_flash/api.py
+++ b/anyway/views/news_flash/api.py
@@ -44,9 +44,10 @@ class NewsFlashQuery(BaseModel):
     @validator("resolution")
     def check_supported_resolutions(cls, v):
         supported_resolutions = get_supported_resolutions()
-        if not set(v) <= supported_resolutions:
+        requested_resolutions = set([resolution.lower() for resolution in v])
+        if not requested_resolutions <= supported_resolutions:
             raise ValueError(f"Resolution must be one of: {supported_resolutions}")
-        return v
+        return requested_resolutions
 
 def news_flash():
     news_flash_id = request.values.get("id")

--- a/anyway/views/news_flash/api.py
+++ b/anyway/views/news_flash/api.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import logging
 
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from flask import request, Response, make_response, jsonify
 from sqlalchemy import and_, not_, or_

--- a/anyway/views/news_flash/api.py
+++ b/anyway/views/news_flash/api.py
@@ -4,10 +4,12 @@
 import datetime
 import json
 import logging
+
 from typing import List, Optional
 
 from flask import request, Response, make_response, jsonify
-from sqlalchemy import and_, not_
+from sqlalchemy import and_, not_, or_
+
 
 from anyway.app_and_db import db
 from anyway.backend_constants import BE_CONST
@@ -26,10 +28,9 @@ class NewsFlashQuery(BaseModel):
     road_number: Optional[int]
     offset: Optional[int] = DEFAULT_OFFSET_REQ_PARAMETER
     limit: Optional[int] = DEFAULT_LIMIT_REQ_PARAMETER
-    interurban_only: Optional[bool]
-    road_segment_only: Optional[bool]
-    source: Optional[str]
-    # Must set default value in order to be accessed from "check_missing_date" validator when no value provided
+    resolution: Optional[List[str]]
+    source: Optional[List[BE_CONST.Source]]
+    # Must set default value in order to allow access from "check_missing_date" validator when no value provided
     # from the request
     start_date: Optional[datetime.datetime] = None
     end_date: Optional[datetime.datetime] = None
@@ -40,36 +41,63 @@ class NewsFlashQuery(BaseModel):
             raise ValueError("Must provide both start and end date")
         return v
 
-    @validator("source")
-    def check_source_exist(cls, v):
-        valid_sources = [
-            str(source_name[0])
-            for source_name in db.session.query(NewsFlash.source).distinct().all()
-        ]
-        if not v in valid_sources:
-            raise ValueError(f"Source must be one of: {valid_sources}")
+    @validator("resolution")
+    def check_supported_resolutions(cls, v):
+        supported_resolutions = get_supported_resolutions()
+        if not set(v) <= supported_resolutions:
+            raise ValueError(f"Resolution must be one of: {supported_resolutions}")
         return v
-
 
 def news_flash():
     news_flash_id = request.values.get("id")
-    requested_query_params = request.args
 
+    if news_flash_id is not None:
+        query = db.session.query(NewsFlash)
+        news_flash_obj = query.filter(NewsFlash.id == news_flash_id).first()
+        if news_flash_obj is not None:
+            if is_news_flash_resolution_supported(news_flash_obj):
+                return Response(
+                    json.dumps(news_flash_obj.serialize(), default=str), mimetype="application/json"
+                )
+            else:
+                return Response("News flash location not supported", 406)
+        return Response(status=404)
+
+    query = gen_news_flash_query(
+        db.session,
+        source=request.values.get("source"),
+        start_date=request.values.get("start_date"),
+        end_date=request.values.get("end_date"),
+        interurban_only=request.values.get("interurban_only"),
+        road_number=request.values.get("road_number"),
+        road_segment=request.values.get("road_segment_only"),
+        offset=request.values.get("offset", DEFAULT_OFFSET_REQ_PARAMETER),
+        limit=request.values.get("limit", DEFAULT_LIMIT_REQ_PARAMETER),
+    )
+    news_flashes = query.all()
+
+    news_flashes_jsons = [n.serialize() for n in news_flashes]
+    for news_flash in news_flashes_jsons:
+        set_display_source(news_flash)
+    return Response(json.dumps(news_flashes_jsons, default=str), mimetype="application/json")
+
+
+def news_flash_v2():
+    requested_query_params = normalize_query(request.args)
     try:
         validated_query_params = NewsFlashQuery(**requested_query_params).dict(exclude_none=True)
     except ValidationError as e:
         return make_response(jsonify(e.errors()[0]["msg"]), 404)
 
-    query = db.session.query(NewsFlash)
     if "id" in validated_query_params:
-        return get_news_flash_by_id(validated_query_params["id"], query)
+        return get_news_flash_by_id(validated_query_params["id"])
 
-    query = gen_news_flash_query_new(query, validated_query_params)
+    query = gen_news_flash_query_v2(validated_query_params)
     news_flashes = query.all()
 
     news_flashes_jsons = [n.serialize() for n in news_flashes]
     for news_flash in news_flashes_jsons:
-        set_display_source(news_flash, news_flash_id)
+        set_display_source(news_flash)
     return Response(json.dumps(news_flashes_jsons, default=str), mimetype="application/json")
 
 
@@ -94,7 +122,7 @@ def news_flash_new(args: dict) -> List[dict]:
 
     news_flashes_jsons = [n.serialize() for n in news_flashes]
     for news_flash in news_flashes_jsons:
-        set_display_source(news_flash, news_flash_id)
+        set_display_source(news_flash)
     return news_flashes_jsons
 
 
@@ -155,20 +183,20 @@ def gen_news_flash_query(
     return query
 
 
-def gen_news_flash_query_new(query, valid_params: dict):
-    filters = {
-        "source": filter_news_flash_by_source,
-        "start_date": filter_news_flash_by_start_date,
-        "end_date": filter_news_flash_by_end_date,
-        "interurban_only": filter_news_flash_by_interurban_only,
-        "road_segment_only": filter_news_flash_by_road_segment,
-        "road_number": filter_news_flash_by_road_number,
-    }
-
-    for param in valid_params:
-        if param is not "offset" and param is not "limit":
-            query = filters[param](query, valid_params[param])
-
+def gen_news_flash_query_v2(valid_params: dict):
+    query = db.session.query(NewsFlash)
+    for param, value in valid_params.items():
+        if param == "road_number":
+            query = query.filter(NewsFlash.road1 == value)
+        if param == "source":
+            sources = [source.value for source in value]
+            query = query.filter(NewsFlash.source.in_(sources))
+        if param == "start_date":
+            query = query.filter(
+                NewsFlash.date >= value and NewsFlash.date <= valid_params["end_date"]
+            )
+        if param == "resolution":
+            query = filter_by_resolutions(query, value)
     query = query.filter(
         and_(
             NewsFlash.accident == True,
@@ -176,18 +204,17 @@ def gen_news_flash_query_new(query, valid_params: dict):
             not_(and_(NewsFlash.lat == None, NewsFlash.lon == None)),
         )
     ).order_by(NewsFlash.date.desc())
-
-    query = filter_news_flash_by_offset(query, valid_params["offset"])
-    query = filter_news_flash_by_limit(query, valid_params["limit"])
+    query = query.offset(valid_params["offset"])
+    query = query.limit(valid_params["limit"])
     return query
 
 
-def set_display_source(news_flash, news_flash_id):
+def set_display_source(news_flash):
     news_flash["display_source"] = BE_CONST.SOURCE_MAPPING.get(
         news_flash["source"], BE_CONST.UNKNOWN
     )
     if news_flash["display_source"] == BE_CONST.UNKNOWN:
-        logging.warning(f"Unknown source of news-flash with id {str(news_flash_id)}")
+        logging.warning(f"Unknown source of news-flash with id")
 
 
 def filter_by_timeframe(end_date, news_flash_obj, start_date):
@@ -207,10 +234,11 @@ def single_news_flash(news_flash_id: int):
 
 
 def get_supported_resolutions() -> set:
-    return set([x.value for x in BE_CONST.SUPPORTED_RESOLUTIONS])
+    return set([x.name.lower() for x in BE_CONST.SUPPORTED_RESOLUTIONS])
 
 
-def get_news_flash_by_id(id: int, query):
+def get_news_flash_by_id(id: int):
+    query = db.session.query(NewsFlash)
     news_flash_with_id = query.filter(NewsFlash.id == id).first()
     if news_flash_with_id is None:
         return Response(status=404)
@@ -221,37 +249,31 @@ def get_news_flash_by_id(id: int, query):
     )
 
 
-def filter_news_flash_by_interurban_only(query, interurban_only: bool):
-    return query.filter(NewsFlash.resolution.in_(["כביש בינעירוני"]))
+def filter_by_resolutions(query, resolutions: List[str]):
+    ands = []
+    if "suburban_road" in resolutions:
+        ands.append(
+            and_(
+                NewsFlash.resolution == BE_CONST.ResolutionCategories.SUBURBAN_ROAD.value,
+                NewsFlash.road_segment_name != None,
+            )
+        )
+    if "street" in resolutions:
+        ands.append(
+            and_(
+                NewsFlash.resolution == BE_CONST.ResolutionCategories.STREET.value,
+                NewsFlash.street1_hebrew != None,
+            )
+        )
+    if len(ands) > 1:
+        return query.filter(or_(*ands))
+    return query.filter(ands.pop())
 
 
-def filter_news_flash_by_road_number(query, road_number):
-    return query.filter(NewsFlash.road1 == road_number)
+def normalize_query_param(key, value):
+    return value if key == "source" or key == "resolution" else value[0]
 
 
-def filter_news_flash_by_road_segment(query, road_segment_required: bool):
-    return query.filter(not_(NewsFlash.road_segment_name == None))
-
-
-def filter_news_flash_by_start_date(query, start_date: datetime.datetime):
-    return query.filter(NewsFlash.date >= start_date)
-
-
-def filter_news_flash_by_end_date(query, end_date: datetime.datetime):
-    return query.filter(NewsFlash.date <= end_date)
-
-
-def filter_news_flash_by_supported_resolutions(query, supported_resolutions):
-    return query.filter(NewsFlash.resolution.in_(supported_resolutions))
-
-
-def filter_news_flash_by_source(query, source):
-    return query.filter(NewsFlash.source == source)
-
-
-def filter_news_flash_by_offset(query, offset):
-    return query.offset(offset)
-
-
-def filter_news_flash_by_limit(query, limit):
-    return query.limit(limit)
+def normalize_query(params):
+    params_non_flat = params.to_dict(flat=False)
+    return {k: normalize_query_param(k, v) for k, v in params_non_flat.items()}

--- a/anyway/views/news_flash/api.py
+++ b/anyway/views/news_flash/api.py
@@ -1,3 +1,6 @@
+# pylint: disable=no-name-in-module
+# pylint: disable=no-self-argument
+
 import datetime
 import json
 import logging
@@ -94,6 +97,7 @@ def news_flash_new(args: dict) -> List[dict]:
         set_display_source(news_flash, news_flash_id)
     return news_flashes_jsons
 
+
 def gen_news_flash_query(
     session,
     source=None,
@@ -149,6 +153,7 @@ def gen_news_flash_query(
     query = query.limit(limit)
 
     return query
+
 
 def gen_news_flash_query_new(query, valid_params: dict):
     filters = {
@@ -212,7 +217,8 @@ def get_news_flash_by_id(id: int, query):
     if not is_news_flash_resolution_supported(news_flash_with_id):
         return Response("News flash location not supported", 406)
     return Response(
-    json.dumps(news_flash_with_id.serialize(), default=str), mimetype="application/json")
+        json.dumps(news_flash_with_id.serialize(), default=str), mimetype="application/json"
+    )
 
 
 def filter_news_flash_by_interurban_only(query, interurban_only: bool):

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ boto3==1.17.68
 py3-validate-email==0.2.16
 phonenumbers==8.12.21
 flask-principal==0.4.0
+pydantic==1.8.2


### PR DESCRIPTION
This is a fix for #1869 .
My main goal with this fix is to gracefully handle invalid query parameter values to the API.
Previously many inputs could lead to an internal server error response when the fault was with the 
user inputs.

The fix uses Pydantic for parsing and validation.