### PR TITLE
2136 use only location cache

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -64,6 +64,7 @@ jobs:
         docker exec anyway alembic upgrade head
         docker exec anyway ./main.py process registered-vehicles
         docker exec anyway ./main.py process cbs --source local_dir_for_tests_only
+        docker exec anyway ./main.py process road-segments
     - name: Tests
       env:
         TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}

--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -1362,45 +1362,6 @@ def embedded_reports_api():
     return response
 
 
-# def infographics_data_by_location():
-#     mock_data = request.values.get("mock", "false")
-#     personalized_data = request.values.get("personalized", "false")
-#     if mock_data == "true":
-#         output = get_infographics_mock_data()
-#     elif mock_data == "false":
-#         road_segment_id = request.values.get("road_segment_id")
-#         if road_segment_id == None:
-#             log_bad_request(request)
-#             return abort(http_client.BAD_REQUEST)
-#
-#         number_of_years_ago = request.values.get("years_ago", BE_CONST.DEFAULT_NUMBER_OF_YEARS_AGO)
-#         lang: str = request.values.get("lang", "he")
-#         logging.debug(
-#             (
-#                 "getting infographics data for news_flash_id: {news_flash_id}, "
-#                 + "in time period:{number_of_years_ago}, lang:{lang}"
-#             ).format(
-#                 news_flash_id=road_segment_id, number_of_years_ago=number_of_years_ago, lang=lang
-#             )
-#         )
-#         output = get_infographics_data_for_road_segment(
-#             road_segment_id=road_segment_id, years_ago=number_of_years_ago, lang=lang
-#         )
-#         if not output:
-#             log_bad_request(request)
-#             return abort(http_client.NOT_FOUND)
-#     else:
-#         log_bad_request(request)
-#         return abort(http_client.BAD_REQUEST)
-#
-#     if personalized_data == "true":
-#         output = widgets_personalisation_for_user(output)
-#
-#     json_data = json.dumps(output, default=str)
-#     return Response(json_data, mimetype="application/json")
-#
-#
-
 # User system API
 app.add_url_rule("/user/add_role", view_func=add_role, methods=["POST"])
 app.add_url_rule(

--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -1194,7 +1194,7 @@ class InfographicsData(Resource):
     @api.doc("get infographics data")
     @api.expect(parser)
     def get(self):
-        return infographics_data()
+        return infographics_data_by_location()
 
 
 def infographics_data():

--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -27,6 +27,9 @@ from anyway.parsers import resolution_dict
 from anyway.infographics_dictionaries import head_on_collisions_comparison_dict
 from anyway.parsers import infographics_data_cache_updater
 from anyway.widgets.widget import Widget, widgets_dict
+from anyway.parsers.infographics_data_cache_updater import (
+    get_infographics_data_from_cache_by_road_segment,
+)
 
 # We need to import the modules, which in turn imports all the widgets, and registers them, even if they are not
 # explicitly used here
@@ -261,7 +264,8 @@ def create_infographics_items(request_params: RequestParams) -> Dict:
 
 
 def get_infographics_data(news_flash_id, years_ago, lang: str) -> Dict:
-    request_params = get_request_params(news_flash_id, years_ago, lang)
+    vals = {"news_flash_id": news_flash_id, "years_ago": years_ago, "lang": lang}
+    request_params = get_request_params_from_request_values(vals)
     if os.environ.get("FLASK_ENV") == "development":
         output = create_infographics_items(request_params)
     else:
@@ -285,14 +289,13 @@ def get_infographics_data(news_flash_id, years_ago, lang: str) -> Dict:
 
 
 def get_infographics_data_for_road_segment(road_segment_id, years_ago, lang: str) -> Dict:
-    request_params = get_request_params_for_road_segment(road_segment_id, years_ago, lang)
+    vals = {"road_segment_id": road_segment_id, "years_ago": years_ago, "lang": lang}
+    request_params = get_request_params_from_request_values(vals)
     if os.environ.get("FLASK_ENV") == "development":
         output = create_infographics_items(request_params)
     else:
         try:
-            output = infographics_data_cache_updater.get_infographics_data_from_cache_by_road_segment(
-                road_segment_id, years_ago
-            )
+            output = get_infographics_data_from_cache_by_road_segment(road_segment_id, years_ago)
         except Exception as e:
             logging.error(
                 f"Exception while retrieving from infographics cache({road_segment_id},{years_ago})"

--- a/anyway/infographics_utils.py
+++ b/anyway/infographics_utils.py
@@ -246,6 +246,7 @@ def create_infographics_items(request_params: RequestParams) -> Dict:
         output["meta"] = {
             "location_info": request_params.location_info.copy(),
             "location_text": request_params.location_text,
+            "resolution": request_params.resolution.name,
             "dates_comment": get_dates_comment(),
         }
         output["widgets"] = []

--- a/anyway/request_params.py
+++ b/anyway/request_params.py
@@ -45,7 +45,7 @@ def get_request_params_from_request_values(vals: dict) -> Optional[RequestParams
     location = get_location_from_request_values(vals)
     if location is None:
         return None
-    years_ago = vals.get("years_ago")
+    years_ago = vals.get("years_ago", BE_CONST.DEFAULT_NUMBER_OF_YEARS_AGO)
     lang = vals.get("lang", "he")
     location_text = location["text"]
     gps = location["gps"]
@@ -90,7 +90,7 @@ def get_request_params_from_request_values(vals: dict) -> Optional[RequestParams
     return request_params
 
 
-def get_location_from_request_values(vals: dict) -> dict:
+def get_location_from_request_values(vals: dict) -> Optional[dict]:
     news_flash_id = vals.get("news_flash_id")
     if news_flash_id is not None:
         return get_location_from_news_flash(news_flash_id)
@@ -101,8 +101,8 @@ def get_location_from_request_values(vals: dict) -> dict:
         "street1" in vals or "street1_hebrew" in vals
     ):
         return extract_street_location(vals)
-    logging.error(f"Unsupported location:{vals}")
-    return {}
+    logging.error(f"Unsupported location:{vals.values()}")
+    return None
 
 
 def get_location_from_news_flash(news_flash_id: str) -> Optional[dict]:

--- a/anyway/request_params.py
+++ b/anyway/request_params.py
@@ -43,6 +43,8 @@ class RequestParams:
 # todo: merge with get_request_params()
 def get_request_params_from_request_values(vals: dict) -> Optional[RequestParams]:
     location = get_location_from_request_values(vals)
+    if location is None:
+        return None
     years_ago = vals.get("years_ago")
     lang = vals.get("lang", "he")
     location_text = location["text"]
@@ -103,9 +105,13 @@ def get_location_from_request_values(vals: dict) -> dict:
     return {}
 
 
-def get_location_from_news_flash(news_flash_id: str) -> dict:
+def get_location_from_news_flash(news_flash_id: str) -> Optional[dict]:
     news_flash = extract_news_flash_obj(news_flash_id)
+    if news_flash is None:
+        return None
     loc = extract_news_flash_location(news_flash)
+    if loc is None:
+        return None
     res = loc["data"]["resolution"]
     loc["data"]["resolution"] = BE_CONST.ResolutionCategories(res)
     loc["text"] = get_news_flash_location_text(news_flash)

--- a/anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py
+++ b/anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py
@@ -65,6 +65,8 @@ class AccidentCountBySeverityWidget(AllLocationsWidget):
                 + f" - {request_params.location_info['road_segment_name']}"
             }
         elif request_params.resolution == BE_CONST.ResolutionCategories.STREET:
+            # To have FE to treat it as a different widget
+            items["name"] = "accident_count_by_severity_urban"
             num_accidents = items["data"]["items"]["total_accidents_count"]
             s = "{} {} - {} {} {}, {}, {} {} {}".format(
                 _("in years"),

--- a/anyway/widgets/suburban_widgets/most_severe_accidents_table_widget.py
+++ b/anyway/widgets/suburban_widgets/most_severe_accidents_table_widget.py
@@ -34,16 +34,13 @@ def get_most_severe_accidents_with_entities(
 def get_most_severe_accidents_table_title(
     location_info: dict, resolution: BE_CONST.ResolutionCategories
 ):
-    # todo: hack - will be fixed in next PR
-    if isinstance(resolution, BE_CONST.ResolutionCategories):
-        resolution = resolution.value
-    if resolution == BE_CONST.ResolutionCategories.SUBURBAN_ROAD.value:
+    if resolution == BE_CONST.ResolutionCategories.SUBURBAN_ROAD:
         return (
             _("Most severe accidents in segment")
             + " "
             + segment_dictionary[location_info["road_segment_name"]]
         )
-    elif resolution == BE_CONST.ResolutionCategories.STREET.value:
+    elif resolution == BE_CONST.ResolutionCategories.STREET:
         return (
             _("Most severe accidents in street")
             + f" {location_info['street1_hebrew']} "

--- a/tests/test_infographic_api.py
+++ b/tests/test_infographic_api.py
@@ -74,7 +74,7 @@ class TestInfographicApi:
         """Should success and be empty when no flash id is sent"""
         rv = app.get("/api/infographics-data")
 
-        assert rv.status_code == http_client.BAD_REQUEST
+        assert rv.status_code == http_client.NOT_FOUND
 
     def test_limit(self, app):
         """Should process the limit parameter successfully"""


### PR DESCRIPTION
Stop usage of news-flash cache.
The unused code and table are not removed yet. Will be removed after this change is in use, so we are sure it is OK.
Fixes #2136 