### PR TITLE
Integrate with anyway etl

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Starting Server and DB
       run: |
-        docker-compose -f docker-compose.yml up -d --build
+        docker-compose -f docker-compose.yml up -d --build anyway
     - name: Waiting for DB startup
       run: |
         bash ./wait_for_postgres.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,7 @@ jobs:
         DOCKER_REPOSITORY_DB_BACKUP: ${{ env.SERVER }}/${{ env.DOCKER_REPOSITORY_DB_BACKUP }}
         DOCKER_REPOSITORY_NGINX: ${{ env.SERVER }}/${{ env.DOCKER_REPOSITORY_NGINX }}
         HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
+        ANYWAY_ETL_DEPLOY_KEY: ${{ secrets.ANYWAY_ETL_DEPLOY_KEY }}
       run: |
         if [ "${GITHUB_REF}" == "refs/heads/master" ] || [ "${GITHUB_REF}" == "refs/heads/dev" ]; then
           SHA_TAG=sha-`git rev-parse --short $GITHUB_SHA` &&\
@@ -117,6 +118,21 @@ jobs:
             else
               git add ./values.auto-updated.yaml && git commit -m "automatic update of anyway"
             fi &&\
+            git push origin master &&\
+            cd `mktemp -d` &&\
+            echo "${ANYWAY_ETL_DEPLOY_KEY}" > anyway_etl_deploy_key &&\
+            chmod 400 anyway_etl_deploy_key &&\
+            export GIT_SSH_COMMAND="ssh -i `pwd`/anyway_etl_deploy_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" &&\
+            git clone git@github.com:hasadna/anyway-etl.git &&\
+            cd anyway-etl &&\
+            if [ "${GITHUB_REF}" == "refs/heads/dev" ]; then
+              ANYWAY_ETL_COMMIT_FILENAME=anyway-dev-commit.txt
+            else
+              ANYWAY_ETL_COMMIT_FILENAME=anyway-master-commit.txt
+            fi &&\
+            echo "${GITHUB_SHA}" > $ANYWAY_ETL_COMMIT_FILENAME &&\
+            git add ./$ANYWAY_ETL_COMMIT_FILENAME &&\
+            git commit -m "automatic update of $ANYWAY_ETL_COMMIT_FILENAME" &&\
             git push origin master
           fi
         fi

--- a/anyway/__init__.py
+++ b/anyway/__init__.py
@@ -1,1 +1,5 @@
-from anyway.flask_app import app
+try:
+    from anyway.flask_app import app
+except ModuleNotFoundError:
+    pass
+

--- a/anyway/database.py
+++ b/anyway/database.py
@@ -1,3 +1,6 @@
-from anyway.app_and_db import db
-
-Base = db.Model
+try:
+    from anyway.app_and_db import db
+    Base = db.Model
+except ModuleNotFoundError:
+    from sqlalchemy.ext.declarative.api import declarative_base
+    Base = declarative_base()

--- a/anyway/localization.py
+++ b/anyway/localization.py
@@ -199,7 +199,10 @@ _fields = {
     "RSA_LICENSE_PLATE": "סוג לוחית רישוי",
 }
 
-_cities = pd.read_csv("static/data/cities.csv", encoding="utf-8", index_col=field_names.sign)
+try:
+    _cities = pd.read_csv("static/data/cities.csv", encoding="utf-8", index_col=field_names.sign)
+except FileNotFoundError:
+    pass
 
 
 def get_field(field, value=None):

--- a/anyway/models.py
+++ b/anyway/models.py
@@ -5,7 +5,12 @@ import json
 import logging
 from collections import namedtuple
 
