### PR TITLE
Refactored create_infographics_items according to issue 1902

### DIFF
--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import time
 import logging
 import datetime
 import json
@@ -1852,12 +1853,13 @@ def create_infographics_data(news_flash_id, number_of_years_ago, lang: str) -> s
     return json.dumps(output, default=str)
 
 
-# def create_infographics_data_1(request_params: RequestParams) -> str:
-#     output = create_infographics_items(request_params)
-#     return json.dumps(output, default=str)
-
-
 def create_infographics_items(request_params: RequestParams) -> Dict:
+    def get_dates_comment():
+        return {
+            "dates": [request_params.start_time.year, request_params.end_time.year],
+            "last_update": time.mktime(request_params.end_time.timetuple())
+        }
+
     try:
         if request_params is None:
             return {}
@@ -1876,13 +1878,7 @@ def create_infographics_items(request_params: RequestParams) -> Dict:
             "location_text": request_params.location_text,
         }
         output["widgets"] = []
-        output["meta"]["dates_comment"] = (
-            str(request_params.start_time.year)
-            + "-"
-            + str(request_params.end_time.year)
-            + ", עדכון אחרון: "
-            + str(request_params.end_time)
-        )
+        output["meta"]["dates_comment"] = get_dates_comment()
         widgets: List[Widget] = generate_widgets(request_params=request_params, to_cache=True)
         widgets.extend(generate_widgets(request_params=request_params, to_cache=False))
         output["widgets"].extend(list(map(lambda w: w.serialize(), widgets)))

--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -1876,9 +1876,9 @@ def create_infographics_items(request_params: RequestParams) -> Dict:
         output["meta"] = {
             "location_info": request_params.location_info.copy(),
             "location_text": request_params.location_text,
+            "dates_comment": get_dates_comment()
         }
         output["widgets"] = []
-        output["meta"]["dates_comment"] = get_dates_comment()
         widgets: List[Widget] = generate_widgets(request_params=request_params, to_cache=True)
         widgets.extend(generate_widgets(request_params=request_params, to_cache=False))
         output["widgets"].extend(list(map(lambda w: w.serialize(), widgets)))

--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -1856,7 +1856,7 @@ def create_infographics_data(news_flash_id, number_of_years_ago, lang: str) -> s
 def create_infographics_items(request_params: RequestParams) -> Dict:
     def get_dates_comment():
         return {
-            "dates": [request_params.start_time.year, request_params.end_time.year],
+            "date_range": [request_params.start_time.year, request_params.end_time.year],
             "last_update": time.mktime(request_params.end_time.timetuple())
         }
 


### PR DESCRIPTION
See [issue](https://github.com/hasadna/anyway/issues/1902) for details.

Note: 
will return last_update as Unix timestamp (decimal).
Example:
```
{
'dates': [2014, 2021],
'last_update': 1627689600.0
}
```

