### PR TITLE
Remove road type filter from head_on_collisions_comparison_widget

### DIFF
--- a/anyway/widgets/suburban_widgets/head_on_collisions_comparison_widget.py
+++ b/anyway/widgets/suburban_widgets/head_on_collisions_comparison_widget.py
@@ -3,7 +3,7 @@ from typing import Dict
 from flask_babel import _
 
 from anyway.request_params import RequestParams
-from anyway.backend_constants import BE_CONST, AccidentSeverity, AccidentType
+from anyway.backend_constants import AccidentSeverity, AccidentType
 from anyway.widgets.widget_utils import get_accidents_stats
 from anyway.models import AccidentMarkerView
 from anyway.widgets.widget import register
@@ -29,11 +29,8 @@ class HeadOnCollisionsComparisonWidget(SubUrbanWidget):
     def get_head_to_head_stat(self) -> Dict:
         location_info = self.request_params.location_info
         road_data = {}
-
-        filter_dict = {
-            "road_type": BE_CONST.ROAD_TYPE_NOT_IN_CITY_NOT_IN_INTERSECTION,
-            "accident_severity": AccidentSeverity.FATAL.value,  # pylint: disable=no-member
-        }
+        # pylint: disable=no-member
+        filter_dict = {"accident_severity": AccidentSeverity.FATAL.value}
         all_roads_data = get_accidents_stats(
             table_obj=AccidentMarkerView,
             filters=filter_dict,


### PR DESCRIPTION
So it shows same number of fatal accidents as `accident_count_by_severity`
Fixes #2138 