-from flask_login import UserMixin
+try:
+    from flask_login import UserMixin
+except ModuleNotFoundError:
+    class UserMixin():
+        pass
+
 from geoalchemy2 import Geometry
 from sqlalchemy import (
     Column,
@@ -33,7 +38,12 @@ from anyway import localization
 from anyway.backend_constants import BE_CONST
 from anyway.database import Base
 from anyway.utilities import decode_hebrew
-from anyway.app_and_db import db
+
+try:
+    from anyway.app_and_db import db
+except ModuleNotFoundError:
+    pass
+
 from anyway.vehicle_type import VehicleType as BE_VehicleType
 
 MarkerResult = namedtuple("MarkerResult", ["accident_markers", "rsa_markers", "total_records"])

--- a/anyway/utilities.py
+++ b/anyway/utilities.py
@@ -12,10 +12,23 @@ from urllib.parse import urlparse
 
 import phonenumbers
 from dateutil.relativedelta import relativedelta
-from flask import Flask
+
+try:
+    from flask import Flask
+except ModuleNotFoundError:
+    pass
+
 from phonenumbers import NumberParseException
-from pyproj import Transformer
-from validate_email import validate_email
+
+try:
+    from pyproj import Transformer
+except ModuleNotFoundError:
+    pass
+
+try:
+    from validate_email import validate_email
+except ModuleNotFoundError:
+    pass
 
 from anyway import config
 

--- a/anyway/vehicle_type.py
+++ b/anyway/vehicle_type.py
@@ -2,7 +2,11 @@ from enum import Enum
 from typing import List, Union
 import logging
 import math
-from flask_babel import _
+
+try:
+    from flask_babel import _
+except ModuleNotFoundError:
+    pass
 
 
 class VehicleType(Enum):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,53 @@ services:
       - db
     restart: "no"
 
+  anyway-etl-nginx:
+    image: docker.pkg.github.com/hasadna/anyway-etl/anyway-etl-nginx:latest
+    volumes:
+      - anyway_etl_data:/var/anyway-etl-data
+    restart: unless-stopped
+    ports:
+      - "8083:80"
+
+  airflow-db:
+    image: postgres:13
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: "123456"
+    volumes:
+      - "airflow-db:/var/lib/postgresql/data"
+
+  airflow-webserver:
+    image: docker.pkg.github.com/hasadna/anyway-etl/anyway-etl-airflow:latest
+    restart: unless-stopped
+    environment:
+      ANYWAY_ETL_AIRFLOW_INITIALIZE: "yes"
+      ANYWAY_ETL_AIRFLOW_ROLE: "webserver"
+      ANYWAY_ETL_AIRFLOW_ADMIN_PASSWORD: "123456"
+    ports:
+      - "8082:8080"
+    volumes:
+      - "airflow-home:/var/airflow"
+    depends_on:
+      - airflow-db
+
+  airflow-scheduler:
+    image: docker.pkg.github.com/hasadna/anyway-etl/anyway-etl-airflow:latest
+    restart: unless-stopped
+    environment:
+      ANYWAY_ETL_AIRFLOW_ROLE: "scheduler"
+      ANYWAY_ETL_AIRFLOW_PIP_INSTALL_DEPS: "yes"
+      IMAP_MAIL_USER: "${IMAP_MAIL_USER}"
+      IMAP_MAIL_PASSWORD: "${IMAP_MAIL_PASSWORD}"
+    volumes:
+      - "airflow-home:/var/airflow"
+      - anyway_etl_data:/var/anyway-etl-data
+    depends_on:
+      - airflow-webserver
+      - db
+
 volumes:
   db_data:
   anyway_etl_data:
+  airflow-db:
+  airflow-home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,5 +34,14 @@ services:
       - "9876:5432"
     restart: always
 
+  anyway-etl:
+    image: docker.pkg.github.com/hasadna/anyway-etl/anyway-etl:latest
+    volumes:
+      - anyway_etl_data:/var/anyway-etl-data
+    depends_on:
+      - db
+    restart: "no"
+
 volumes:
   db_data:
+  anyway_etl_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   anyway:
     build: .
-    image: docker.pkg.github.com/hasadna/anyway/anyway:latest
+    image: ghcr.io/hasadna/anyway/anyway:latest
     container_name: anyway
     ports:
       - "8080:5000"
@@ -23,7 +23,7 @@ services:
 
   db:
     build: db_docker
-    image: docker.pkg.github.com/hasadna/anyway/db:latest
+    image: ghcr.io/hasadna/anyway/db:latest
     container_name: db
     environment:
       - DBRESTORE_AWS_ACCESS_KEY_ID
@@ -35,7 +35,7 @@ services:
     restart: always
 
   anyway-etl:
-    image: docker.pkg.github.com/hasadna/anyway-etl/anyway-etl:latest
+    image: ghcr.io/hasadna/anyway-etl/anyway-etl:latest
     volumes:
       - anyway_etl_data:/var/anyway-etl-data
     depends_on:
@@ -43,7 +43,7 @@ services:
     restart: "no"
 
   anyway-etl-nginx:
-    image: docker.pkg.github.com/hasadna/anyway-etl/anyway-etl-nginx:latest
+    image: ghcr.io/hasadna/anyway-etl/anyway-etl-nginx:latest
     volumes:
       - anyway_etl_data:/var/anyway-etl-data
     restart: unless-stopped
@@ -59,7 +59,7 @@ services:
       - "airflow-db:/var/lib/postgresql/data"
 
   airflow-webserver:
-    image: docker.pkg.github.com/hasadna/anyway-etl/anyway-etl-airflow:latest
+    image: ghcr.io/hasadna/anyway-etl/anyway-etl-airflow:latest
     restart: unless-stopped
     environment:
       ANYWAY_ETL_AIRFLOW_INITIALIZE: "yes"
@@ -73,7 +73,7 @@ services:
       - airflow-db
 
   airflow-scheduler:
-    image: docker.pkg.github.com/hasadna/anyway-etl/anyway-etl-airflow:latest
+    image: ghcr.io/hasadna/anyway-etl/anyway-etl-airflow:latest
     restart: unless-stopped
     environment:
       ANYWAY_ETL_AIRFLOW_ROLE: "scheduler"

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -112,10 +112,12 @@ Using VSCODE
 -----------------------
 In order to use VSCODE in debugging mode with DOCKER, check out [VSCODE_CONFIGURATION](VSCODE_CONFIGURATION.md)
 
-## Working on anyway-etl
+## Working on anyway-etl and Airflow
 
-Anyway ETL processes are developed in a different repository: [hasadna/anyway-etl](https://github.com/hasadna/anyway-etl)
+Anyway ETL processes and Airflow server are developed in a different repository: [hasadna/anyway-etl](https://github.com/hasadna/anyway-etl)
 but we use the same Docker Compose environment.
+
+For some tasks you will also need to set secret values in the `.env` file, ask a team member for these values.
 
 **Running anyway-etl tasks**
 
@@ -123,7 +125,7 @@ but we use the same Docker Compose environment.
 * See the available anyway-etl commands: `docker-compose run anyway-etl --help`
 * Run a command: `docker-compose run anyway-etl cbs parse-all`
 
-**Developing anyway-etl**
+**Developing anyway-etl tasks**
 
 To develop anyway-etl using the Docker Compose environment you first need to clone [hasadna/anyway-etl](https://github.com/hasadna/anyway-etl).
 The clone should be a sibling directory to anyway, so it will be at `../anyway-etl` relative to anyway repository.
@@ -131,6 +133,25 @@ The clone should be a sibling directory to anyway, so it will be at `../anyway-e
 * Build the anyway-etl Docker image: `docker-compose -f docker-compose.yml -f ../anyway-etl/docker-compose-override.yaml build anyway-etl`
 * Run anyway-etl commands: `docker-compose -f docker-compose.yml -f ../anyway-etl/docker-compose-override.yaml run anyway-etl --help`
     * When running this command, any changes you make to anyway or anyway-etl code will take effect immediately without requireing to rebuild the image. 
+
+**Running the Airflow server**
+
+* Pull the airflow server image: `docker-compose pull airflow-webserver airflow-scheduler`
+* Start the server: `docker-compose up -d airflow-scheduler`
+* Access the server at http://localhost:8082 with username `admin` and password `123456`
+
+**Developing the Airflow server**
+
+* Build and start the server: `docker-compose -f docker-compose.yml -f ../anyway-etl/docker-compose-override.yaml up -d --build airflow-webserver airflow-scheduler`
+    * On first run it may take a while for the server to be available
+
+**Running the ETL Nginx server**
+
+The ETL Nginx servers allows to browse the data used by the ETL tasks
+
+* Pull the image: `docker-compose pull anyway-etl-nginx`
+* Run the server: `docker-compose up -d anyway-etl-nginx`
+* Browse the files at http://localhost:8083
 
 ## Additional Docker commands
 Use `sudo` before each docker commands if you are using ubuntu.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -46,7 +46,7 @@ $ docker login docker.pkg.github.com -u USERNAME
 ```
 
 **6.** Go to the project's root directory and run:
-    `sudo docker-compose up`
+    `sudo docker-compose up anyway`
 This will start the containers. It will take a few minutes until it's done.
 
 **7.** **You're all set!** ANYWAY is up and running with the DB data - connect to http://127.0.0.1:8080
@@ -95,7 +95,7 @@ $ docker login docker.pkg.github.com -u USERNAME
 ```
 
 **6.** Go to the project's root directory and run:
-    `sudo docker-compose up`
+    `sudo docker-compose up anyway`
 This will start the containers. It will take a few minutes until it's done.
 
 **7.** **You're all set!** ANYWAY is up and running with the DB data - connect to http://127.0.0.1:8080
@@ -112,6 +112,26 @@ Using VSCODE
 -----------------------
 In order to use VSCODE in debugging mode with DOCKER, check out [VSCODE_CONFIGURATION](VSCODE_CONFIGURATION.md)
 
+## Working on anyway-etl
+
+Anyway ETL processes are developed in a different repository: [hasadna/anyway-etl](https://github.com/hasadna/anyway-etl)
+but we use the same Docker Compose environment.
+
+**Running anyway-etl tasks**
+
+* Pull the latest anyway-etl Docker image: `docker-compose pull anyway-etl`
+* See the available anyway-etl commands: `docker-compose run anyway-etl --help`
+* Run a command: `docker-compose run anyway-etl cbs parse-all`
+
+**Developing anyway-etl**
+
+To develop anyway-etl using the Docker Compose environment you first need to clone [hasadna/anyway-etl](https://github.com/hasadna/anyway-etl).
+The clone should be a sibling directory to anyway, so it will be at `../anyway-etl` relative to anyway repository.
+
+* Build the anyway-etl Docker image: `docker-compose -f docker-compose.yml -f ../anyway-etl/docker-compose-override.yaml build anyway-etl`
+* Run anyway-etl commands: `docker-compose -f docker-compose.yml -f ../anyway-etl/docker-compose-override.yaml run anyway-etl --help`
+    * When running this command, any changes you make to anyway or anyway-etl code will take effect immediately without requireing to rebuild the image. 
+
 ## Additional Docker commands
 Use `sudo` before each docker commands if you are using ubuntu.
 
@@ -122,7 +142,7 @@ simply rebuild the image - Run in anyway directory:
 
 Run docker-compose in detached mode - containers are running in background:
 
-    docker-compose up -d
+    docker-compose up -d anyway
 
 List your local docker images:
 

--- a/docs/VSCODE_CONFIGURATION.md
+++ b/docs/VSCODE_CONFIGURATION.md
@@ -32,6 +32,6 @@ CMD FLASK_APP=anyway python -m debugpy --listen 0.0.0.0:5678 -m flask run --host
     ]
 ```
 6. Run `docker-compose build`
-7. Run `docker-compose up`
+7. Run `docker-compose up anyway`
 8. Go to the `RUN` section in VSCODE and choose `ANYWAY Docker: Python - Flask`
 9. Happy Debugging!

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+from os import path
+import time
+
+if path.exists("VERSION.txt"):
+    # this file can be written by CI tools (e.g. Travis)
+    with open("VERSION.txt") as version_file:
+        version = version_file.read().strip().strip("v")
+else:
+    version = str(time.time())
+
+setup(
+    name='anyway',
+    version=version,
+    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+)


### PR DESCRIPTION
This PR includes changes to allow integration with [anyway-etl](https://github.com/hasadna/anyway-etl):

* Changes which allow to import anyway as a module. It mostly prevents exceptions in case of missing modules. The main problem is that a lot of anyway code is dependany on Flask and related modules, in the future we should strive to have independent packages and especially the DB. This PR however solves it for the moment.
* Add anyway-etl and airflow containers to the docker-compose + updates to the documentation
* Added additional deploy step which updates a file containing the anyway commit (dev / master) which is then used as the dependency for anyway-etl tasks