### PR TITLE
Default news-flash API to new version

### DIFF
--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -1082,9 +1082,9 @@ app.add_url_rule(
     view_func=injured_around_schools_api,
     methods=["GET"],
 )
-app.add_url_rule("/api/news-flash", endpoint=None, view_func=news_flash, methods=["GET"])
+app.add_url_rule("/api/news-flash", endpoint=None, view_func=news_flash_v2, methods=["GET"])
 
-app.add_url_rule("/api/news-flash-v2", endpoint=None, view_func=news_flash_v2, methods=["GET"])
+app.add_url_rule("/api/v1/news-flash", endpoint=None, view_func=news_flash, methods=["GET"])
 
 
 nf_parser = reqparse.RequestParser()

--- a/anyway/views/news_flash/api.py
+++ b/anyway/views/news_flash/api.py
@@ -94,7 +94,7 @@ def news_flash_v2():
     if "id" in validated_query_params:
         return get_news_flash_by_id(validated_query_params["id"])
 
-    query = gen_news_flash_query_v2(validated_query_params)
+    query = gen_news_flash_query_v2(db.session, validated_query_params)
     news_flashes = query.all()
 
     news_flashes_jsons = [n.serialize() for n in news_flashes]
@@ -185,8 +185,8 @@ def gen_news_flash_query(
     return query
 
 
-def gen_news_flash_query_v2(valid_params: dict):
-    query = db.session.query(NewsFlash)
+def gen_news_flash_query_v2(session, valid_params: dict):
+    query = session.query(NewsFlash)
     for param, value in valid_params.items():
         if param == "road_number":
             query = query.filter(NewsFlash.road1 == value)


### PR DESCRIPTION
Should only be merged in sync with frontend due to new and deprecated API parameters

Modified the news-flash API routing according to the discussion here.
The old API version is available at https://www.anyway.co.il/api/v1/news-flash.
New API version available at https://www.anyway.co.il/api/news-flash.

Relevant issue: https://github.com/hasadna/anyway-newsflash-infographics/issues/774