### PR TITLE
restore_db script: use the removed tables schema backup file

### DIFF
--- a/db_docker/restore_db.sh
+++ b/db_docker/restore_db.sh
@@ -5,6 +5,12 @@ set -e
 ( [ "${DBRESTORE_AWS_ACCESS_KEY_ID}" == "" ] || [ "${DBRESTORE_AWS_SECRET_ACCESS_KEY}" == "" ] || [ "${DBRESTORE_AWS_BUCKET}" == "" ] ) && echo missing AWS env vars && exit 1
 [ "${DBRESTORE_FILE_NAME}" == "" ] && export DBRESTORE_FILE_NAME="`date +%Y-%m-%d`_anyway_partial.pgdump"
 
+if [[ "$DBRESTORE_FILE_NAME" == *"partial.pgdump"* ]]; then
+  DBRESTORE_SCHEMA_FILE_NAME="${DBRESTORE_FILE_NAME/partial.pgdump/partial_schema.pgdump}"
+else
+  DBRESTORE_SCHEMA_FILE_NAME=""
+fi
+
 export AWS_ACCESS_KEY_ID="${DBRESTORE_AWS_ACCESS_KEY_ID}"
 export AWS_SECRET_ACCESS_KEY="${DBRESTORE_AWS_SECRET_ACCESS_KEY}"
 
@@ -21,6 +27,12 @@ pushd $TEMPDIR
   aws s3 cp "s3://${DBRESTORE_AWS_BUCKET}/${DBRESTORE_FILE_NAME}.gz" ./ &&\
   gzip -d "${DBRESTORE_FILE_NAME}.gz" &&\
   psql -f "${DBRESTORE_FILE_NAME}" &&\
+  if [ "${DBRESTORE_SCHEMA_FILE_NAME}" != "" ]; then
+    echo restoring truncated tables schema &&\
+    aws s3 cp "s3://${DBRESTORE_AWS_BUCKET}/${DBRESTORE_SCHEMA_FILE_NAME}.gz" ./ &&\
+    gzip -d "${DBRESTORE_SCHEMA_FILE_NAME}.gz" &&\
+    psql -f "${DBRESTORE_SCHEMA_FILE_NAME}"
+  fi &&\
   if [ "${DBRESTORE_SET_ANYWAY_PASSWORD}" != "" ]; then
     echo setting anyway role password &&\
     echo "alter role anyway with password '${DBRESTORE_SET_ANYWAY_PASSWORD}'" | psql


### PR DESCRIPTION
**this PR should be merged after #2013 is deployed and at least 1 day passed so the backup files were created**

it adds the removed tables schema backup file to the restore process (see #2013) for details

no deployment is neccesarry for this PR because the restore_db script is only used in the docker compose environment for local development