### PR TITLE
Add road_segment_name filter to injured_count_per_age_group #1708

### DIFF
--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -805,7 +805,6 @@ class TopRoadSegmentsAccidentsPerKmWidget(SubUrbanWidget):
         return result.to_dict(orient="records")  # pylint: disable=no-member
 
 
-@register
 class InjuredCountPerAgeGroupWidget(SubUrbanWidget):
     name: str = "injured_count_per_age_group"
 


### PR DESCRIPTION
Currently the injured_count_per_age_group widget returns results based on the entire road specified in the request.
Filtering by road_segment_name as well should provide more accurate results.