### PR TITLE
use ghcr.io in nginx dockerfile and docker-compose prod environment

### DIFF
--- a/docker-compose-production.override.yml
+++ b/docker-compose-production.override.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   nginx:
     build: nginx_docker
-    image: docker.pkg.github.com/hasadna/anyway/nginx:latest
+    image: ghcr.io/hasadna/anyway/nginx:latest
     depends_on:
       - anyway
     ports:

--- a/nginx_docker/Dockerfile
+++ b/nginx_docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.pkg.github.com/hasadna/anyway/anyway:latest AS builder
+FROM ghcr.io/hasadna/anyway/anyway:latest AS builder
 RUN flask assets build
 
 FROM nginx:stable


### PR DESCRIPTION
we already changed to use ghcr.io in most places, see https://github.com/hasadna/anyway/commit/edce9102e33afbc1e19de9762f1849d6dbe7e803

forgot a couple of additional places